### PR TITLE
return type

### DIFF
--- a/crates/alkanes-std-auth-token/src/lib.rs
+++ b/crates/alkanes-std-auth-token/src/lib.rs
@@ -34,9 +34,11 @@ enum AuthTokenMessage {
     Authenticate,
 
     #[opcode(99)]
+    #[returns(String)]
     GetName,
 
     #[opcode(100)]
+    #[returns(String)]
     GetSymbol,
 }
 

--- a/crates/alkanes-std-genesis-alkane/src/lib.rs
+++ b/crates/alkanes-std-genesis-alkane/src/lib.rs
@@ -31,12 +31,15 @@ enum GenesisAlkaneMessage {
     Mint,
 
     #[opcode(99)]
+    #[returns(String)]
     GetName,
 
     #[opcode(100)]
+    #[returns(String)]
     GetSymbol,
 
     #[opcode(101)]
+    #[returns(u128)]
     GetTotalSupply,
 }
 

--- a/crates/alkanes-std-genesis-protorune/src/lib.rs
+++ b/crates/alkanes-std-genesis-protorune/src/lib.rs
@@ -25,12 +25,15 @@ enum GenesisProtoruneMessage {
     Mint,
 
     #[opcode(99)]
+    #[returns(String)]
     GetName,
 
     #[opcode(100)]
+    #[returns(String)]
     GetSymbol,
 
     #[opcode(101)]
+    #[returns(u128)]
     GetTotalSupply,
 }
 

--- a/crates/alkanes-std-orbital/src/lib.rs
+++ b/crates/alkanes-std-orbital/src/lib.rs
@@ -21,15 +21,19 @@ enum OrbitalMessage {
     Initialize,
 
     #[opcode(99)]
+    #[returns(String)]
     GetName,
 
     #[opcode(100)]
+    #[returns(String)]
     GetSymbol,
 
     #[opcode(101)]
+    #[returns(u128)]
     GetTotalSupply,
 
     #[opcode(1000)]
+    #[returns(Vec<u8>)]
     GetData,
 }
 

--- a/crates/alkanes-std-owned-token/src/lib.rs
+++ b/crates/alkanes-std-owned-token/src/lib.rs
@@ -34,15 +34,19 @@ enum OwnedTokenMessage {
     SetNameAndSymbol { name: String, symbol: String },
 
     #[opcode(99)]
+    #[returns(String)]
     GetName,
 
     #[opcode(100)]
+    #[returns(String)]
     GetSymbol,
 
     #[opcode(101)]
+    #[returns(u128)]
     GetTotalSupply,
 
     #[opcode(1000)]
+    #[returns(Vec<u8>)]
     GetData,
 }
 

--- a/crates/alkanes-std-test/src/lib.rs
+++ b/crates/alkanes-std-test/src/lib.rs
@@ -28,6 +28,7 @@ enum LoggerAlkaneMessage {
     MintTokens,
 
     #[opcode(5)]
+    #[returns(Vec<u8>)]
     ReturnData1,
 
     #[opcode(50)]
@@ -37,6 +38,7 @@ enum LoggerAlkaneMessage {
     HashLoop,
 
     #[opcode(99)]
+    #[returns(Vec<u8>)]
     ReturnDefaultData,
 }
 


### PR DESCRIPTION
Example: 

OwnedToken ABI: { "contract": "OwnedToken", "methods": [{ "name": "initialize", "opcode": 0, "params": [{ "type": "u128", "name": "auth_token_units" }, { "type": "u128", "name": "token_units" }], "returns": "void" }, { "name": "mint", "opcode": 77, "params": [{ "type": "u128", "name": "token_units" }], "returns": "void" }, { "name": "set_name_and_symbol", "opcode": 88, "params": [{ "type": "String", "name": "name" }, { "type": "String", "name": "symbol" }], "returns": "void" }, { "name": "get_name", "opcode": 99, "params": [], "returns": "String" }, { "name": "get_symbol", "opcode": 100, "params": [], "returns": "String" }, { "name": "get_total_supply", "opcode": 101, "params": [], "returns": "u128" }, { "name": "get_data", "opcode": 1000, "params": [], "returns": "Vec<u8>" }] }