### PR TITLE
rev bytes

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -191,10 +191,11 @@ pub fn genesis(block: &Block) -> Result<()> {
         }
     })?;
     let outpoint_bytes = outpoint_encode(&OutPoint {
-        txid: &Txid::from_byte_array(
+        txid: Txid::from_byte_array(
             <Vec<u8> as AsRef<[u8]>>::as_ref(
                 &hex::decode(genesis::GENESIS_OUTPOINT)?
                     .iter()
+                    .cloned()
                     .rev()
                     .collect::<Vec<u8>>(),
             )
@@ -225,7 +226,13 @@ pub fn genesis(block: &Block) -> Result<()> {
                 .HEIGHT_TO_TRANSACTION_IDS
                 .select_value::<u64>(genesis::GENESIS_OUTPOINT_BLOCK_HEIGHT),
         )
-        .append(Arc::new(hex::decode(genesis::GENESIS_OUTPOINT)?));
+        .append(Arc::new(
+            hex::decode(genesis::GENESIS_OUTPOINT)?
+                .iter()
+                .cloned()
+                .rev()
+                .collect::<Vec<u8>>(),
+        ));
     atomic.commit();
     Ok(())
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -191,9 +191,14 @@ pub fn genesis(block: &Block) -> Result<()> {
         }
     })?;
     let outpoint_bytes = outpoint_encode(&OutPoint {
-        txid: Txid::from_byte_array(
-            <Vec<u8> as AsRef<[u8]>>::as_ref(&hex::decode(genesis::GENESIS_OUTPOINT)?)
-                .try_into()?,
+        txid: &Txid::from_byte_array(
+            <Vec<u8> as AsRef<[u8]>>::as_ref(
+                &hex::decode(genesis::GENESIS_OUTPOINT)?
+                    .iter()
+                    .rev()
+                    .collect::<Vec<u8>>(),
+            )
+            .try_into()?,
         ),
         vout: 0,
     })?;

--- a/src/tests/genesis.rs
+++ b/src/tests/genesis.rs
@@ -235,6 +235,7 @@ fn test_genesis_indexer_premine() -> Result<()> {
             <Vec<u8> as AsRef<[u8]>>::as_ref(
                 &hex::decode(genesis::GENESIS_OUTPOINT)?
                     .iter()
+                    .cloned()
                     .rev()
                     .collect::<Vec<u8>>(),
             )

--- a/src/tests/genesis.rs
+++ b/src/tests/genesis.rs
@@ -232,8 +232,13 @@ fn test_genesis_indexer_premine() -> Result<()> {
     index_block(&test_block, block_height)?;
     let outpoint = OutPoint {
         txid: Txid::from_byte_array(
-            <Vec<u8> as AsRef<[u8]>>::as_ref(&hex::decode(genesis::GENESIS_OUTPOINT)?)
-                .try_into()?,
+            <Vec<u8> as AsRef<[u8]>>::as_ref(
+                &hex::decode(genesis::GENESIS_OUTPOINT)?
+                    .iter()
+                    .rev()
+                    .collect::<Vec<u8>>(),
+            )
+            .try_into()?,
         ),
         vout: 0,
     };


### PR DESCRIPTION
This issue occurs because when you copy a TXID from a block explorer, it's in the display format (big-endian), but the Bitcoin library's internal representation is little-endian. Without the byte reversal, the TXID will be incorrect when compared to what would be produced by tx.compute_txid().