### PR TITLE
add test for 1000 edict

### DIFF
--- a/crates/protorune/src/test_helpers.rs
+++ b/crates/protorune/src/test_helpers.rs
@@ -351,7 +351,11 @@ pub fn create_tx_from_runestone(
     };
 
     // op return must be less than 80 bytes or else miners will not accept it
-    assert!(op_return.size() <= 80);
+    assert!(
+        op_return.size() <= 80,
+        "op return ({}) > 80 bytes",
+        op_return.size()
+    );
 
     let mut txouts = additional_txouts.clone();
     txouts.push(op_return);
@@ -414,7 +418,11 @@ pub fn create_rune_etching_transaction(config: &RunesTestingConfig) -> Transacti
     };
 
     // op return must be less than 80 bytes or else miners will not accept it
-    assert!(op_return.size() <= 80);
+    assert!(
+        op_return.size() <= 80,
+        "op return ({}) > 80 bytes",
+        op_return.size()
+    );
 
     Transaction {
         version: Version::ONE,
@@ -474,7 +482,11 @@ pub fn create_rune_transfer_transaction(
     };
 
     // op return must be less than 80 bytes or else miners will not accept it
-    assert!(op_return.size() <= 80);
+    assert!(
+        op_return.size() <= 80,
+        "op return ({}) > 80 bytes",
+        op_return.size()
+    );
 
     Transaction {
         version: Version::ONE,
@@ -584,7 +596,11 @@ pub fn create_transaction_with_middle_op_return(
     };
 
     // op return must be less than 80 bytes or else miners will not accept it
-    assert!(op_return.size() <= 80);
+    assert!(
+        op_return.size() <= 80,
+        "op return ({}) > 80 bytes",
+        op_return.size()
+    );
 
     Transaction {
         version: Version::ONE,
@@ -717,7 +733,11 @@ pub fn create_protostone_encoded_tx(
     };
 
     // op return must be less than 80 bytes or else miners will not accept it
-    assert!(op_return.size() <= 80);
+    assert!(
+        op_return.size() <= 80,
+        "op return ({}) > 80 bytes",
+        op_return.size()
+    );
 
     Transaction {
         version: Version::ONE,
@@ -793,7 +813,11 @@ pub fn create_multi_protoburn_transaction(
     };
 
     // op return must be less than 80 bytes or else miners will not accept it
-    assert!(op_return.size() <= 80);
+    assert!(
+        op_return.size() <= 80,
+        "op return ({}) > 80 bytes",
+        op_return.size()
+    );
 
     let mut output = burn_protocol_ids
         .into_iter()
@@ -899,7 +923,11 @@ pub fn create_protostone_transaction(
     };
 
     // op return must be less than 80 bytes or else miners will not accept it
-    assert!(op_return.size() <= 80);
+    assert!(
+        op_return.size() <= 80,
+        "op return ({}) > 80 bytes",
+        op_return.size()
+    );
 
     Transaction {
         version: Version::ONE,
@@ -977,7 +1005,11 @@ pub fn create_multiple_protomessage_from_edict_tx(
     };
 
     // op return must be less than 80 bytes or else miners will not accept it
-    assert!(op_return.size() <= 80);
+    assert!(
+        op_return.size() <= 80,
+        "op return ({}) > 80 bytes",
+        op_return.size()
+    );
     outs.push(op_return);
     Transaction {
         version: Version::ONE,
@@ -1056,7 +1088,11 @@ pub fn create_protomessage_from_edict_tx(
     };
 
     // op return must be less than 80 bytes or else miners will not accept it
-    assert!(op_return.size() <= 80);
+    assert!(
+        op_return.size() <= 80,
+        "op return ({}) > 80 bytes",
+        op_return.size()
+    );
 
     Transaction {
         version: Version::ONE,

--- a/crates/protorune/src/test_helpers.rs
+++ b/crates/protorune/src/test_helpers.rs
@@ -350,6 +350,9 @@ pub fn create_tx_from_runestone(
         script_pubkey: runestone_script,
     };
 
+    // op return must be less than 80 bytes or else miners will not accept it
+    assert!(op_return.size() <= 80);
+
     let mut txouts = additional_txouts.clone();
     txouts.push(op_return);
 
@@ -410,6 +413,9 @@ pub fn create_rune_etching_transaction(config: &RunesTestingConfig) -> Transacti
         script_pubkey: runestone,
     };
 
+    // op return must be less than 80 bytes or else miners will not accept it
+    assert!(op_return.size() <= 80);
+
     Transaction {
         version: Version::ONE,
         lock_time: bitcoin::absolute::LockTime::ZERO,
@@ -466,6 +472,9 @@ pub fn create_rune_transfer_transaction(
         value: Amount::from_sat(0),
         script_pubkey: runestone,
     };
+
+    // op return must be less than 80 bytes or else miners will not accept it
+    assert!(op_return.size() <= 80);
 
     Transaction {
         version: Version::ONE,
@@ -573,6 +582,9 @@ pub fn create_transaction_with_middle_op_return(
         value: Amount::from_sat(40_000_000),
         script_pubkey: script_pubkey.clone(),
     };
+
+    // op return must be less than 80 bytes or else miners will not accept it
+    assert!(op_return.size() <= 80);
 
     Transaction {
         version: Version::ONE,
@@ -704,6 +716,9 @@ pub fn create_protostone_encoded_tx(
         script_pubkey: runestone,
     };
 
+    // op return must be less than 80 bytes or else miners will not accept it
+    assert!(op_return.size() <= 80);
+
     Transaction {
         version: Version::ONE,
         lock_time: bitcoin::absolute::LockTime::ZERO,
@@ -777,6 +792,9 @@ pub fn create_multi_protoburn_transaction(
         script_pubkey: runestone,
     };
 
+    // op return must be less than 80 bytes or else miners will not accept it
+    assert!(op_return.size() <= 80);
+
     let mut output = burn_protocol_ids
         .into_iter()
         .map(|_| txout.clone())
@@ -807,7 +825,7 @@ pub fn create_default_protoburn_transaction(
     );
 }
 
-/// Create a protoburn given an input that holds runes
+/// Create a protoburn given an input that holds runes.
 /// Outpoint with protorunes is the txid and vout 0
 /// This outpoint holds 1000 protorunes
 pub fn create_protostone_transaction(
@@ -879,6 +897,9 @@ pub fn create_protostone_transaction(
         value: Amount::from_sat(0),
         script_pubkey: runestone,
     };
+
+    // op return must be less than 80 bytes or else miners will not accept it
+    assert!(op_return.size() <= 80);
 
     Transaction {
         version: Version::ONE,
@@ -954,6 +975,9 @@ pub fn create_multiple_protomessage_from_edict_tx(
         value: Amount::from_sat(0),
         script_pubkey: runestone,
     };
+
+    // op return must be less than 80 bytes or else miners will not accept it
+    assert!(op_return.size() <= 80);
     outs.push(op_return);
     Transaction {
         version: Version::ONE,
@@ -1030,6 +1054,9 @@ pub fn create_protomessage_from_edict_tx(
         value: Amount::from_sat(0),
         script_pubkey: runestone,
     };
+
+    // op return must be less than 80 bytes or else miners will not accept it
+    assert!(op_return.size() <= 80);
 
     Transaction {
         version: Version::ONE,

--- a/crates/protorune/src/tests/index_protoburns.rs
+++ b/crates/protorune/src/tests/index_protoburns.rs
@@ -129,8 +129,6 @@ mod tests {
             PROTOCOL_ID,
             protostone_edicts,
         );
-        // OP return should be under 80 bytes to be picked up by miners
-        println!("transfer tx OP RETURN: {:?}", transfer_tx.output[1].size());
         test_block.txdata.push(transfer_tx);
 
         assert!(Protorune::index_block::<TestMessageContext>(
@@ -277,53 +275,55 @@ mod tests {
         assert_eq!(protoburn_protorunes_balances[0], 222);
     }
 
-    #[wasm_bindgen_test]
-    fn protostone_many_edict_test() {
-        // the only valid protorune id
-        let protorune_id = ProtoruneRuneId {
-            block: BLOCK_HEIGHT as u128,
-            tx: 1,
-        };
+    /// This is supported, but the op return exceeds the 80 byte limit which makes it
+    /// hard for miners to pick up.
+    // #[wasm_bindgen_test]
+    // fn protostone_many_edict_test() {
+    //     // the only valid protorune id
+    //     let protorune_id = ProtoruneRuneId {
+    //         block: BLOCK_HEIGHT as u128,
+    //         tx: 1,
+    //     };
 
-        // transfer all remaining protorunes to the op return to burn it
-        let test_block = protostone_transfer_test_template(
-            1,
-            vec![
-                ProtostoneEdict {
-                    id: protorune_id,
-                    amount: 1,
-                    output: 0,
-                };
-                1000
-            ],
-        );
-        let tx2_outpoint: OutPoint = OutPoint {
-            txid: test_block.txdata[2].compute_txid(),
-            vout: 0,
-        };
+    //     // transfer all remaining protorunes to the op return to burn it
+    //     let test_block = protostone_transfer_test_template(
+    //         1,
+    //         vec![
+    //             ProtostoneEdict {
+    //                 id: protorune_id,
+    //                 amount: 1,
+    //                 output: 0,
+    //             };
+    //             1000
+    //         ],
+    //     );
+    //     let tx2_outpoint: OutPoint = OutPoint {
+    //         txid: test_block.txdata[2].compute_txid(),
+    //         vout: 0,
+    //     };
 
-        let tx2_rune_balances =
-            helpers::get_rune_balance_by_outpoint(tx2_outpoint, vec![protorune_id]);
-        assert_eq!(tx2_rune_balances[0], 0);
+    //     let tx2_rune_balances =
+    //         helpers::get_rune_balance_by_outpoint(tx2_outpoint, vec![protorune_id]);
+    //     assert_eq!(tx2_rune_balances[0], 0);
 
-        let protoburn_protorunes_balances = helpers::get_protorune_balance_by_outpoint(
-            PROTOCOL_ID,
-            tx2_outpoint,
-            vec![protorune_id],
-        );
-        assert_eq!(protoburn_protorunes_balances[0], 1000);
-        assert_eq!(
-            helpers::get_protorune_balance_by_outpoint(
-                PROTOCOL_ID,
-                OutPoint {
-                    txid: test_block.txdata[2].compute_txid(),
-                    vout: 1,
-                },
-                vec![protorune_id],
-            )[0],
-            0
-        );
-    }
+    //     let protoburn_protorunes_balances = helpers::get_protorune_balance_by_outpoint(
+    //         PROTOCOL_ID,
+    //         tx2_outpoint,
+    //         vec![protorune_id],
+    //     );
+    //     assert_eq!(protoburn_protorunes_balances[0], 1000);
+    //     assert_eq!(
+    //         helpers::get_protorune_balance_by_outpoint(
+    //             PROTOCOL_ID,
+    //             OutPoint {
+    //                 txid: test_block.txdata[2].compute_txid(),
+    //                 vout: 1,
+    //             },
+    //             vec![protorune_id],
+    //         )[0],
+    //         0
+    //     );
+    // }
 
     #[wasm_bindgen_test]
     fn protostone_edict_burn_test() {

--- a/crates/protorune/src/tests/index_protoburns.rs
+++ b/crates/protorune/src/tests/index_protoburns.rs
@@ -129,6 +129,8 @@ mod tests {
             PROTOCOL_ID,
             protostone_edicts,
         );
+        // OP return should be under 80 bytes to be picked up by miners
+        println!("transfer tx OP RETURN: {:?}", transfer_tx.output[1].size());
         test_block.txdata.push(transfer_tx);
 
         assert!(Protorune::index_block::<TestMessageContext>(
@@ -273,6 +275,54 @@ mod tests {
             vec![protorune_id],
         );
         assert_eq!(protoburn_protorunes_balances[0], 222);
+    }
+
+    #[wasm_bindgen_test]
+    fn protostone_many_edict_test() {
+        // the only valid protorune id
+        let protorune_id = ProtoruneRuneId {
+            block: BLOCK_HEIGHT as u128,
+            tx: 1,
+        };
+
+        // transfer all remaining protorunes to the op return to burn it
+        let test_block = protostone_transfer_test_template(
+            1,
+            vec![
+                ProtostoneEdict {
+                    id: protorune_id,
+                    amount: 1,
+                    output: 0,
+                };
+                1000
+            ],
+        );
+        let tx2_outpoint: OutPoint = OutPoint {
+            txid: test_block.txdata[2].compute_txid(),
+            vout: 0,
+        };
+
+        let tx2_rune_balances =
+            helpers::get_rune_balance_by_outpoint(tx2_outpoint, vec![protorune_id]);
+        assert_eq!(tx2_rune_balances[0], 0);
+
+        let protoburn_protorunes_balances = helpers::get_protorune_balance_by_outpoint(
+            PROTOCOL_ID,
+            tx2_outpoint,
+            vec![protorune_id],
+        );
+        assert_eq!(protoburn_protorunes_balances[0], 1000);
+        assert_eq!(
+            helpers::get_protorune_balance_by_outpoint(
+                PROTOCOL_ID,
+                OutPoint {
+                    txid: test_block.txdata[2].compute_txid(),
+                    vout: 1,
+                },
+                vec![protorune_id],
+            )[0],
+            0
+        );
     }
 
     #[wasm_bindgen_test]

--- a/crates/protorune/src/tests/index_protomessage.rs
+++ b/crates/protorune/src/tests/index_protomessage.rs
@@ -313,7 +313,11 @@ mod tests {
         };
 
         // op return must be less than 80 bytes or else miners will not accept it
-        assert!(op_return.size() <= 80);
+        assert!(
+            op_return.size() <= 80,
+            "op return ({}) > 80 bytes",
+            op_return.size()
+        );
 
         helpers::create_block_with_txs(vec![Transaction {
             version: bitcoin::transaction::Version(2),

--- a/crates/protorune/src/tests/index_protomessage.rs
+++ b/crates/protorune/src/tests/index_protomessage.rs
@@ -312,6 +312,9 @@ mod tests {
             script_pubkey: runestone,
         };
 
+        // op return must be less than 80 bytes or else miners will not accept it
+        assert!(op_return.size() <= 80);
+
         helpers::create_block_with_txs(vec![Transaction {
             version: bitcoin::transaction::Version(2),
             lock_time: bitcoin::absolute::LockTime::ZERO,

--- a/src/tests/auth_token.rs
+++ b/src/tests/auth_token.rs
@@ -241,7 +241,7 @@ fn test_owned_token_set_name_and_symbol() -> Result<()> {
     // For a long name that spans multiple u128s
     // "SuperLongCustomTokenNameThatSpansMultipleU128Values" (49 characters)
     let name_data1 = u128::from_le_bytes(*b"SuperLongCustomT");
-    let name_data2 = u128::from_le_bytes(*b"okenNameThatSpa\0");
+    let name_data2 = u128::from_le_bytes(*b"ok\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
 
     // For "SLCT" symbol (4 characters)
     let symbol_data = u128::from_le_bytes(*b"SLCT\0\0\0\0\0\0\0\0\0\0\0\0");
@@ -317,7 +317,7 @@ fn test_owned_token_set_name_and_symbol() -> Result<()> {
 
     println!("trace {:?}", trace_str);
 
-    let expected_name = "SuperLongCustomTokenNameThatSpannsMultipleU128Vaalues";
+    let expected_name = "SuperLongCustomTok";
     let expected_symbol = "SLCT";
 
     // Check if the trace data contains the expected name

--- a/src/tests/auth_token.rs
+++ b/src/tests/auth_token.rs
@@ -241,9 +241,7 @@ fn test_owned_token_set_name_and_symbol() -> Result<()> {
     // For a long name that spans multiple u128s
     // "SuperLongCustomTokenNameThatSpansMultipleU128Values" (49 characters)
     let name_data1 = u128::from_le_bytes(*b"SuperLongCustomT");
-    let name_data2 = u128::from_le_bytes(*b"okenNameThatSpan");
-    let name_data3 = u128::from_le_bytes(*b"nsMultipleU128Va");
-    let name_data4 = u128::from_le_bytes(*b"alues\0\0\0\0\0\0\0\0\0\0\0");
+    let name_data2 = u128::from_le_bytes(*b"okenNameThatSpa\0");
 
     // For "SLCT" symbol (4 characters)
     let symbol_data = u128::from_le_bytes(*b"SLCT\0\0\0\0\0\0\0\0\0\0\0\0");
@@ -257,8 +255,6 @@ fn test_owned_token_set_name_and_symbol() -> Result<()> {
             1000,        /* owned_token token_units */
             name_data1,  // first part of the name
             name_data2,  // second part of the name
-            name_data3,  // third part of the name
-            name_data4,  // fourth part of the name with null terminator
             symbol_data, // null-terminated symbol data
         ],
     };

--- a/src/tests/helpers.rs
+++ b/src/tests/helpers.rs
@@ -190,7 +190,11 @@ pub fn create_protostone_tx_with_inputs_and_default_pointer(
     };
 
     // op return must be less than 80 bytes or else miners will not accept it
-    assert!(op_return.size() <= 80);
+    assert!(
+        op_return.size() <= 80,
+        "op return ({}) > 80 bytes",
+        op_return.size()
+    );
 
     let address: Address<NetworkChecked> = get_address(&ADDRESS1().as_str());
     let _script_pubkey = address.script_pubkey();
@@ -300,7 +304,11 @@ pub fn create_multiple_cellpack_with_witness_and_txins_edicts(
             op_return.size()
         );
     }
-    assert!(op_return.size() <= 80);
+    assert!(
+        op_return.size() <= 80,
+        "op return ({}) > 80 bytes",
+        op_return.size()
+    );
 
     let address: Address<NetworkChecked> = get_address(&ADDRESS1().as_str());
 

--- a/src/tests/helpers.rs
+++ b/src/tests/helpers.rs
@@ -188,6 +188,10 @@ pub fn create_protostone_tx_with_inputs_and_default_pointer(
         value: Amount::from_sat(0),
         script_pubkey: runestone,
     };
+
+    // op return must be less than 80 bytes or else miners will not accept it
+    assert!(op_return.size() <= 80);
+
     let address: Address<NetworkChecked> = get_address(&ADDRESS1().as_str());
     let _script_pubkey = address.script_pubkey();
     let mut _outputs = outputs.clone();
@@ -288,6 +292,16 @@ pub fn create_multiple_cellpack_with_witness_and_txins_edicts(
         value: Amount::from_sat(0),
         script_pubkey: runestone,
     };
+
+    // op return must be less than 80 bytes or else miners will not accept it
+    if (op_return.size() > 80) {
+        println!(
+            "op return size: {} greater than 80 bytes! This is dangerous",
+            op_return.size()
+        );
+    }
+    assert!(op_return.size() <= 80);
+
     let address: Address<NetworkChecked> = get_address(&ADDRESS1().as_str());
 
     let script_pubkey = address.script_pubkey();

--- a/src/tests/helpers.rs
+++ b/src/tests/helpers.rs
@@ -358,7 +358,7 @@ pub fn assert_token_id_has_no_deployment(token_id: AlkaneId) -> Result<()> {
     return Ok(());
 }
 
-fn get_sheet_for_outpoint(
+pub fn get_sheet_for_outpoint(
     test_block: &Block,
     tx_num: usize,
     vout: u32,

--- a/src/tests/memory_security_tests.rs
+++ b/src/tests/memory_security_tests.rs
@@ -17,7 +17,7 @@ use wasm_bindgen_test::wasm_bindgen_test;
 fn create_malformed_cellpack_large_inputs() -> Cellpack {
     Cellpack {
         target: AlkaneId { block: 1, tx: 0 },
-        inputs: vec![u128::MAX, u128::MAX - 1, u128::MAX - 2], // Extremely large inputs
+        inputs: vec![u128::MAX], // Extremely large inputs
     }
 }
 


### PR DESCRIPTION
```
test tests::index_protomessage::tests::protomessage_same_tx_as_protoburn_test ... ok
transfer tx OP RETURN: 29
test tests::index_protoburns::tests::protostone_edict_even_distribution_test ... ok
transfer tx OP RETURN: 29
test tests::index_protoburns::tests::protostone_edict_burn_test ... ok
transfer tx OP RETURN: 4518
test tests::index_protoburns::tests::protostone_many_edict_test ... ok
transfer tx OP RETURN: 28
test tests::index_protoburns::tests::protostone_edict_test ... ok
transfer tx OP RETURN: 20
test tests::index_protoburns::tests::protoburn_pointer_to_OP_RETURN ... ok
transfer tx OP RETURN: 20
test tests::index_protoburns::tests::protoburn_pointer_cenotaph_test ... ok
transfer tx OP RETURN: 20
```