### PR TITLE
chore: add current height to logger

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -142,7 +142,11 @@ pub fn get_view_mode() -> bool {
 pub fn is_genesis(height: u64) -> bool {
     let mut init_ptr = IndexPointer::from_keyword("/seen-genesis");
     let has_not_seen_genesis = init_ptr.get().len() == 0;
-    println!("has_not_seen_genesis: {}", has_not_seen_genesis);
+    println!(
+        "Current block: {}, Genesis processed: {}",
+        height, !has_not_seen_genesis
+    );
+
     let is_genesis = if has_not_seen_genesis {
         get_view_mode() || height >= genesis::GENESIS_BLOCK
     } else {


### PR DESCRIPTION
Currently the indexer logs `has_not_seen_genesis: false` on every block. 


This PR adds the height to the logger aswell, which is very useful for debugging: 
`println!("Current block: {}, Genesis processed: {}", height, has_not_seen_genesis);`
