### PR TITLE
Add MCP server integration and recent enhancements

### DIFF
--- a/alkanes-mcp-server/.gitignore
+++ b/alkanes-mcp-server/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.log
+.env
+.DS_Store

--- a/alkanes-mcp-server/README.md
+++ b/alkanes-mcp-server/README.md
@@ -7,6 +7,8 @@ A comprehensive Model Context Protocol (MCP) server that exposes all `alkanes-cl
 - **Complete CLI Coverage**: All `alkanes-cli` commands are available as MCP tools
 - **Multi-Environment Support**: Configure and switch between regtest, signet, and mainnet
 - **Secure Credential Management**: Environment variable support and encrypted passphrase handling
+- **Documentation Resources**: Access to comprehensive Alkanes documentation, guides, and gotchas
+- **AI-Optimized Prompts**: Pre-configured prompts with best practices for common tasks
 - **Comprehensive Tool Set**: 200+ tools covering:
   - Bitcoin Core RPC operations
   - Wallet management and transactions
@@ -16,6 +18,35 @@ A comprehensive Model Context Protocol (MCP) server that exposes all `alkanes-cl
   - Ord/Inscription operations
   - OPI indexer queries
   - And much more
+
+## MCP Capabilities
+
+### Tools
+All `alkanes-cli` commands are exposed as MCP tools that AI agents can invoke directly. This includes operations like executing contracts, checking balances, swapping tokens, and querying blockchain data.
+
+### Resources
+The server exposes comprehensive documentation as MCP resources that agents can read on-demand:
+
+- **Technical Context**: Core technologies, dependencies, and build system
+- **System Patterns**: Design patterns, AlkaneId addressing, table relationships, and critical gotchas
+- **Contract Development Guide**: How to build Alkanes contracts with common pitfalls
+- **AssemblyScript Tx-Scripts**: Building efficient batch query scripts
+- **WAT Templates**: On-chain WASM script development
+- **Common Gotchas**: Frequent mistakes and debugging tips
+- **CLI Overview**: All available commands and usage patterns
+
+Resources reduce token usage by letting agents access documentation only when needed, and ensure they always have up-to-date information from the repository.
+
+### Prompts
+Pre-configured prompts inject best practices and gotchas proactively:
+
+- **debug-alkanes-contract**: Debug failing contracts with gotcha checklist
+- **build-token-contract**: Build tokens (owned, auth, custom) following best practices
+- **deploy-contract**: Deploy contracts with proper addressing (sequential, custom, factory)
+- **optimize-swap-path**: Find optimal AMM swap paths
+- **write-txscript**: Write AssemblyScript tx-scripts for batch operations
+
+Prompts ensure agents consider common pitfalls before making mistakes, improving success rates for complex operations.
 
 ## Installation
 

--- a/alkanes-mcp-server/README.md
+++ b/alkanes-mcp-server/README.md
@@ -1,0 +1,325 @@
+# Alkanes CLI MCP Server
+
+A comprehensive Model Context Protocol (MCP) server that exposes all `alkanes-cli` functionality as callable tools for AI agents. This server provides complete access to the Alkanes ecosystem, including Bitcoin operations, wallet management, smart contract interactions, and more.
+
+## Features
+
+- **Complete CLI Coverage**: All `alkanes-cli` commands are available as MCP tools
+- **Multi-Environment Support**: Configure and switch between regtest, signet, and mainnet
+- **Secure Credential Management**: Environment variable support and encrypted passphrase handling
+- **Comprehensive Tool Set**: 200+ tools covering:
+  - Bitcoin Core RPC operations
+  - Wallet management and transactions
+  - Alkanes protocol operations
+  - BRC20-Prog contract interactions
+  - Data API queries
+  - Ord/Inscription operations
+  - OPI indexer queries
+  - And much more
+
+## Installation
+
+```bash
+cd alkanes-mcp-server
+npm install
+npm run build
+```
+
+## Configuration
+
+The MCP server supports configuration via the MCP server configuration or environment variables.
+
+### Configuration Schema
+
+```json
+{
+  "environments": {
+    "regtest": {
+      "cli_path": "/path/to/alkanes-cli",
+      "provider": "regtest",
+      "wallet_file": "~/.alkanes/wallet.json",
+      "passphrase": "${WALLET_PASSPHRASE}",
+      "jsonrpc_url": "https://regtest.subfrost.io/v4/...",
+      "data_api": "https://regtest.subfrost.io/v4/...",
+      "bitcoin_rpc_url": "http://localhost:18443",
+      "esplora_api_url": "http://localhost:50010",
+      "ord_server_url": "http://localhost:8090",
+      "metashrew_rpc_url": "http://localhost:8080"
+    },
+    "signet": {
+      "cli_path": "/path/to/alkanes-cli",
+      "provider": "signet",
+      "wallet_file": "~/.alkanes/wallet-signet.json",
+      "passphrase": "${WALLET_PASSPHRASE}",
+      "jsonrpc_url": "https://signet.subfrost.io/v4/...",
+      "data_api": "https://signet.subfrost.io/v4/..."
+    },
+    "mainnet": {
+      "cli_path": "/path/to/alkanes-cli",
+      "provider": "mainnet",
+      "wallet_file": "~/.alkanes/wallet-mainnet.json",
+      "passphrase": "${WALLET_PASSPHRASE}",
+      "jsonrpc_url": "https://mainnet.subfrost.io/v4/...",
+      "data_api": "https://mainnet-api.oyl.gg"
+    }
+  },
+  "default_environment": "regtest",
+  "timeout_seconds": 600
+}
+```
+
+### Environment Variables
+
+- `environments`: JSON string containing the environments configuration (automatically serialized by MCP clients)
+- `default_environment`: Name of the default environment to use
+- `timeout_seconds`: Optional timeout for command execution (default: 600)
+- `ALKANES_CLI_PATH`: Path to the alkanes-cli binary (fallback if not in config)
+- `WALLET_PASSPHRASE`: Wallet passphrase (can be referenced in config as `${WALLET_PASSPHRASE}`)
+
+## Usage
+
+### Running the Server
+
+```bash
+npm start
+```
+
+Or for development:
+
+```bash
+npm run dev
+```
+
+### MCP Client Configuration
+
+Add to your MCP client configuration (e.g., Cursor, Claude Desktop):
+
+**Recommended Format:**
+
+The configuration structure can be placed directly in the `env` object. Your MCP client will automatically serialize nested objects to JSON strings when passing them as environment variables:
+
+```json
+{
+  "mcpServers": {
+    "alkanes-cli": {
+      "command": "node",
+      "args": ["/path/to/alkanes-mcp-server/dist/index.js"],
+      "env": {
+        "environments": {
+          "regtest": {
+            "cli_path": "/path/to/alkanes-cli",
+            "provider": "regtest",
+            "wallet_file": "~/.alkanes/wallet.json",
+            "passphrase": "${WALLET_PASSPHRASE}",
+            "jsonrpc_url": "https://regtest.subfrost.io/v4/...",
+            "data_api": "https://regtest.subfrost.io/v4/...",
+            "bitcoin_rpc_url": "http://localhost:18443",
+            "esplora_api_url": "http://localhost:50010",
+            "ord_server_url": "http://localhost:8090",
+            "metashrew_rpc_url": "http://localhost:8080"
+          },
+          "signet": {
+            "cli_path": "/path/to/alkanes-cli",
+            "provider": "signet",
+            "wallet_file": "~/.alkanes/wallet-signet.json",
+            "passphrase": "${WALLET_PASSPHRASE}",
+            "jsonrpc_url": "https://signet.subfrost.io/v4/...",
+            "data_api": "https://signet.subfrost.io/v4/..."
+          },
+          "mainnet": {
+            "cli_path": "/path/to/alkanes-cli",
+            "provider": "mainnet",
+            "wallet_file": "~/.alkanes/wallet-mainnet.json",
+            "passphrase": "${WALLET_PASSPHRASE}",
+            "jsonrpc_url": "https://mainnet.subfrost.io/v4/...",
+            "data_api": "https://mainnet-api.oyl.gg"
+          }
+        },
+        "default_environment": "regtest",
+        "timeout_seconds": "600",
+        "WALLET_PASSPHRASE": "your-passphrase-here"
+      }
+    }
+  }
+}
+```
+
+## Available Tools
+
+### Bitcoin Core RPC Tools
+
+- `bitcoind_getblockcount` - Get current block count
+- `bitcoind_generatetoaddress` - Generate blocks (regtest only)
+- `bitcoind_getblockchaininfo` - Get blockchain information
+- `bitcoind_getrawtransaction` - Get raw transaction
+- `bitcoind_getblock` - Get block
+- `bitcoind_sendrawtransaction` - Send raw transaction
+- And 11 more...
+
+### Wallet Tools
+
+- `wallet_create` - Create a new wallet
+- `wallet_addresses` - Get addresses from wallet
+- `wallet_utxos` - List UTXOs
+- `wallet_send` - Send transaction
+- `wallet_balance` - Get balance
+- `wallet_sign` - Sign PSBT
+- And 12 more...
+
+### Alkanes Tools
+
+- `alkanes_execute` - Execute an alkanes transaction
+- `alkanes_inspect` - Inspect an alkanes contract
+- `alkanes_trace` - Trace an alkanes transaction
+- `alkanes_simulate` - Simulate an alkanes transaction
+- `alkanes_wrap_btc` - Wrap BTC to frBTC
+- `alkanes_swap` - Execute a swap on the AMM
+- `alkanes_init_pool` - Initialize a liquidity pool
+- And 14 more...
+
+### BRC20-Prog Tools
+
+- `brc20_prog_deploy_contract` - Deploy a BRC20-prog contract
+- `brc20_prog_transact` - Call a BRC20-prog contract function
+- `brc20_prog_wrap_btc` - Wrap BTC to frBTC
+- `brc20_prog_get_code` - Get contract bytecode
+- `brc20_prog_call` - Call a contract function
+- `brc20_prog_get_balance` - Get frBTC balance
+- And 25+ more...
+
+### DataAPI Tools
+
+- `dataapi_get_alkanes` - Get all alkanes
+- `dataapi_get_alkane_details` - Get alkane details
+- `dataapi_get_pools` - Get all pools
+- `dataapi_get_pool_by_id` - Get pool details
+- `dataapi_get_holders` - Get holders of a token
+- And 11 more...
+
+### Additional Tool Categories
+
+- **Ord Tools**: Inscription queries, address info, rune info
+- **OPI Tools**: BRC-20, Runes, Bitmap, POW20, SNS indexer queries
+- **Esplora Tools**: Block and transaction queries
+- **Metashrew Tools**: Block height, state root queries
+- **Lua Tools**: Lua script execution
+- **Protorunes Tools**: Protorune queries
+- **Runestone Tools**: Runestone analysis
+- **Subfrost Tools**: frBTC unwrap utilities
+- **ESPO Tools**: Alkanes balance indexer queries
+
+## Examples
+
+### Get Block Count
+
+```json
+{
+  "name": "bitcoind_getblockcount",
+  "arguments": {}
+}
+```
+
+### Create Wallet
+
+```json
+{
+  "name": "wallet_create",
+  "arguments": {
+    "output": "~/.alkanes/my-wallet.json"
+  }
+}
+```
+
+### Get Wallet Balance
+
+```json
+{
+  "name": "wallet_balance",
+  "arguments": {
+    "raw": true
+  }
+}
+```
+
+### Execute Alkanes Transaction
+
+```json
+{
+  "name": "alkanes_execute",
+  "arguments": {
+    "to": ["p2tr:0"],
+    "protostones": ["B:1000"],
+    "auto_confirm": true
+  }
+}
+```
+
+### Deploy BRC20-Prog Contract
+
+```json
+{
+  "name": "brc20_prog_deploy_contract",
+  "arguments": {
+    "foundry_json_path": "./out/MyToken.sol/MyToken.json",
+    "auto_confirm": true
+  }
+}
+```
+
+## Security Considerations
+
+1. **Passphrase Handling**:
+
+   - Use environment variables for passphrases (e.g., `${WALLET_PASSPHRASE}`)
+   - Never hardcode passphrases in configuration files
+   - Passphrases are never logged
+
+2. **Configuration Validation**:
+
+   - All URLs are validated for proper format
+   - File paths are sanitized to prevent directory traversal
+   - Network/provider consistency is verified
+
+3. **Command Execution**:
+   - All tool parameters are validated
+   - Command injection is prevented
+   - Timeouts are enforced (default: 10 minutes)
+
+## Error Handling
+
+The server provides comprehensive error handling:
+
+- `CONFIG_ERROR`: Configuration issues
+- `EXECUTION_ERROR`: Command execution failures
+- `TIMEOUT_ERROR`: Command timeouts
+- `VALIDATION_ERROR`: Parameter validation failures
+
+All errors include detailed messages and context for debugging.
+
+## Development
+
+### Building
+
+```bash
+npm run build
+```
+
+### Development Mode
+
+```bash
+npm run dev
+```
+
+### Type Checking
+
+```bash
+npx tsc --noEmit
+```
+
+## License
+
+MIT
+
+## Support
+
+For issues and questions, please refer to the main Alkanes project documentation.

--- a/alkanes-mcp-server/mcp-config.json
+++ b/alkanes-mcp-server/mcp-config.json
@@ -1,0 +1,14 @@
+{
+  "environments": {
+    "regtest": {
+      "cli_path": "/Users/andrewhathaway/code/oyl/alkanes-rs/target/release/alkanes-cli",
+      "provider": "regtest",
+      "wallet_file": "~/.alkanes/wallet.json",
+      "passphrase": "${WALLET_PASSPHRASE}",
+      "jsonrpc_url": "https://regtest.subfrost.io/v4/cd5e637ee36b786f9e496d51b7060a01",
+      "data_api": "https://regtest.subfrost.io/v4/cd5e637ee36b786f9e496d51b7060a01"
+    }
+  },
+  "default_environment": "regtest",
+  "timeout_seconds": 600
+}

--- a/alkanes-mcp-server/package-lock.json
+++ b/alkanes-mcp-server/package-lock.json
@@ -1,0 +1,1704 @@
+{
+  "name": "alkanes-mcp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "alkanes-mcp-server",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.4"
+      },
+      "bin": {
+        "alkanes-mcp-server": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.8.tgz",
+      "integrity": "sha512-0/g2lIOPzX8f3vzW1ggQgvG5mjtFBDBHFAzI5SFAi2DzSqS9luJwqg9T6O/gKYLi+inS7eNxBeIFkkghIPvrMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
+      "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.7",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
+      "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
+      "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
+      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/alkanes-mcp-server/package.json
+++ b/alkanes-mcp-server/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "alkanes-mcp-server",
+  "version": "1.0.0",
+  "description": "MCP server for alkanes-cli - exposes all CLI commands as MCP tools",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "alkanes-mcp-server": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "watch": "tsc --watch"
+  },
+  "keywords": [
+    "mcp",
+    "alkanes",
+    "bitcoin",
+    "cli"
+  ],
+  "author": "Alkanes Team",
+  "license": "MIT",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/alkanes-mcp-server/src/config.ts
+++ b/alkanes-mcp-server/src/config.ts
@@ -143,10 +143,41 @@ function validateEnvironmentConfig(
 
 /**
  * Load configuration from environment variables
- * MCP clients serialize nested objects to JSON strings automatically
+ * Prioritizes individual environment variables over legacy MCP_SERVER_CONFIG
  */
 export function loadConfigFromEnv(): McpServerConfig | null {
-  // First, check for MCP_SERVER_CONFIG (single JSON string with full config)
+  // First, check for individual environment variables (preferred approach)
+  const environmentsValue = process.env.environments;
+  const defaultEnv = process.env.default_environment;
+  const timeoutSeconds = process.env.timeout_seconds;
+
+  if (environmentsValue && defaultEnv) {
+    try {
+      // Parse environments from JSON string (MCP clients serialize nested objects)
+      const environments = JSON.parse(environmentsValue);
+
+      const config: Record<string, unknown> = {
+        environments,
+        default_environment: defaultEnv,
+      };
+
+      if (timeoutSeconds) {
+        const timeout = parseInt(timeoutSeconds, 10);
+        if (!isNaN(timeout)) {
+          config.timeout_seconds = timeout;
+        }
+      }
+
+      return loadConfig(config);
+    } catch (error) {
+      throw new ConfigurationError(
+        `Failed to parse environments from env var: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  // Fall back to legacy MCP_SERVER_CONFIG (single JSON string with full config)
+  // This is kept for backward compatibility but not recommended
   const mcpServerConfig = process.env.MCP_SERVER_CONFIG;
   if (mcpServerConfig) {
     try {
@@ -159,37 +190,7 @@ export function loadConfigFromEnv(): McpServerConfig | null {
     }
   }
 
-  // Fall back to individual environment variables
-  const environmentsValue = process.env.environments;
-  const defaultEnv = process.env.default_environment;
-  const timeoutSeconds = process.env.timeout_seconds;
-
-  if (!environmentsValue || !defaultEnv) {
-    return null;
-  }
-
-  try {
-    // Parse environments from JSON string (MCP clients serialize nested objects)
-    const environments = JSON.parse(environmentsValue);
-
-    const config: Record<string, unknown> = {
-      environments,
-      default_environment: defaultEnv,
-    };
-
-    if (timeoutSeconds) {
-      const timeout = parseInt(timeoutSeconds, 10);
-      if (!isNaN(timeout)) {
-        config.timeout_seconds = timeout;
-      }
-    }
-
-    return loadConfig(config);
-  } catch (error) {
-    throw new ConfigurationError(
-      `Failed to parse environments from env var: ${error instanceof Error ? error.message : String(error)}`
-    );
-  }
+  return null;
 }
 
 /**

--- a/alkanes-mcp-server/src/config.ts
+++ b/alkanes-mcp-server/src/config.ts
@@ -146,6 +146,20 @@ function validateEnvironmentConfig(
  * MCP clients serialize nested objects to JSON strings automatically
  */
 export function loadConfigFromEnv(): McpServerConfig | null {
+  // First, check for MCP_SERVER_CONFIG (single JSON string with full config)
+  const mcpServerConfig = process.env.MCP_SERVER_CONFIG;
+  if (mcpServerConfig) {
+    try {
+      const parsedConfig = JSON.parse(mcpServerConfig);
+      return loadConfig(parsedConfig);
+    } catch (error) {
+      throw new ConfigurationError(
+        `Failed to parse MCP_SERVER_CONFIG: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  // Fall back to individual environment variables
   const environmentsValue = process.env.environments;
   const defaultEnv = process.env.default_environment;
   const timeoutSeconds = process.env.timeout_seconds;
@@ -162,14 +176,14 @@ export function loadConfigFromEnv(): McpServerConfig | null {
       environments,
       default_environment: defaultEnv,
     };
-    
+
     if (timeoutSeconds) {
       const timeout = parseInt(timeoutSeconds, 10);
       if (!isNaN(timeout)) {
         config.timeout_seconds = timeout;
       }
     }
-    
+
     return loadConfig(config);
   } catch (error) {
     throw new ConfigurationError(

--- a/alkanes-mcp-server/src/config.ts
+++ b/alkanes-mcp-server/src/config.ts
@@ -1,0 +1,260 @@
+/**
+ * Configuration management for the MCP server
+ */
+
+import { ConfigurationError, ValidationError } from './error.js';
+import { expandPath } from './utils.js';
+
+export interface EnvironmentConfig {
+  cli_path: string;
+  provider: 'regtest' | 'signet' | 'mainnet';
+  wallet_file?: string;
+  passphrase?: string;
+  jsonrpc_url?: string;
+  data_api?: string;
+  bitcoin_rpc_url?: string;
+  esplora_api_url?: string;
+  ord_server_url?: string;
+  metashrew_rpc_url?: string;
+  brc20_prog_rpc_url?: string;
+  frbtc_address?: string;
+  opi_url?: string;
+  espo_rpc_url?: string;
+  subfrost_api_key?: string;
+  jsonrpc_headers?: string[];
+  opi_headers?: string[];
+  hd_path?: string;
+  wallet_address?: string;
+  wallet_key?: string;
+  wallet_key_file?: string;
+  titan_api_url?: string;
+}
+
+export interface McpServerConfig {
+  environments: Record<string, EnvironmentConfig>;
+  default_environment: string;
+  timeout_seconds?: number;
+}
+
+/**
+ * Resolve environment variable references in strings
+ * Supports ${VAR_NAME} and $VAR_NAME syntax
+ */
+function resolveEnvVar(value: string): string {
+  // Handle ${VAR_NAME} syntax
+  value = value.replace(/\$\{([^}]+)\}/g, (_, varName) => {
+    const envValue = process.env[varName];
+    if (envValue === undefined) {
+      throw new ConfigurationError(
+        `Environment variable ${varName} is not set`
+      );
+    }
+    return envValue;
+  });
+
+  // Handle $VAR_NAME syntax (but not ${VAR_NAME} which we already handled)
+  value = value.replace(/\$([A-Z_][A-Z0-9_]*)/g, (_, varName) => {
+    const envValue = process.env[varName];
+    if (envValue === undefined) {
+      throw new ConfigurationError(
+        `Environment variable ${varName} is not set`
+      );
+    }
+    return envValue;
+  });
+
+  return value;
+}
+
+/**
+ * Expand and resolve configuration values
+ */
+function expandConfigValue(value: string | undefined): string | undefined {
+  if (!value) return value;
+  const expanded = expandPath(value);
+  return resolveEnvVar(expanded);
+}
+
+/**
+ * Validate environment configuration
+ */
+function validateEnvironmentConfig(
+  name: string,
+  config: EnvironmentConfig
+): void {
+  if (!config.cli_path) {
+    throw new ValidationError(
+      `Environment ${name}: cli_path is required`
+    );
+  }
+
+  // Expand and validate cli_path
+  const cliPath = expandConfigValue(config.cli_path);
+  if (!cliPath) {
+    throw new ValidationError(
+      `Environment ${name}: cli_path cannot be empty`
+    );
+  }
+
+  // Validate provider
+  const validProviders = ['regtest', 'signet', 'mainnet'];
+  if (!validProviders.includes(config.provider)) {
+    throw new ValidationError(
+      `Environment ${name}: provider must be one of ${validProviders.join(', ')}`
+    );
+  }
+
+  // Validate URLs if provided
+  const urlFields = [
+    'jsonrpc_url',
+    'data_api',
+    'bitcoin_rpc_url',
+    'esplora_api_url',
+    'ord_server_url',
+    'metashrew_rpc_url',
+    'brc20_prog_rpc_url',
+    'opi_url',
+    'espo_rpc_url',
+    'titan_api_url',
+  ] as const;
+
+  for (const field of urlFields) {
+    const url = config[field];
+    if (url && typeof url === 'string') {
+      try {
+        new URL(url);
+      } catch {
+        throw new ValidationError(
+          `Environment ${name}: ${field} is not a valid URL: ${url}`
+        );
+      }
+    }
+  }
+
+  // Validate wallet_file path if provided
+  if (config.wallet_file) {
+    const walletPath = expandConfigValue(config.wallet_file);
+    if (walletPath && !walletPath.startsWith('~') && !walletPath.startsWith('/')) {
+      // Relative paths are okay, but warn if they don't exist
+      // We'll check existence at runtime
+    }
+  }
+}
+
+/**
+ * Load configuration from environment variables
+ * MCP clients serialize nested objects to JSON strings automatically
+ */
+export function loadConfigFromEnv(): McpServerConfig | null {
+  const environmentsValue = process.env.environments;
+  const defaultEnv = process.env.default_environment;
+  const timeoutSeconds = process.env.timeout_seconds;
+
+  if (!environmentsValue || !defaultEnv) {
+    return null;
+  }
+
+  try {
+    // Parse environments from JSON string (MCP clients serialize nested objects)
+    const environments = JSON.parse(environmentsValue);
+
+    const config: Record<string, unknown> = {
+      environments,
+      default_environment: defaultEnv,
+    };
+    
+    if (timeoutSeconds) {
+      const timeout = parseInt(timeoutSeconds, 10);
+      if (!isNaN(timeout)) {
+        config.timeout_seconds = timeout;
+      }
+    }
+    
+    return loadConfig(config);
+  } catch (error) {
+    throw new ConfigurationError(
+      `Failed to parse environments from env var: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
+ * Load and validate MCP server configuration
+ */
+export function loadConfig(configJson: unknown): McpServerConfig {
+  if (!configJson || typeof configJson !== 'object') {
+    throw new ConfigurationError('Configuration must be an object');
+  }
+
+  const config = configJson as Record<string, unknown>;
+
+  if (!config.environments || typeof config.environments !== 'object') {
+    throw new ConfigurationError('Configuration must have an "environments" object');
+  }
+
+  const environments = config.environments as Record<string, unknown>;
+  const defaultEnv = config.default_environment as string | undefined;
+
+  if (!defaultEnv) {
+    throw new ConfigurationError('Configuration must have a "default_environment"');
+  }
+
+  if (!environments[defaultEnv]) {
+    throw new ConfigurationError(
+      `Default environment "${defaultEnv}" not found in environments`
+    );
+  }
+
+  // Validate all environments
+  const validatedEnvironments: Record<string, EnvironmentConfig> = {};
+  for (const [name, envConfig] of Object.entries(environments)) {
+    if (!envConfig || typeof envConfig !== 'object') {
+      throw new ValidationError(`Environment ${name}: must be an object`);
+    }
+
+    const expandedConfig: EnvironmentConfig = {
+      ...(envConfig as EnvironmentConfig),
+      cli_path: expandConfigValue((envConfig as EnvironmentConfig).cli_path) || '',
+      wallet_file: expandConfigValue((envConfig as EnvironmentConfig).wallet_file),
+      passphrase: expandConfigValue((envConfig as EnvironmentConfig).passphrase),
+      jsonrpc_url: expandConfigValue((envConfig as EnvironmentConfig).jsonrpc_url),
+      data_api: expandConfigValue((envConfig as EnvironmentConfig).data_api),
+      bitcoin_rpc_url: expandConfigValue((envConfig as EnvironmentConfig).bitcoin_rpc_url),
+      esplora_api_url: expandConfigValue((envConfig as EnvironmentConfig).esplora_api_url),
+      ord_server_url: expandConfigValue((envConfig as EnvironmentConfig).ord_server_url),
+      metashrew_rpc_url: expandConfigValue((envConfig as EnvironmentConfig).metashrew_rpc_url),
+      brc20_prog_rpc_url: expandConfigValue((envConfig as EnvironmentConfig).brc20_prog_rpc_url),
+      opi_url: expandConfigValue((envConfig as EnvironmentConfig).opi_url),
+      espo_rpc_url: expandConfigValue((envConfig as EnvironmentConfig).espo_rpc_url),
+      titan_api_url: expandConfigValue((envConfig as EnvironmentConfig).titan_api_url),
+    };
+
+    validateEnvironmentConfig(name, expandedConfig);
+    validatedEnvironments[name] = expandedConfig;
+  }
+
+  return {
+    environments: validatedEnvironments,
+    default_environment: defaultEnv,
+    timeout_seconds: (config.timeout_seconds as number | undefined) || 600,
+  };
+}
+
+/**
+ * Get environment configuration
+ */
+export function getEnvironmentConfig(
+  config: McpServerConfig,
+  environment?: string
+): EnvironmentConfig {
+  const envName = environment || config.default_environment;
+  const envConfig = config.environments[envName];
+
+  if (!envConfig) {
+    throw new ConfigurationError(
+      `Environment "${envName}" not found. Available: ${Object.keys(config.environments).join(', ')}`
+    );
+  }
+
+  return envConfig;
+}

--- a/alkanes-mcp-server/src/error.ts
+++ b/alkanes-mcp-server/src/error.ts
@@ -1,0 +1,84 @@
+/**
+ * Error handling for the MCP server
+ */
+
+export class AlkanesMcpError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly details?: unknown
+  ) {
+    super(message);
+    this.name = 'AlkanesMcpError';
+  }
+}
+
+export class ConfigurationError extends AlkanesMcpError {
+  constructor(message: string, details?: unknown) {
+    super(message, 'CONFIG_ERROR', details);
+    this.name = 'ConfigurationError';
+  }
+}
+
+export class ExecutionError extends AlkanesMcpError {
+  constructor(message: string, details?: unknown) {
+    super(message, 'EXECUTION_ERROR', details);
+    this.name = 'ExecutionError';
+  }
+}
+
+export class TimeoutError extends AlkanesMcpError {
+  constructor(message: string, details?: unknown) {
+    super(message, 'TIMEOUT_ERROR', details);
+    this.name = 'TimeoutError';
+  }
+}
+
+export class ValidationError extends AlkanesMcpError {
+  constructor(message: string, details?: unknown) {
+    super(message, 'VALIDATION_ERROR', details);
+    this.name = 'ValidationError';
+  }
+}
+
+/**
+ * Map CLI exit codes and errors to MCP error codes
+ */
+export function mapCliError(
+  error: unknown,
+  command: string
+): AlkanesMcpError {
+  if (error instanceof AlkanesMcpError) {
+    return error;
+  }
+
+  const errorMessage = error instanceof Error ? error.message : String(error);
+
+  // Check for common error patterns
+  if (errorMessage.includes('timeout') || errorMessage.includes('timed out')) {
+    return new TimeoutError(
+      `Command timed out: ${command}`,
+      { command, originalError: errorMessage }
+    );
+  }
+
+  if (errorMessage.includes('not found') || errorMessage.includes('No such file')) {
+    return new ConfigurationError(
+      `CLI binary or file not found: ${errorMessage}`,
+      { command, originalError: errorMessage }
+    );
+  }
+
+  if (errorMessage.includes('permission denied')) {
+    return new ExecutionError(
+      `Permission denied: ${errorMessage}`,
+      { command, originalError: errorMessage }
+    );
+  }
+
+  // Default to execution error
+  return new ExecutionError(
+    `Command failed: ${command}`,
+    { command, originalError: errorMessage }
+  );
+}

--- a/alkanes-mcp-server/src/executor.ts
+++ b/alkanes-mcp-server/src/executor.ts
@@ -1,0 +1,248 @@
+/**
+ * CLI command executor
+ */
+
+import { spawn } from 'child_process';
+import { readFile } from 'fs/promises';
+import { ExecutionError, TimeoutError, mapCliError } from './error.js';
+import type { EnvironmentConfig } from './config.js';
+import { buildArgs } from './utils.js';
+
+export interface ExecutionResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  success: boolean;
+}
+
+export interface ExecutionOptions {
+  timeout?: number;
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+/**
+ * Execute alkanes-cli command
+ */
+export async function executeCommand(
+  config: EnvironmentConfig,
+  command: string[],
+  options: ExecutionOptions = {}
+): Promise<ExecutionResult> {
+  const timeout = options.timeout || 600000; // 10 minutes default
+  const cwd = options.cwd || process.cwd();
+
+  return new Promise((resolve, reject) => {
+    const cliPath = config.cli_path;
+    const args = buildBaseArgs(config).concat(command);
+
+    let stdout = '';
+    let stderr = '';
+    let timeoutHandle: NodeJS.Timeout | null = null;
+
+    const child = spawn(cliPath, args, {
+      cwd,
+      env: {
+        ...process.env,
+        ...options.env,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    child.stdout?.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on('error', (error) => {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      reject(
+        mapCliError(
+          new ExecutionError(`Failed to execute command: ${error.message}`, { cliPath, args }),
+          command.join(' ')
+        )
+      );
+    });
+
+    child.on('exit', (code) => {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+
+      const exitCode = code ?? 1;
+      const success = exitCode === 0;
+
+      resolve({
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        exitCode,
+        success,
+      });
+    });
+
+    // Set timeout
+    timeoutHandle = setTimeout(() => {
+      child.kill('SIGTERM');
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      reject(
+        new TimeoutError(
+          `Command timed out after ${timeout}ms`,
+          { command: command.join(' '), timeout }
+        )
+      );
+    }, timeout);
+  });
+}
+
+/**
+ * Build base arguments from environment configuration
+ */
+function buildBaseArgs(config: EnvironmentConfig): string[] {
+  const args: string[] = [];
+
+  // Provider
+  if (config.provider) {
+    args.push('-p', config.provider);
+  }
+
+  // Wallet configuration
+  if (config.wallet_file) {
+    args.push('--wallet-file', config.wallet_file);
+  }
+
+  if (config.passphrase) {
+    args.push('--passphrase', config.passphrase);
+  }
+
+  if (config.hd_path) {
+    args.push('--hd-path', config.hd_path);
+  }
+
+  if (config.wallet_address) {
+    args.push('--wallet-address', config.wallet_address);
+  }
+
+  if (config.wallet_key) {
+    args.push('--wallet-key', config.wallet_key);
+  }
+
+  if (config.wallet_key_file) {
+    args.push('--wallet-key-file', config.wallet_key_file);
+  }
+
+  // RPC URLs
+  if (config.jsonrpc_url) {
+    args.push('--jsonrpc-url', config.jsonrpc_url);
+  }
+
+  if (config.titan_api_url) {
+    args.push('--titan-api-url', config.titan_api_url);
+  }
+
+  if (config.subfrost_api_key) {
+    args.push('--subfrost-api-key', config.subfrost_api_key);
+  }
+
+  if (config.bitcoin_rpc_url) {
+    args.push('--bitcoin-rpc-url', config.bitcoin_rpc_url);
+  }
+
+  if (config.esplora_api_url) {
+    args.push('--esplora-api-url', config.esplora_api_url);
+  }
+
+  if (config.ord_server_url) {
+    args.push('--ord-server-url', config.ord_server_url);
+  }
+
+  if (config.metashrew_rpc_url) {
+    args.push('--metashrew-rpc-url', config.metashrew_rpc_url);
+  }
+
+  if (config.brc20_prog_rpc_url) {
+    args.push('--brc20-prog-rpc-url', config.brc20_prog_rpc_url);
+  }
+
+  if (config.frbtc_address) {
+    args.push('--frbtc-address', config.frbtc_address);
+  }
+
+  if (config.data_api) {
+    args.push('--data-api', config.data_api);
+  }
+
+  if (config.opi_url) {
+    args.push('--opi-url', config.opi_url);
+  }
+
+  if (config.espo_rpc_url) {
+    args.push('--espo-rpc-url', config.espo_rpc_url);
+  }
+
+  // Headers
+  if (config.jsonrpc_headers) {
+    for (const header of config.jsonrpc_headers) {
+      args.push('--jsonrpc-header', header);
+    }
+  }
+
+  if (config.opi_headers) {
+    for (const header of config.opi_headers) {
+      args.push('--opi-header', header);
+    }
+  }
+
+  return args;
+}
+
+/**
+ * Parse JSON response from CLI
+ */
+export function parseJsonResponse<T = unknown>(stdout: string): T {
+  try {
+    return JSON.parse(stdout) as T;
+  } catch (error) {
+    throw new ExecutionError(
+      `Failed to parse JSON response: ${error instanceof Error ? error.message : String(error)}`,
+      { stdout }
+    );
+  }
+}
+
+/**
+ * Execute command and parse JSON response
+ */
+export async function executeCommandJson<T = unknown>(
+  config: EnvironmentConfig,
+  command: string[],
+  options: ExecutionOptions = {}
+): Promise<T> {
+  const result = await executeCommand(config, command, options);
+
+  if (!result.success) {
+    throw new ExecutionError(
+      `Command failed with exit code ${result.exitCode}`,
+      {
+        command: command.join(' '),
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exitCode: result.exitCode,
+      }
+    );
+  }
+
+  // Try to parse JSON from stdout
+  try {
+    return parseJsonResponse<T>(result.stdout);
+  } catch {
+    // If not JSON, return the raw stdout as a string
+    return result.stdout as unknown as T;
+  }
+}

--- a/alkanes-mcp-server/src/index.ts
+++ b/alkanes-mcp-server/src/index.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+/**
+ * Alkanes CLI MCP Server
+ * 
+ * Exposes all alkanes-cli commands as MCP tools for AI agents
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  McpError,
+  ErrorCode,
+} from '@modelcontextprotocol/sdk/types.js';
+import { loadConfig, loadConfigFromEnv, getEnvironmentConfig, type McpServerConfig } from './config.js';
+import { registerAllTools } from './tools/mod.js';
+import { getAllTools, executeTool } from './tools/registry.js';
+import type { EnvironmentConfig } from './config.js';
+
+// Load configuration from environment or MCP server config
+let serverConfig: McpServerConfig;
+let currentEnvironment: string | undefined;
+
+try {
+  // Try to load from environment variables (new format)
+  // Supports both:
+  // 1. New format: environments, default_environment, timeout_seconds as separate env vars
+  // 2. Old format: MCP_SERVER_CONFIG as JSON string
+  const loadedConfig = loadConfigFromEnv();
+  if (loadedConfig) {
+    serverConfig = loadedConfig;
+  } else {
+    // Default configuration - can be overridden via MCP server config
+    serverConfig = {
+      environments: {
+        regtest: {
+          cli_path: process.env.ALKANES_CLI_PATH || './target/release/alkanes-cli',
+          provider: 'regtest',
+        },
+      },
+      default_environment: 'regtest',
+    };
+  }
+} catch (error) {
+  console.error('Failed to load configuration:', error);
+  process.exit(1);
+}
+
+// Register all tools first
+registerAllTools();
+
+// Create MCP server
+const server = new Server(
+  {
+    name: 'alkanes-cli-mcp-server',
+    version: '1.0.0',
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+// Get current environment configuration
+function getCurrentConfig(): EnvironmentConfig {
+  return getEnvironmentConfig(serverConfig, currentEnvironment);
+}
+
+// Handle list tools request
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: getAllTools(),
+  };
+});
+
+// Handle tool calls
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  try {
+    const config = getCurrentConfig();
+    const result = await executeTool(
+      request.params.name,
+      config,
+      request.params.arguments || {}
+    );
+    // MCP expects content array format
+    return {
+      content: result.content,
+    };
+  } catch (error) {
+    if (error instanceof McpError) {
+      throw error;
+    }
+    throw new McpError(
+      ErrorCode.InternalError,
+      `Error executing tool: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+});
+
+// Note: Configuration updates would be handled via MCP notifications if needed
+// For now, configuration is loaded from environment variables at startup
+
+// Start server
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('Alkanes CLI MCP Server running on stdio');
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/alkanes-mcp-server/src/index.ts
+++ b/alkanes-mcp-server/src/index.ts
@@ -11,12 +11,18 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
   McpError,
   ErrorCode,
 } from '@modelcontextprotocol/sdk/types.js';
 import { loadConfig, loadConfigFromEnv, getEnvironmentConfig, type McpServerConfig } from './config.js';
 import { registerAllTools } from './tools/mod.js';
 import { getAllTools, executeTool } from './tools/registry.js';
+import { listResources, readResource } from './resources.js';
+import { listPrompts, getPrompt } from './prompts.js';
 import type { EnvironmentConfig } from './config.js';
 
 // Load configuration from environment or MCP server config
@@ -60,6 +66,8 @@ const server = new Server(
   {
     capabilities: {
       tools: {},
+      resources: {},
+      prompts: {},
     },
   }
 );
@@ -96,6 +104,51 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     throw new McpError(
       ErrorCode.InternalError,
       `Error executing tool: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+});
+
+// Handle list resources request
+server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  return {
+    resources: listResources(),
+  };
+});
+
+// Handle read resource request
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  try {
+    const content = await readResource(request.params.uri);
+    return {
+      contents: [content],
+    };
+  } catch (error) {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      `Resource not found: ${request.params.uri}`
+    );
+  }
+});
+
+// Handle list prompts request
+server.setRequestHandler(ListPromptsRequestSchema, async () => {
+  return {
+    prompts: listPrompts(),
+  };
+});
+
+// Handle get prompt request
+server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+  try {
+    const result = getPrompt(request.params.name, request.params.arguments);
+    return {
+      description: `Prompt for ${request.params.name}`,
+      messages: result.messages,
+    };
+  } catch (error) {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      `Prompt not found: ${request.params.name}`
     );
   }
 });

--- a/alkanes-mcp-server/src/prompts.ts
+++ b/alkanes-mcp-server/src/prompts.ts
@@ -1,0 +1,500 @@
+/**
+ * Prompts API - Provides pre-configured prompts with best practices and gotchas
+ */
+
+export interface Prompt {
+  name: string;
+  description: string;
+  arguments?: Array<{
+    name: string;
+    description: string;
+    required: boolean;
+  }>;
+}
+
+export interface PromptMessage {
+  role: 'user' | 'assistant';
+  content: {
+    type: 'text';
+    text: string;
+  };
+}
+
+export interface GetPromptResult {
+  messages: PromptMessage[];
+}
+
+/**
+ * Get list of all available prompts
+ */
+export function listPrompts(): Prompt[] {
+  return [
+    {
+      name: 'debug-alkanes-contract',
+      description: 'Debug a failing Alkanes contract with common gotchas in mind',
+      arguments: [
+        {
+          name: 'error',
+          description: 'The error message or symptom',
+          required: true,
+        },
+      ],
+    },
+    {
+      name: 'build-token-contract',
+      description: 'Build an Alkanes token contract following best practices',
+      arguments: [
+        {
+          name: 'token_type',
+          description: 'Token type: owned, auth, or custom',
+          required: true,
+        },
+        {
+          name: 'features',
+          description: 'Additional features needed (optional)',
+          required: false,
+        },
+      ],
+    },
+    {
+      name: 'deploy-contract',
+      description: 'Deploy an Alkanes contract with proper addressing and initialization',
+      arguments: [
+        {
+          name: 'deployment_type',
+          description: 'Deployment type: sequential, custom-address, or factory',
+          required: true,
+        },
+      ],
+    },
+    {
+      name: 'optimize-swap-path',
+      description: 'Find optimal swap path between tokens using AMM pools',
+      arguments: [
+        {
+          name: 'from_token',
+          description: 'Source token AlkaneId (e.g., "2:0")',
+          required: true,
+        },
+        {
+          name: 'to_token',
+          description: 'Destination token AlkaneId (e.g., "2:1")',
+          required: true,
+        },
+        {
+          name: 'amount',
+          description: 'Amount to swap',
+          required: true,
+        },
+      ],
+    },
+    {
+      name: 'write-txscript',
+      description: 'Write an AssemblyScript tx-script for batch operations',
+      arguments: [
+        {
+          name: 'operation',
+          description: 'What operation to batch (e.g., "fetch pool details")',
+          required: true,
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Get a specific prompt by name
+ */
+export function getPrompt(name: string, args?: Record<string, string>): GetPromptResult {
+  switch (name) {
+    case 'debug-alkanes-contract':
+      return getDebugContractPrompt(args?.error || 'unknown error');
+
+    case 'build-token-contract':
+      return getBuildTokenPrompt(args?.token_type || 'owned', args?.features);
+
+    case 'deploy-contract':
+      return getDeployContractPrompt(args?.deployment_type || 'sequential');
+
+    case 'optimize-swap-path':
+      return getOptimizeSwapPrompt(
+        args?.from_token || '',
+        args?.to_token || '',
+        args?.amount || ''
+      );
+
+    case 'write-txscript':
+      return getWriteTxScriptPrompt(args?.operation || '');
+
+    default:
+      throw new Error(`Prompt not found: ${name}`);
+  }
+}
+
+/**
+ * Debug contract prompt
+ */
+function getDebugContractPrompt(error: string): GetPromptResult {
+  return {
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `Debug this Alkanes contract error: ${error}
+
+Before investigating, check these CRITICAL gotchas:
+
+1. **Double Indexing** - Did you call index_block multiple times for the same block? This causes:
+   - Unexpected token IDs
+   - Swapped balances
+   - Inconsistent state
+
+2. **Auth Token Initialization** - For owned tokens, did you initialize with auth token units?
+   \`\`\`rust
+   inputs: vec![0, 100, 1000] // opcode, auth_units, token_units
+   \`\`\`
+
+3. **AlkaneId Addressing** - Is your AlkaneId correct?
+   - [1, 0] → deploys to [2, next_sequence]
+   - [3, n] → deploys to [4, n]
+   - block parameter is NOT block height!
+
+4. **Cellpack Format** - Is the first input the opcode?
+   \`\`\`rust
+   inputs: [opcode, param1, param2, ...]
+   \`\`\`
+
+5. **Table Population** - Are the required tables populated?
+   - OUTPOINTS_FOR_ADDRESS - populated for all txs
+   - RUNE_ID_TO_OUTPOINTS - only for runestone txs
+
+6. **Protobuf Encoding** - For RPC calls, is Uint128 encoded as length-delimited?
+
+7. **Fuel Metering** - Is there adequate fuel for the operation?
+
+Check the gotchas documentation (alkanes://docs/gotchas) for detailed solutions.
+
+Now let's investigate your specific error...`,
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Build token contract prompt
+ */
+function getBuildTokenPrompt(tokenType: string, features?: string): GetPromptResult {
+  const featuresText = features ? `\nAdditional features: ${features}` : '';
+
+  return {
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `Build an Alkanes ${tokenType} token contract following best practices.${featuresText}
+
+Key requirements for ${tokenType} tokens:
+
+${tokenType === 'owned' ? `
+**Owned Token Checklist**:
+1. Implement AlkaneResponder trait
+2. Implement AuthenticatedResponder trait
+3. Opcode 0 (initialize):
+   - Deploy auth token with deploy_auth_token()
+   - Store auth token ID at /auth
+   - Return both auth token and owned token
+4. Opcode 77 (mint):
+   - Call only_owner() first
+   - Mint new tokens
+   - Return minted tokens
+5. CRITICAL: Initialize with both auth_token_units and token_units
+
+Example initialization:
+\`\`\`rust
+inputs: vec![
+    0,    // opcode: initialize
+    100,  // auth_token_units (REQUIRED)
+    1000, // token_units
+]
+\`\`\`
+` : ''}
+
+${tokenType === 'auth' ? `
+**Auth Token Checklist**:
+1. Opcode 0 (initialize):
+   - Mint initial supply
+   - Return auth tokens to caller
+2. Opcode 1 (authenticate):
+   - Verify exactly 1 incoming alkane
+   - Verify it's the auth token
+   - Verify at least 1 unit
+   - Return auth token to maintain ownership
+` : ''}
+
+${tokenType === 'custom' ? `
+**Custom Token Checklist**:
+1. Implement AlkaneResponder trait
+2. Define your opcodes (0 should be initialize)
+3. Handle state management with load/store
+4. Return proper CallResponse with alkanes
+5. Consider if you need authentication
+` : ''}
+
+**Common Pitfalls**:
+- Don't forget to return alkanes in the response
+- Use shift_or_err() to safely extract inputs
+- Always handle the default case in opcode match
+- Test with simulation before deployment
+
+Read the contract development guide (alkanes://docs/contract-development) for full details.`,
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Deploy contract prompt
+ */
+function getDeployContractPrompt(deploymentType: string): GetPromptResult {
+  return {
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `Deploy an Alkanes contract using ${deploymentType} deployment.
+
+**Deployment Types**:
+
+${deploymentType === 'sequential' ? `
+**Sequential Deployment ([1, 0] → [2, n])**:
+1. Use target [1, 0] in your cellpack
+2. Contract will be deployed to [2, next_sequence]
+3. Sequence starts at 1 (0 is reserved for genesis ALKANE)
+
+\`\`\`bash
+alkanes-cli alkanes execute \\
+  --target 1:0 \\
+  --inputs 0,100,1000 \\
+  --envelope my_contract.wasm \\
+  --fee 50000
+\`\`\`
+` : ''}
+
+${deploymentType === 'custom-address' ? `
+**Custom Address Deployment ([3, n] → [4, n])**:
+1. Choose a unique u128 value for n
+2. Use target [3, n] in your cellpack
+3. Contract will be deployed to [4, n]
+
+\`\`\`bash
+alkanes-cli alkanes execute \\
+  --target 3:0xffddffee \\
+  --inputs 0,100,1000 \\
+  --envelope my_contract.wasm \\
+  --fee 50000
+\`\`\`
+
+This allows deploying to predictable addresses.
+` : ''}
+
+${deploymentType === 'factory' ? `
+**Factory Deployment (Clone Pattern)**:
+
+Option 1: Clone from sequential ([5, n]):
+\`\`\`bash
+# Deploy template to [2, n]
+alkanes-cli alkanes execute --target 1:0 --envelope template.wasm --fee 50000
+
+# Clone it (assuming it's at [2, 5])
+alkanes-cli alkanes execute --target 5:5 --inputs 0,500 --fee 30000
+\`\`\`
+
+Option 2: Clone from custom address ([6, n]):
+\`\`\`bash
+# Deploy template to [4, 0xffddffee]
+alkanes-cli alkanes execute --target 3:0xffddffee --envelope template.wasm --fee 50000
+
+# Clone it
+alkanes-cli alkanes execute --target 6:0xffddffee --inputs 0,500 --fee 30000
+\`\`\`
+
+Factory pattern is ideal for contracts deployed many times (tokens, pools, etc).
+` : ''}
+
+**Deployment Checklist**:
+1. ✅ Simulate first: \`alkanes-cli alkanes simulate ...\`
+2. ✅ Verify WASM compiles correctly
+3. ✅ Check initialization inputs are correct
+4. ✅ Set adequate fee for contract size
+5. ✅ Verify deployment address after execution
+
+**CRITICAL**: The block parameter is NOT blockchain block height - it's the deployment selector!
+
+Read the contract development guide (alkanes://docs/contract-development) for more details.`,
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Optimize swap path prompt
+ */
+function getOptimizeSwapPrompt(fromToken: string, toToken: string, amount: string): GetPromptResult {
+  return {
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `Find the optimal swap path from ${fromToken} to ${toToken} for amount ${amount}.
+
+**Approach**:
+
+1. **Query available pools**:
+\`\`\`bash
+alkanes-cli alkanes simulate <factory_id> --inputs 3
+\`\`\`
+
+2. **Build liquidity graph**:
+   - For each pool, get token pair
+   - Build adjacency list of token connections
+
+3. **Search for paths** (1-4 hops):
+   - Use BFS/DFS to find all paths
+   - Consider liquidity thresholds
+   - Calculate output for each path
+
+4. **Select optimal path**:
+   - Compare output amounts
+   - Consider price impact
+   - Factor in gas costs
+
+**Using tx-scripts for efficiency**:
+
+Instead of N+1 RPC calls, use a WASM tx-script:
+
+\`\`\`bash
+# Compile the path optimizer
+cd crates/alkanes-cli-common/src/alkanes/asc/optimize-path
+npm run build
+
+# Run with envelope
+alkanes-cli alkanes simulate 1:0 \\
+  --inputs <factory_block>,<factory_tx>,<from_block>,<from_tx>,<to_block>,<to_tx>,<amount>,<max_hops> \\
+  --envelope build/release.wasm
+\`\`\`
+
+This batches all pool queries and path calculation into a single RPC call.
+
+**Execute the swap**:
+\`\`\`bash
+alkanes-cli alkanes swap \\
+  --path ${fromToken},<intermediate>,...,${toToken} \\
+  --input ${amount} \\
+  --min-output <calculated_min> \\
+  --fee 20000
+\`\`\`
+
+Read the AssemblyScript guide (alkanes://docs/assemblyscript-txscripts) for tx-script development.`,
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Write tx-script prompt
+ */
+function getWriteTxScriptPrompt(operation: string): GetPromptResult {
+  return {
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `Write an AssemblyScript tx-script to: ${operation}
+
+**Tx-Script Architecture**:
+
+Tx-scripts are WASM programs that run in the Alkanes simulation environment to batch multiple operations into a single RPC call.
+
+**Setup**:
+\`\`\`bash
+cd crates/alkanes-cli-common/src/alkanes/asc
+mkdir my-txscript
+cd my-txscript
+npm init -y
+npm install --save-dev assemblyscript
+\`\`\`
+
+**Basic Template**:
+\`\`\`typescript
+import {
+  ExecutionContext,
+  staticcallWithInputs,
+  AlkaneId,
+  ExtendedCallResponse
+} from '../alkanes-asm-common/assembly/index';
+
+export function __execute(): i32 {
+  // 1. Load context and parse inputs
+  const ctx = ExecutionContext.load();
+  const input0 = ctx.getInput(0);
+  const input1 = ctx.getInput(1);
+
+  // 2. Make staticcalls to gather data
+  const target = new AlkaneId(input0, input1);
+  const response1 = staticcallWithInputs(target, [3]); // opcode 3
+
+  // 3. Process response data
+  // ... parse and compute ...
+
+  // 4. Build and return response
+  const response = new ExtendedCallResponse();
+  response.writeU128(result);
+  return response.finalize();
+}
+\`\`\`
+
+**Memory Layout Convention**:
+\`\`\`
+0-1023:       Context
+2048-2095:    Cellpack 1
+3200-3215:    Empty AlkaneTransferParcel
+3300-3303:    Empty StorageMap
+4096-4143:    Cellpack 2
+8192-12287:   Return buffer 1
+12288-16383:  Return buffer 2
+16384+:       Final response
+\`\`\`
+
+**Build & Use**:
+\`\`\`bash
+# Build
+npm run asbuild:release
+
+# Use with CLI
+alkanes-cli alkanes simulate 1:0 \\
+  --inputs <params> \\
+  --envelope build/release.wasm
+\`\`\`
+
+**Performance Tips**:
+1. Minimize allocations - reuse buffers
+2. Use inline functions
+3. Avoid String operations
+4. Pre-calculate sizes
+5. Batch staticcalls
+
+Read the full guide (alkanes://docs/assemblyscript-txscripts) for detailed patterns and examples.`,
+        },
+      },
+    ],
+  };
+}

--- a/alkanes-mcp-server/src/resources.ts
+++ b/alkanes-mcp-server/src/resources.ts
@@ -1,0 +1,790 @@
+/**
+ * Resources API - Exposes Alkanes documentation and guides to AI agents
+ */
+
+import { promises as fs } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = join(__dirname, '..', '..');
+
+export interface Resource {
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: string;
+}
+
+export interface ResourceContent {
+  uri: string;
+  mimeType: string;
+  text: string;
+}
+
+/**
+ * Get list of all available resources
+ */
+export function listResources(): Resource[] {
+  return [
+    // Core documentation
+    {
+      uri: 'alkanes://docs/tech-context',
+      name: 'Alkanes Technical Context',
+      description: 'Core technologies, dependencies, build system, and constraints',
+      mimeType: 'text/markdown',
+    },
+    {
+      uri: 'alkanes://docs/system-patterns',
+      name: 'Alkanes System Patterns & Architecture',
+      description: 'Key design patterns, table relationships, alkane addressing, and gotchas',
+      mimeType: 'text/markdown',
+    },
+    {
+      uri: 'alkanes://docs/product-context',
+      name: 'Alkanes Product Context',
+      description: 'What Alkanes is, key features, and use cases',
+      mimeType: 'text/markdown',
+    },
+
+    // Contract development guides
+    {
+      uri: 'alkanes://docs/contract-development',
+      name: 'Contract Development Guide',
+      description: 'How to build Alkanes contracts with common pitfalls and best practices',
+      mimeType: 'text/markdown',
+    },
+    {
+      uri: 'alkanes://docs/assemblyscript-txscripts',
+      name: 'AssemblyScript Tx-Scripts Guide',
+      description: 'Building efficient batch query scripts with AssemblyScript',
+      mimeType: 'text/markdown',
+    },
+    {
+      uri: 'alkanes://docs/wat-templates',
+      name: 'WebAssembly WAT Templates',
+      description: 'On-chain WASM script development and optimization',
+      mimeType: 'text/markdown',
+    },
+
+    // Common gotchas
+    {
+      uri: 'alkanes://docs/gotchas',
+      name: 'Common Gotchas & Debugging',
+      description: 'Frequent mistakes, debugging tips, and how to avoid them',
+      mimeType: 'text/markdown',
+    },
+
+    // CLI and API references
+    {
+      uri: 'alkanes://docs/cli-overview',
+      name: 'CLI Commands Overview',
+      description: 'Overview of available alkanes-cli commands and usage',
+      mimeType: 'text/markdown',
+    },
+  ];
+}
+
+/**
+ * Read a specific resource by URI
+ */
+export async function readResource(uri: string): Promise<ResourceContent> {
+  switch (uri) {
+    case 'alkanes://docs/tech-context':
+      return {
+        uri,
+        mimeType: 'text/markdown',
+        text: await fs.readFile(join(repoRoot, 'memory-bank/techContext.md'), 'utf-8'),
+      };
+
+    case 'alkanes://docs/system-patterns':
+      return {
+        uri,
+        mimeType: 'text/markdown',
+        text: await fs.readFile(join(repoRoot, 'memory-bank/systemPatterns.md'), 'utf-8'),
+      };
+
+    case 'alkanes://docs/product-context':
+      return {
+        uri,
+        mimeType: 'text/markdown',
+        text: await fs.readFile(join(repoRoot, 'memory-bank/productContext.md'), 'utf-8'),
+      };
+
+    case 'alkanes://docs/contract-development':
+      return {
+        uri,
+        mimeType: 'text/markdown',
+        text: await buildContractDevelopmentGuide(),
+      };
+
+    case 'alkanes://docs/assemblyscript-txscripts':
+      return {
+        uri,
+        mimeType: 'text/markdown',
+        text: await fs.readFile(
+          join(repoRoot, 'crates/alkanes-cli-common/src/alkanes/asc/README.md'),
+          'utf-8'
+        ),
+      };
+
+    case 'alkanes://docs/wat-templates':
+      return {
+        uri,
+        mimeType: 'text/markdown',
+        text: await fs.readFile(
+          join(repoRoot, 'crates/alkanes-cli-common/src/alkanes/wat/README.md'),
+          'utf-8'
+        ),
+      };
+
+    case 'alkanes://docs/gotchas':
+      return {
+        uri,
+        mimeType: 'text/markdown',
+        text: buildGotchasDoc(),
+      };
+
+    case 'alkanes://docs/cli-overview':
+      return {
+        uri,
+        mimeType: 'text/markdown',
+        text: buildCliOverview(),
+      };
+
+    default:
+      throw new Error(`Resource not found: ${uri}`);
+  }
+}
+
+/**
+ * Build contract development guide from various sources
+ */
+async function buildContractDevelopmentGuide(): Promise<string> {
+  return `# Alkanes Contract Development Guide
+
+This guide covers how to build smart contracts for the Alkanes protocol.
+
+## Overview
+
+Alkanes are executable programs in the ALKANES metaprotocol that also function as transferable assets:
+
+- **Dual Nature**: Alkanes are both executable programs and transferable assets
+- **Asset Transfer**: They conform to a standard of behavior for asset transfer consistent with runes
+- **Balance Sheet**: They can hold a balance sheet of alkanes the way that a UTXO can
+- **Storage and Execution**: They have the ability to read/write to storage slots they own and execute against other alkanes
+
+## AlkaneId Structure and Addressing
+
+**CRITICAL**: The \`block\` parameter in AlkaneId is NOT the same as the block height of the chain. It's a sequence number or specific u128 value used for addressing.
+
+### AlkaneId Format
+- Alkanes are addressed by their AlkaneId: \`[block, tx]\` where both are u128 values
+- Their addresses are always \`[2, n]\` or \`[4, n]\`
+- \`[2, 0]\` is the genesis ALKANE with incentives for block optimization
+- The sequence number in \`[2, n]\` increases by 1 for each new alkane instantiated
+- Since \`[2, 0]\` is already taken by the genesis ALKANE, the first available sequence number is 1
+
+### Deployment Headers
+
+When deploying an Alkane, the cellpack header determines the deployment address:
+
+1. **[1, 0] Header**: Deploys the WASM at address \`[2, n]\`, where n is the next available sequence number
+2. **[3, n] Header**: Deploys the alkane to address \`[4, n]\`, if the number is not already occupied
+3. **[5, n] Header**: Clones the WASM stored at \`[2, n]\` and deploys to \`[2, next_sequence_number]\`
+4. **[6, n] Header**: Clones the WASM at \`[4, n]\` and deploys to \`[2, next_sequence_number]\`
+
+## Cellpack Structure
+
+Cellpacks are protomessages that interact with alkanes:
+
+- **Format**: A cellpack is a protomessage whose calldata is an encoded list of leb128 varints
+- **Header**: The first two varints are either the AlkaneId targeted, or a pair with special meanings
+- **Inputs**: The remaining varints after the target are considered inputs to the alkane
+- **Opcodes**: By convention, the first input after the cellpack target is interpreted as an opcode
+- **Initialization**: The 0 opcode following the cellpack target should call initialization logic
+
+Example:
+\`\`\`rust
+let cellpack = Cellpack {
+    target: AlkaneId { block: 1, tx: 0 },
+    inputs: vec![
+        0,    // opcode (initialization)
+        100,  // parameter 1
+        200,  // parameter 2
+    ],
+};
+\`\`\`
+
+## Standard Contract Types
+
+### Auth Token Contract
+Provides authentication and access control:
+- Opcode 0: Initializes with specified amount
+- Opcode 1: Verifies authentication (requires at least 1 unit of auth token)
+- Returns the auth token in the response to maintain ownership
+
+### Owned Token Contract
+Token with ownership verification:
+- **CRITICAL**: Must deploy an auth token during initialization
+- Opcode 0: Initializes token and deploys auth token
+- Opcode 77: Mints new tokens (only callable by owner)
+- Uses \`only_owner()\` method for ownership verification
+
+## Common Gotchas
+
+### 1. Auth Token Initialization
+**CRITICAL**: Owned token contracts MUST be deployed with an auth token. Without a properly initialized auth token, owned token operations will revert.
+
+\`\`\`rust
+// Correct initialization
+let cellpack = Cellpack {
+    target: AlkaneId { block: 1, tx: 0 },
+    inputs: vec![
+        0,    // opcode: initialize
+        100,  // auth_token_units
+        1000, // token_units
+    ],
+};
+\`\`\`
+
+### 2. AlkaneId Block Parameter Confusion
+The \`block\` parameter is NOT block height - it's a sequence number for addressing:
+- \`[2, n]\` - Sequentially assigned alkanes
+- \`[4, n]\` - Custom address alkanes
+- Never use actual blockchain block heights as AlkaneId.block values
+
+### 3. Cellpack Parameter Interpretation
+The first input after the target is ALWAYS the opcode:
+- inputs[0] = opcode
+- inputs[1..] = function parameters
+
+Don't confuse parameter values with their semantic meaning - the contract defines what each parameter means.
+
+### 4. Factory Patterns
+Use factory opcodes for cloning templates:
+\`\`\`rust
+// Deploy template at static address
+let template = Cellpack {
+    target: AlkaneId { block: 3, tx: 0xffddffee },
+    inputs: vec![/* init params */],
+};
+
+// Clone the template
+let instance = Cellpack {
+    target: AlkaneId { block: 6, tx: 0xffddffee },
+    inputs: vec![/* instance params */],
+};
+\`\`\`
+
+## WASM Contract Development
+
+### Using the declare_alkane! Macro
+\`\`\`rust
+use alkanes_support::declare_alkane;
+
+struct MyContract;
+
+impl AlkaneResponder for MyContract {
+    fn execute(&self) -> Result<CallResponse> {
+        let mut inputs = self.context()?.inputs.clone();
+        let opcode = shift_or_err(&mut inputs)?;
+
+        match opcode {
+            0 => self.initialize(&mut inputs),
+            1 => self.do_something(&mut inputs),
+            _ => Err(anyhow!("unrecognized opcode"))
+        }
+    }
+}
+
+declare_alkane!(MyContract);
+\`\`\`
+
+### Memory Layout for WASM Scripts
+\`\`\`
+0-1023:       Context buffer
+1024-2047:    Working buffer for cellpacks
+2048-4095:    Data buffers
+4096+:        Response buffer
+\`\`\`
+
+## Testing Contracts
+
+### CRITICAL: Avoid Double Indexing
+**NEVER** call \`index_block\` multiple times for the same block - it leads to:
+- Additional tokens created with unexpected IDs
+- Balances swapped or duplicated
+- Inconsistent state between tables
+
+\`\`\`rust
+// Correct - index once
+Protorune::index_block::<AlkaneMessageContext>(block.clone(), height)?;
+
+// Wrong - never do this
+Protorune::index_block::<AlkaneMessageContext>(block.clone(), height)?;
+Protorune::index_block::<AlkaneMessageContext>(block.clone(), height)?; // BAD!
+\`\`\`
+
+## CLI Usage for Contract Development
+
+\`\`\`bash
+# Deploy a contract
+alkanes-cli alkanes execute \\
+  --target 1:0 \\
+  --inputs 0,100,1000 \\
+  --fee 10000
+
+# Simulate before deploying
+alkanes-cli alkanes simulate 1:0 \\
+  --inputs 0,100,1000
+
+# Call a deployed contract
+alkanes-cli alkanes execute \\
+  --target 2:1 \\
+  --inputs 1,500 \\
+  --fee 10000
+\`\`\`
+
+## Further Reading
+
+For more details, see:
+- System Patterns documentation (alkanes://docs/system-patterns)
+- Technical Context (alkanes://docs/tech-context)
+- AssemblyScript Tx-Scripts Guide (alkanes://docs/assemblyscript-txscripts)
+- WAT Templates Guide (alkanes://docs/wat-templates)
+`;
+}
+
+/**
+ * Build comprehensive gotchas documentation
+ */
+function buildGotchasDoc(): string {
+  return `# Common Gotchas & Debugging Guide
+
+This document covers the most common mistakes when working with Alkanes and how to avoid them.
+
+## Critical Gotchas
+
+### 1. Double Indexing - NEVER DO THIS
+**Severity**: Critical - Causes inconsistent state
+
+**Problem**: Calling \`index_block\` or \`Protorune::index_block\` multiple times for the same block leads to:
+- Additional tokens created with unexpected IDs
+- Balances swapped or duplicated
+- Inconsistent state between different tables
+- Confusing test results
+
+**Solution**: Only call \`index_block\` once per block in tests
+\`\`\`rust
+// Correct
+Protorune::index_block::<AlkaneMessageContext>(block.clone(), height)?;
+
+// Wrong - NEVER do this
+Protorune::index_block::<AlkaneMessageContext>(block.clone(), height)?;
+Protorune::index_block::<AlkaneMessageContext>(block.clone(), height)?; // BAD!
+\`\`\`
+
+### 2. Auth Token Initialization Required
+**Severity**: Critical - Causes contract execution to fail
+
+**Problem**: Owned token contracts must be deployed with an auth token. Without proper initialization, \`only_owner()\` calls will revert.
+
+**Solution**: Always initialize owned tokens with auth token units:
+\`\`\`rust
+// Correct - opcode 0 with auth_token_units and token_units
+let cellpack = Cellpack {
+    target: AlkaneId { block: 1, tx: 0 },
+    inputs: vec![
+        0,    // opcode: initialize
+        100,  // auth_token_units (REQUIRED)
+        1000, // token_units
+    ],
+};
+\`\`\`
+
+### 3. AlkaneId Block Parameter Confusion
+**Severity**: High - Causes addressing errors
+
+**Problem**: The \`block\` parameter in AlkaneId is NOT the blockchain block height - it's a sequence number or custom address selector.
+
+**AlkaneId Addressing Rules**:
+- \`[1, 0]\` → Deploys to \`[2, next_sequence]\`
+- \`[2, n]\` → Sequentially assigned alkanes (n = 0, 1, 2, ...)
+- \`[3, n]\` → Deploys to \`[4, n]\` (custom address)
+- \`[4, n]\` → Custom address alkanes
+- \`[5, n]\` → Clone from \`[2, n]\` → deploy to \`[2, next_sequence]\`
+- \`[6, n]\` → Clone from \`[4, n]\` → deploy to \`[2, next_sequence]\`
+
+**Example**:
+\`\`\`rust
+// Wrong - using block height
+AlkaneId { block: 850000, tx: 0 } // This is not how it works!
+
+// Correct - using sequence number
+AlkaneId { block: 2, tx: 1 } // Second sequentially deployed alkane
+
+// Correct - using custom address
+AlkaneId { block: 4, tx: 0xffddffee } // Custom address alkane
+\`\`\`
+
+### 4. Cellpack Parameter Interpretation
+**Severity**: High - Causes incorrect function calls
+
+**Problem**: Misunderstanding what cellpack inputs represent:
+- The first input is ALWAYS the opcode
+- Remaining inputs are parameters for that opcode
+- Parameter values are just numbers - their meaning is defined by the contract
+
+**Example**:
+\`\`\`rust
+// Cellpack structure
+let cellpack = Cellpack {
+    target: AlkaneId { block: 2, tx: 1 },
+    inputs: vec![
+        77,    // [0] = opcode (mint function)
+        1000,  // [1] = first parameter (amount to mint)
+        5,     // [2] = second parameter (some other config)
+    ],
+};
+
+// Common mistake: thinking inputs[1] means "1000 of something"
+// Reality: The contract defines what 1000 means in the context of opcode 77
+\`\`\`
+
+### 5. Table Population Dependencies
+**Severity**: Medium - Causes empty query results
+
+**Problem**: Different tables are populated through different code paths:
+
+**Table Population Paths**:
+- \`OUTPOINTS_FOR_ADDRESS\` - Populated for ALL transactions with valid addresses
+- \`OUTPOINT_SPENDABLE_BY\` - Populated during normal transaction indexing
+- \`RUNE_ID_TO_OUTPOINTS\` - Only populated for runestone transactions
+- \`OUTPOINT_TO_RUNES\` - Populated during runestone processing
+
+**Solution**: Ensure proper indexing flow:
+\`\`\`rust
+// This populates OUTPOINTS_FOR_ADDRESS
+index_spendables(&tx, height)?;
+
+// This populates RUNE_ID_TO_OUTPOINTS (only for runestones)
+if is_runestone {
+    add_rune_outpoint(&rune_id, &outpoint)?;
+}
+\`\`\`
+
+### 6. Protobuf Message Encoding
+**Severity**: Medium - Causes RPC call failures
+
+**Problem**: Incorrect encoding of nested types like \`Uint128\` in protobuf messages.
+
+**Solution**: Encode \`Uint128\` as length-delimited fields:
+\`\`\`rust
+// Correct - encode as nested message
+let mut protocol_tag = Uint128::new();
+protocol_tag.set_value(1);
+request.set_protocol_tag(protocol_tag);
+
+// Wrong - trying to use as varint
+request.set_protocol_tag(1); // Doesn't work!
+\`\`\`
+
+### 7. Context Inputs in WASM
+**Severity**: Medium - Causes incorrect parameter reads
+
+**Problem**: Context inputs are located at specific memory offsets in WASM scripts.
+
+**Memory Layout**:
+\`\`\`
+Offset 0-99:   Context header
+Offset 100+:   Context inputs (each input is 16 bytes / u128)
+\`\`\`
+
+**Solution**: Read inputs at correct offsets:
+\`\`\`wat
+;; Read first input (offset 100)
+(i32.const 100)
+(i64.load)
+
+;; Read second input (offset 116 = 100 + 16)
+(i32.const 116)
+(i64.load)
+\`\`\`
+
+### 8. Fuel Metering
+**Severity**: Low - Causes execution failures
+
+**Problem**: Complex operations may run out of fuel.
+
+**Solution**: Provide adequate fuel for staticcalls:
+\`\`\`rust
+// Low fuel - might fail for complex operations
+staticcall(target, opcode, 1000)?;
+
+// High fuel - safe for most operations
+staticcall(target, opcode, 0xFFFFFFFFFFFFFFFF)?;
+\`\`\`
+
+## Debugging Tips
+
+### 1. Enable Debug Logging
+\`\`\`bash
+# Set log level
+export RUST_LOG=debug
+alkanes-cli alkanes simulate ...
+\`\`\`
+
+### 2. Use Simulation Before Execution
+Always simulate before broadcasting:
+\`\`\`bash
+# Simulate first
+alkanes-cli alkanes simulate 1:0 --inputs 0,100,1000
+
+# If successful, then execute
+alkanes-cli alkanes execute 1:0 --inputs 0,100,1000 --fee 10000
+\`\`\`
+
+### 3. Check Storage State
+Use the inspector to examine contract storage:
+\`\`\`bash
+alkanes-cli alkanes inspect 2:1 --storage /auth
+\`\`\`
+
+### 4. Trace Execution
+Use trace functionality to see execution flow:
+\`\`\`bash
+alkanes-cli alkanes simulate 2:1 --inputs 1,500 --trace
+\`\`\`
+
+### 5. Verify AlkaneId Resolution
+Double-check that your AlkaneIds resolve to the expected contracts:
+\`\`\`bash
+# List all deployed alkanes
+alkanes-cli alkanes list
+
+# Get details for specific alkane
+alkanes-cli alkanes details 2:1
+\`\`\`
+
+## Error Messages and Solutions
+
+### "did not authenticate with only the authentication token"
+- **Cause**: Sending wrong alkane or multiple alkanes to \`only_owner()\`
+- **Solution**: Send exactly 1 unit of the correct auth token
+
+### "supplied alkane is not authentication token"
+- **Cause**: Sending wrong AlkaneId to \`only_owner()\`
+- **Solution**: Verify auth token AlkaneId stored at \`/auth\`
+
+### "less than 1 unit of authentication token supplied"
+- **Cause**: Sending 0 or fractional units of auth token
+- **Solution**: Send at least 1 unit
+
+### "unrecognized opcode"
+- **Cause**: Invalid opcode for the contract
+- **Solution**: Check contract ABI for supported opcodes
+
+### Empty query results
+- **Cause**: Tables not populated or using wrong token IDs
+- **Solution**: Verify indexing ran correctly and check token ID mapping
+
+## Testing Best Practices
+
+1. **Use \`clear()\` between tests** - Ensure clean state
+2. **Never double-index** - Only call \`index_block\` once per block
+3. **Verify table population** - Check that expected tables are populated
+4. **Test with simulation first** - Don't go straight to execution
+5. **Use realistic fuel amounts** - Don't under-fuel your operations
+
+## When to Read Documentation
+
+If you encounter issues with:
+- **Contract development** → Read "Contract Development Guide"
+- **AlkaneId addressing** → Read "System Patterns" section on AlkaneId
+- **Table relationships** → Read "System Patterns" section on Table Relationships
+- **WASM scripts** → Read "AssemblyScript Tx-Scripts Guide" or "WAT Templates"
+- **Build system** → Read "Technical Context"
+
+## Getting Help
+
+If you're still stuck:
+1. Check the error message against this guide
+2. Review the System Patterns documentation
+3. Look at example contracts in \`crates/alkanes-std-*\`
+4. Simulate with \`--trace\` to see execution flow
+5. Check the memory-bank/ documentation files
+`;
+}
+
+/**
+ * Build CLI overview documentation
+ */
+function buildCliOverview(): string {
+  return `# Alkanes CLI Commands Overview
+
+This document provides an overview of available alkanes-cli commands and their usage.
+
+## Core Commands
+
+### Alkanes (Smart Contracts)
+
+#### \`alkanes execute\`
+Execute an alkanes smart contract operation (broadcasts transaction).
+
+\`\`\`bash
+alkanes-cli alkanes execute \\
+  --target 2:1 \\
+  --inputs 1,500,1000 \\
+  --fee 10000
+\`\`\`
+
+#### \`alkanes simulate\`
+Simulate alkanes execution without broadcasting (dry run).
+
+\`\`\`bash
+alkanes-cli alkanes simulate 2:1 \\
+  --inputs 1,500 \\
+  --trace
+\`\`\`
+
+#### \`alkanes swap\`
+Swap tokens using AMM pools.
+
+\`\`\`bash
+alkanes-cli alkanes swap \\
+  --path 2:0,2:1,2:2 \\
+  --input 1000000 \\
+  --min-output 950000
+\`\`\`
+
+### Wallet Operations
+
+#### \`wallet balance\`
+Check wallet balances for alkanes and runes.
+
+\`\`\`bash
+alkanes-cli wallet balance
+\`\`\`
+
+#### \`wallet send\`
+Send alkanes or runes to another address.
+
+\`\`\`bash
+alkanes-cli wallet send \\
+  --to <address> \\
+  --alkane 2:1 \\
+  --amount 1000
+\`\`\`
+
+### Bitcoin Operations
+
+#### \`bitcoind getblockcount\`
+Get current block height.
+
+\`\`\`bash
+alkanes-cli bitcoind getblockcount
+\`\`\`
+
+#### \`bitcoind getblock\`
+Get block data by height or hash.
+
+\`\`\`bash
+alkanes-cli bitcoind getblock 850000
+\`\`\`
+
+### Data API
+
+#### \`dataapi query\`
+Query the alkanes data API.
+
+\`\`\`bash
+alkanes-cli dataapi query /alkanes/2:1
+\`\`\`
+
+### Registry
+
+#### \`registry lookup\`
+Look up alkanes in the registry.
+
+\`\`\`bash
+alkanes-cli registry lookup 2:1
+\`\`\`
+
+## MCP Integration
+
+#### \`mcp install\`
+Install and build the MCP server.
+
+\`\`\`bash
+alkanes-cli mcp install
+\`\`\`
+
+#### \`mcp configure\`
+Generate MCP configuration from CLI settings.
+
+\`\`\`bash
+alkanes-cli mcp configure --editor cursor
+\`\`\`
+
+#### \`mcp status\`
+Check MCP server status and configuration.
+
+\`\`\`bash
+alkanes-cli mcp status
+\`\`\`
+
+#### \`mcp setup\`
+Complete automated setup (install + configure + verify).
+
+\`\`\`bash
+alkanes-cli mcp setup --editor cursor
+\`\`\`
+
+## Common Patterns
+
+### Deploy a new contract
+\`\`\`bash
+# 1. Simulate first
+alkanes-cli alkanes simulate 1:0 \\
+  --inputs 0,100,1000 \\
+  --envelope my_contract.wasm
+
+# 2. If successful, deploy
+alkanes-cli alkanes execute 1:0 \\
+  --inputs 0,100,1000 \\
+  --envelope my_contract.wasm \\
+  --fee 50000
+\`\`\`
+
+### Call a deployed contract
+\`\`\`bash
+# Opcode 1, with parameter 500
+alkanes-cli alkanes execute 2:1 \\
+  --inputs 1,500 \\
+  --fee 10000
+\`\`\`
+
+### Batch operations with tx-scripts
+\`\`\`bash
+# Use WASM script to batch multiple calls
+alkanes-cli alkanes simulate 1:0 \\
+  --inputs 0,10 \\
+  --envelope batch_query.wasm
+\`\`\`
+
+## Tips
+
+- Always simulate before executing
+- Use \`--trace\` flag to debug execution
+- Check \`--help\` on any command for full options
+- Set appropriate fees based on network conditions
+- Use MCP integration for AI-assisted development
+
+For detailed information on specific commands, run:
+\`\`\`bash
+alkanes-cli <command> --help
+\`\`\`
+`;
+}

--- a/alkanes-mcp-server/src/response.ts
+++ b/alkanes-mcp-server/src/response.ts
@@ -1,0 +1,82 @@
+/**
+ * Response formatting for MCP tools
+ */
+
+import type { ExecutionResult } from './executor.js';
+import { parseJsonResponse } from './executor.js';
+
+export interface FormattedResponse {
+  content: Array<{
+    type: 'text' | 'image' | 'resource';
+    text?: string;
+    data?: string;
+    mimeType?: string;
+  }>;
+  isError?: boolean;
+}
+
+/**
+ * Format CLI response for MCP tool response
+ */
+export function formatResponse(
+  result: ExecutionResult,
+  parseJson = true
+): FormattedResponse {
+  if (!result.success) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Command failed with exit code ${result.exitCode}\n\nSTDOUT:\n${result.stdout}\n\nSTDERR:\n${result.stderr}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  // Try to parse as JSON if requested
+  if (parseJson) {
+    try {
+      const json = parseJsonResponse(result.stdout);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(json, null, 2),
+          },
+        ],
+        isError: false,
+      };
+    } catch {
+      // Not JSON, return as text
+    }
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: result.stdout || result.stderr || 'Command executed successfully',
+      },
+    ],
+    isError: false,
+  };
+}
+
+/**
+ * Format error response
+ */
+export function formatErrorResponse(error: unknown): FormattedResponse {
+  const message = error instanceof Error ? error.message : String(error);
+  const stack = error instanceof Error ? error.stack : undefined;
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: stack ? `${message}\n\n${stack}` : message,
+      },
+    ],
+    isError: true,
+  };
+}

--- a/alkanes-mcp-server/src/tools/alkanes.ts
+++ b/alkanes-mcp-server/src/tools/alkanes.ts
@@ -1,0 +1,396 @@
+/**
+ * Alkanes tools
+ */
+
+import { createSimpleTool, createPositionalTool } from './helpers.js';
+
+export function registerAlkanesTools(): void {
+  // Alkanes execute
+  createSimpleTool(
+    'alkanes_execute',
+    'Execute an alkanes transaction',
+    ['alkanes', 'execute'],
+    {
+      type: 'object',
+      properties: {
+        inputs: { type: 'string', description: 'Input requirements (format: "B:amount", "B:amount:vN", "block:tx:amount")' },
+        to: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Recipient addresses',
+        },
+        from: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Addresses to source UTXOs from',
+        },
+        change: { type: 'string', description: 'Change address for BTC' },
+        alkanes_change: { type: 'string', description: 'Change address for unwanted alkanes' },
+        fee_rate: { type: 'number', description: 'Fee rate in sat/vB' },
+        envelope: { type: 'string', description: 'Path to the envelope file (for contract deployment)' },
+        protostones: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Protostone specifications',
+        },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        trace: { type: 'boolean', description: 'Enable transaction tracing' },
+        mine: { type: 'boolean', description: 'Mine a block after broadcasting (regtest only)' },
+        auto_confirm: { type: 'boolean', description: 'Automatically confirm the transaction preview' },
+      },
+      required: ['to'],
+    }
+  );
+
+  // Alkanes inspect
+  createPositionalTool(
+    'alkanes_inspect',
+    'Inspect an alkanes contract',
+    ['alkanes', 'inspect'],
+    ['outpoint'],
+    {
+      type: 'object',
+      properties: {
+        outpoint: { type: 'string', description: 'The outpoint of the contract' },
+        disasm: { type: 'boolean', description: 'Disassemble the contract bytecode' },
+        fuzz: { type: 'boolean', description: 'Fuzz the contract with a range of opcodes' },
+        fuzz_ranges: { type: 'string', description: 'The range of opcodes to fuzz' },
+        meta: { type: 'boolean', description: 'Show contract metadata' },
+        codehash: { type: 'boolean', description: 'Show the contract code hash' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['outpoint'],
+    }
+  );
+
+  // Alkanes trace
+  createPositionalTool(
+    'alkanes_trace',
+    'Trace an alkanes transaction',
+    ['alkanes', 'trace'],
+    ['outpoint'],
+    {
+      type: 'object',
+      properties: {
+        outpoint: { type: 'string', description: 'The outpoint of the transaction to trace' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['outpoint'],
+    }
+  );
+
+  // Alkanes simulate
+  createPositionalTool(
+    'alkanes_simulate',
+    'Simulate an alkanes transaction',
+    ['alkanes', 'simulate'],
+    ['alkane_id'],
+    {
+      type: 'object',
+      properties: {
+        alkane_id: { type: 'string', description: 'The alkane ID to simulate (format: block:tx:arg1:arg2:...)' },
+        inputs: { type: 'string', description: 'Input alkanes as comma-separated triplets' },
+        height: { type: 'number', description: 'Block height for simulation' },
+        block: { type: 'string', description: 'Block hex data (0x prefixed)' },
+        transaction: { type: 'string', description: 'Transaction hex data (0x prefixed)' },
+        envelope: { type: 'string', description: 'Path to binary file (e.g., WASM) to pack into transaction witness' },
+        pointer: { type: 'number', description: 'Pointer value', default: 0 },
+        txindex: { type: 'number', description: 'Transaction index', default: 1 },
+        refund: { type: 'number', description: 'Refund pointer', default: 0 },
+        block_tag: { type: 'string', description: 'Block tag to query (e.g., "latest" or a block height)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['alkane_id'],
+    }
+  );
+
+  // Alkanes tx-script
+  createSimpleTool(
+    'alkanes_tx_script',
+    'Execute a tx-script with WASM bytecode',
+    ['alkanes', 'tx-script'],
+    {
+      type: 'object',
+      properties: {
+        envelope: { type: 'string', description: 'Path to WASM file' },
+        inputs: { type: 'string', description: 'Cellpack inputs as comma-separated u128 values' },
+        block_tag: { type: 'string', description: 'Block tag to query' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['envelope'],
+    }
+  );
+
+  // Alkanes sequence
+  createSimpleTool(
+    'alkanes_sequence',
+    'Get the sequence for an outpoint',
+    ['alkanes', 'sequence'],
+    {
+      type: 'object',
+      properties: {
+        block_tag: { type: 'string', description: 'Block tag to query' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  // Alkanes spendables
+  createPositionalTool(
+    'alkanes_spendables',
+    'Get spendable outpoints for an address',
+    ['alkanes', 'spendables'],
+    ['address'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'The address to get spendables for' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['address'],
+    }
+  );
+
+  // Alkanes traceblock
+  createPositionalTool(
+    'alkanes_traceblock',
+    'Trace a block',
+    ['alkanes', 'traceblock'],
+    ['height'],
+    {
+      type: 'object',
+      properties: {
+        height: { type: 'number', description: 'The height of the block to trace' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['height'],
+    }
+  );
+
+  // Alkanes getbytecode
+  createPositionalTool(
+    'alkanes_getbytecode',
+    'Get the bytecode for an alkane',
+    ['alkanes', 'getbytecode'],
+    ['alkane_id'],
+    {
+      type: 'object',
+      properties: {
+        alkane_id: { type: 'string', description: 'The alkane ID to get the bytecode for' },
+        block_tag: { type: 'string', description: 'Block tag to query' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['alkane_id'],
+    }
+  );
+
+  // Alkanes getbalance
+  createSimpleTool(
+    'alkanes_getbalance',
+    'Get the balance of an address',
+    ['alkanes', 'getbalance'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'The address to get the balance for' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  // Alkanes wrap-btc
+  createPositionalTool(
+    'alkanes_wrap_btc',
+    'Wrap BTC to frBTC and lock in vault',
+    ['alkanes', 'wrap-btc'],
+    ['amount'],
+    {
+      type: 'object',
+      properties: {
+        amount: { type: 'number', description: 'Amount of BTC to wrap (in satoshis)' },
+        to: { type: 'string', description: 'Address to receive the frBTC tokens' },
+        from: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Addresses to source UTXOs from',
+        },
+        change: { type: 'string', description: 'Change address' },
+        fee_rate: { type: 'number', description: 'Fee rate in sat/vB' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        trace: { type: 'boolean', description: 'Enable transaction tracing' },
+        mine: { type: 'boolean', description: 'Mine a block after broadcasting (regtest only)' },
+        auto_confirm: { type: 'boolean', description: 'Automatically confirm the transaction preview' },
+      },
+      required: ['amount', 'to'],
+    }
+  );
+
+  // Alkanes unwrap
+  createSimpleTool(
+    'alkanes_unwrap',
+    'Get pending unwraps',
+    ['alkanes', 'unwrap'],
+    {
+      type: 'object',
+      properties: {
+        block_tag: { type: 'string', description: 'Block tag to query' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  // Alkanes backtest
+  createPositionalTool(
+    'alkanes_backtest',
+    'Backtest a transaction by simulating it in a block',
+    ['alkanes', 'backtest'],
+    ['txid'],
+    {
+      type: 'object',
+      properties: {
+        txid: { type: 'string', description: 'Transaction ID to backtest' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['txid'],
+    }
+  );
+
+  // Alkanes get-all-pools
+  createSimpleTool(
+    'alkanes_get_all_pools',
+    'Get all pools from an AMM factory contract (defaults to 4:65522)',
+    ['alkanes', 'get-all-pools'],
+    {
+      type: 'object',
+      properties: {
+        factory: { type: 'string', description: 'Factory alkane ID (format: block:tx)', default: '4:65522' },
+        pool_details: { type: 'boolean', description: 'Also fetch detailed information for each pool' },
+        experimental_asm: { type: 'boolean', description: 'Use experimental AssemblyScript WASM' },
+        experimental_batch_asm: { type: 'boolean', description: 'Use experimental WASM-based batch optimization' },
+        experimental_asm_parallel: { type: 'boolean', description: 'Use experimental parallel WASM fetching' },
+        chunk_size: { type: 'number', description: 'Chunk size for batch fetching', default: 30 },
+        max_concurrent: { type: 'number', description: 'Maximum concurrent requests', default: 10 },
+        range: { type: 'string', description: 'Specific range to fetch (format: "0-50")' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  // Alkanes all-pools-details
+  createPositionalTool(
+    'alkanes_all_pools_details',
+    'Get all pools with detailed information from an AMM factory contract',
+    ['alkanes', 'all-pools-details'],
+    ['factory_id'],
+    {
+      type: 'object',
+      properties: {
+        factory_id: { type: 'string', description: 'Factory alkane ID (format: block:tx)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['factory_id'],
+    }
+  );
+
+  // Alkanes pool-details
+  createPositionalTool(
+    'alkanes_pool_details',
+    'Get details for a specific pool',
+    ['alkanes', 'pool-details'],
+    ['pool_id'],
+    {
+      type: 'object',
+      properties: {
+        pool_id: { type: 'string', description: 'Pool alkane ID (format: block:tx)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['pool_id'],
+    }
+  );
+
+  // Alkanes reflect-alkane
+  createPositionalTool(
+    'alkanes_reflect_alkane',
+    'Reflect metadata for an alkane by calling standard view opcodes',
+    ['alkanes', 'reflect-alkane'],
+    ['alkane_id'],
+    {
+      type: 'object',
+      properties: {
+        alkane_id: { type: 'string', description: 'Alkane ID to reflect (format: block:tx)' },
+        concurrency: { type: 'number', description: 'Maximum concurrent RPC calls', default: 30 },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['alkane_id'],
+    }
+  );
+
+  // Alkanes reflect-alkane-range
+  createPositionalTool(
+    'alkanes_reflect_alkane_range',
+    'Reflect metadata for a range of alkanes',
+    ['alkanes', 'reflect-alkane-range'],
+    ['block', 'start_tx', 'end_tx'],
+    {
+      type: 'object',
+      properties: {
+        block: { type: 'number', description: 'Starting block number' },
+        start_tx: { type: 'number', description: 'Starting transaction index' },
+        end_tx: { type: 'number', description: 'Ending transaction index' },
+        concurrency: { type: 'number', description: 'Maximum concurrent RPC calls', default: 30 },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['block', 'start_tx', 'end_tx'],
+    }
+  );
+
+  // Alkanes init-pool
+  createSimpleTool(
+    'alkanes_init_pool',
+    'Initialize a new liquidity pool',
+    ['alkanes', 'init-pool'],
+    {
+      type: 'object',
+      properties: {
+        pair: { type: 'string', description: 'Token pair in format: BLOCK:TX,BLOCK:TX' },
+        liquidity: { type: 'string', description: 'Initial liquidity amounts in format: AMOUNT0:AMOUNT1' },
+        to: { type: 'string', description: 'Recipient address identifier (e.g., p2tr:0)' },
+        from: { type: 'string', description: 'Sender address identifier (e.g., p2tr:0)' },
+        change: { type: 'string', description: 'Change address identifier' },
+        minimum: { type: 'number', description: 'Minimum LP tokens to receive' },
+        fee_rate: { type: 'number', description: 'Fee rate in sat/vB' },
+        trace: { type: 'boolean', description: 'Show trace after transaction confirms' },
+        factory: { type: 'string', description: 'Factory ID', default: '4:1' },
+        auto_confirm: { type: 'boolean', description: 'Auto-confirm transaction without prompting' },
+      },
+      required: ['pair', 'liquidity', 'to', 'from'],
+    }
+  );
+
+  // Alkanes swap
+  createSimpleTool(
+    'alkanes_swap',
+    'Execute a swap on the AMM',
+    ['alkanes', 'swap'],
+    {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'Swap path as comma-separated alkane IDs' },
+        input: { type: 'number', description: 'Input token amount' },
+        minimum_output: { type: 'number', description: 'Minimum output amount' },
+        slippage: { type: 'number', description: 'Slippage percentage', default: 5.0 },
+        expires: { type: 'number', description: 'Expiry block height' },
+        to: { type: 'string', description: 'Recipient address identifier', default: 'p2tr:0' },
+        from: { type: 'string', description: 'Sender address identifier', default: 'p2tr:0' },
+        change: { type: 'string', description: 'Change address identifier' },
+        fee_rate: { type: 'number', description: 'Fee rate in sat/vB' },
+        trace: { type: 'boolean', description: 'Show trace after transaction confirms' },
+        mine: { type: 'boolean', description: 'Mine a block after broadcasting (regtest only)' },
+        factory: { type: 'string', description: 'Factory ID for path optimization', default: '4:65522' },
+        no_optimize: { type: 'boolean', description: 'Skip path optimization' },
+        auto_confirm: { type: 'boolean', description: 'Auto-confirm transaction without prompting' },
+      },
+      required: ['path', 'input'],
+    }
+  );
+}

--- a/alkanes-mcp-server/src/tools/bitcoind.ts
+++ b/alkanes-mcp-server/src/tools/bitcoind.ts
@@ -1,0 +1,263 @@
+/**
+ * Bitcoind tools - Bitcoin Core RPC commands
+ */
+
+import { createSimpleTool, createPositionalTool } from './helpers.js';
+
+export function registerBitcoindTools(): void {
+  // Simple tools with no arguments
+  createSimpleTool(
+    'bitcoind_getblockcount',
+    'Get current block count',
+    ['bitcoind', 'getblockcount'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'bitcoind_getblockchaininfo',
+    'Get blockchain information',
+    ['bitcoind', 'getblockchaininfo'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'bitcoind_getnetworkinfo',
+    'Get network information',
+    ['bitcoind', 'getnetworkinfo'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'bitcoind_generatefuture',
+    'Generate a single block with a future-claiming protostone in the coinbase (regtest only)',
+    ['bitcoind', 'generatefuture'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createSimpleTool(
+    'bitcoind_getchaintips',
+    'Get chain tips',
+    ['bitcoind', 'getchaintips'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'bitcoind_getmempoolinfo',
+    'Get mempool information',
+    ['bitcoind', 'getmempoolinfo'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'bitcoind_getrawmempool',
+    'Get raw mempool',
+    ['bitcoind', 'getrawmempool'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  // Tools with positional arguments
+  createPositionalTool(
+    'bitcoind_generatetoaddress',
+    'Generate blocks to an address (regtest only)',
+    ['bitcoind', 'generatetoaddress'],
+    ['nblocks', 'address'],
+    {
+      type: 'object',
+      properties: {
+        nblocks: { type: 'number', description: 'Number of blocks to generate' },
+        address: { type: 'string', description: 'Address to generate to' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['nblocks', 'address'],
+    }
+  );
+
+  createPositionalTool(
+    'bitcoind_getrawtransaction',
+    'Get raw transaction',
+    ['bitcoind', 'getrawtransaction'],
+    ['txid'],
+    {
+      type: 'object',
+      properties: {
+        txid: { type: 'string', description: 'Transaction ID' },
+        block_hash: { type: 'string', description: 'Block hash (optional)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['txid'],
+    }
+  );
+
+  createPositionalTool(
+    'bitcoind_getblock',
+    'Get block',
+    ['bitcoind', 'getblock'],
+    ['hash'],
+    {
+      type: 'object',
+      properties: {
+        hash: { type: 'string', description: 'Block hash' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hash'],
+    }
+  );
+
+  createPositionalTool(
+    'bitcoind_getblockhash',
+    'Get block hash for a given height',
+    ['bitcoind', 'getblockhash'],
+    ['height'],
+    {
+      type: 'object',
+      properties: {
+        height: { type: 'number', description: 'Block height' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['height'],
+    },
+    (args) => {
+      const flags: string[] = [];
+      if (args.raw) flags.push('--raw');
+      return flags;
+    }
+  );
+
+  createPositionalTool(
+    'bitcoind_getblockheader',
+    'Get block header',
+    ['bitcoind', 'getblockheader'],
+    ['hash'],
+    {
+      type: 'object',
+      properties: {
+        hash: { type: 'string', description: 'Block hash' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hash'],
+    }
+  );
+
+  createPositionalTool(
+    'bitcoind_getblockstats',
+    'Get block statistics',
+    ['bitcoind', 'getblockstats'],
+    ['hash'],
+    {
+      type: 'object',
+      properties: {
+        hash: { type: 'string', description: 'Block hash' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hash'],
+    }
+  );
+
+  createPositionalTool(
+    'bitcoind_decoderawtransaction',
+    'Decode a raw transaction',
+    ['bitcoind', 'decoderawtransaction'],
+    ['hex'],
+    {
+      type: 'object',
+      properties: {
+        hex: { type: 'string', description: 'Raw transaction hex' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hex'],
+    }
+  );
+
+  createPositionalTool(
+    'bitcoind_decodepsbt',
+    'Decode a PSBT',
+    ['bitcoind', 'decodepsbt'],
+    ['psbt'],
+    {
+      type: 'object',
+      properties: {
+        psbt: { type: 'string', description: 'PSBT as base64 string' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['psbt'],
+    }
+  );
+
+  createPositionalTool(
+    'bitcoind_gettxout',
+    'Get transaction output',
+    ['bitcoind', 'gettxout'],
+    ['txid', 'vout'],
+    {
+      type: 'object',
+      properties: {
+        txid: { type: 'string', description: 'Transaction ID' },
+        vout: { type: 'number', description: 'Output index' },
+        include_mempool: { type: 'boolean', description: 'Include mempool' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['txid', 'vout'],
+    }
+  );
+
+  // Special case for sendrawtransaction
+  createSimpleTool(
+    'bitcoind_sendrawtransaction',
+    'Send a raw transaction',
+    ['bitcoind', 'sendrawtransaction'],
+    {
+      type: 'object',
+      properties: {
+        tx_hex: { type: 'string', description: 'Transaction hex' },
+        from_file: { type: 'string', description: 'Read transaction hex from file' },
+        use_slipstream: { type: 'boolean', description: 'Use MARA Slipstream service' },
+        use_rebar: { type: 'boolean', description: 'Use Rebar Shield' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    },
+    (args) => {
+      const flags: string[] = [];
+      if (args.from_file) {
+        flags.push('--from-file', String(args.from_file));
+      } else if (args.tx_hex) {
+        flags.push(String(args.tx_hex));
+      }
+      if (args.use_slipstream) flags.push('--use-slipstream');
+      if (args.use_rebar) flags.push('--use-rebar');
+      return flags;
+    }
+  );
+}

--- a/alkanes-mcp-server/src/tools/brc20_prog.ts
+++ b/alkanes-mcp-server/src/tools/brc20_prog.ts
@@ -1,0 +1,563 @@
+/**
+ * BRC20-Prog tools
+ */
+
+import { createSimpleTool, createPositionalTool } from './helpers.js';
+
+export function registerBrc20ProgTools(): void {
+  // Deploy contract
+  createPositionalTool(
+    'brc20_prog_deploy_contract',
+    'Deploy a BRC20-prog contract from Foundry build JSON',
+    ['brc20-prog', 'deploy-contract'],
+    ['foundry_json_path'],
+    {
+      type: 'object',
+      properties: {
+        foundry_json_path: { type: 'string', description: 'Path to Foundry build JSON file' },
+        from: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Addresses to source UTXOs from',
+        },
+        change: { type: 'string', description: 'Change address' },
+        fee_rate: { type: 'number', description: 'Fee rate in sat/vB' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        trace: { type: 'boolean', description: 'Enable transaction tracing' },
+        mine: { type: 'boolean', description: 'Mine a block after broadcasting (regtest only)' },
+        auto_confirm: { type: 'boolean', description: 'Automatically confirm the transaction preview' },
+        no_activation: { type: 'boolean', description: 'Skip activation transaction' },
+        use_slipstream: { type: 'boolean', description: 'Use MARA Slipstream service' },
+        use_rebar: { type: 'boolean', description: 'Use Rebar Shield' },
+        rebar_tier: { type: 'number', description: 'Rebar fee tier (1 or 2)' },
+        strategy: { type: 'string', description: 'Anti-frontrunning strategy' },
+        resume: { type: 'string', description: 'Resume from existing commit transaction' },
+      },
+      required: ['foundry_json_path'],
+    }
+  );
+
+  // Transact
+  createSimpleTool(
+    'brc20_prog_transact',
+    'Call a BRC20-prog contract function',
+    ['brc20-prog', 'transact'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Contract address (0x prefixed hex)' },
+        signature: { type: 'string', description: 'Function signature (e.g., "transfer(address,uint256)")' },
+        calldata: { type: 'string', description: 'Calldata arguments as comma-separated values' },
+        from: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Addresses to source UTXOs from',
+        },
+        change: { type: 'string', description: 'Change address' },
+        fee_rate: { type: 'number', description: 'Fee rate in sat/vB' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        trace: { type: 'boolean', description: 'Enable transaction tracing' },
+        mine: { type: 'boolean', description: 'Mine a block after broadcasting (regtest only)' },
+        auto_confirm: { type: 'boolean', description: 'Automatically confirm the transaction preview' },
+        use_slipstream: { type: 'boolean', description: 'Use MARA Slipstream service' },
+        use_rebar: { type: 'boolean', description: 'Use Rebar Shield' },
+        rebar_tier: { type: 'number', description: 'Rebar fee tier (1 or 2)' },
+        strategy: { type: 'string', description: 'Anti-frontrunning strategy' },
+        resume: { type: 'string', description: 'Resume from existing commit transaction' },
+      },
+      required: ['address', 'signature', 'calldata'],
+    }
+  );
+
+  // Wrap BTC
+  createPositionalTool(
+    'brc20_prog_wrap_btc',
+    'Wrap BTC to frBTC (simple wrap without execution)',
+    ['brc20-prog', 'wrap-btc'],
+    ['amount'],
+    {
+      type: 'object',
+      properties: {
+        amount: { type: 'number', description: 'Amount of BTC to wrap (in satoshis)' },
+        from: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Addresses to source UTXOs from',
+        },
+        change: { type: 'string', description: 'Change address' },
+        fee_rate: { type: 'number', description: 'Fee rate in sat/vB' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        trace: { type: 'boolean', description: 'Enable transaction tracing' },
+        mine: { type: 'boolean', description: 'Mine a block after broadcasting (regtest only)' },
+        auto_confirm: { type: 'boolean', description: 'Automatically confirm the transaction preview' },
+        use_slipstream: { type: 'boolean', description: 'Use MARA Slipstream service' },
+        use_rebar: { type: 'boolean', description: 'Use Rebar Shield' },
+        rebar_tier: { type: 'number', description: 'Rebar fee tier (1 or 2)' },
+        resume: { type: 'string', description: 'Resume from existing commit transaction' },
+      },
+      required: ['amount'],
+    }
+  );
+
+  // Unwrap BTC
+  createSimpleTool(
+    'brc20_prog_unwrap_btc',
+    'Unwrap frBTC to BTC (burns frBTC and queues BTC payment)',
+    ['brc20-prog', 'unwrap-btc'],
+    {
+      type: 'object',
+      properties: {
+        amount: { type: 'number', description: 'Amount of frBTC to unwrap (in satoshis)' },
+        vout: { type: 'number', description: 'Vout index for the inscription output', default: 0 },
+        to: { type: 'string', description: 'Recipient address for the unwrapped BTC' },
+        from: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Addresses to source UTXOs from',
+        },
+        change: { type: 'string', description: 'Change address' },
+        fee_rate: { type: 'number', description: 'Fee rate in sat/vB' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        trace: { type: 'boolean', description: 'Enable transaction tracing' },
+        mine: { type: 'boolean', description: 'Mine a block after broadcasting (regtest only)' },
+        auto_confirm: { type: 'boolean', description: 'Automatically confirm the transaction preview' },
+        use_slipstream: { type: 'boolean', description: 'Use MARA Slipstream service' },
+        use_rebar: { type: 'boolean', description: 'Use Rebar Shield' },
+        rebar_tier: { type: 'number', description: 'Rebar fee tier (1 or 2)' },
+        resume: { type: 'string', description: 'Resume from existing commit transaction' },
+      },
+      required: ['amount', 'to'],
+    }
+  );
+
+  // Wrap and execute
+  createSimpleTool(
+    'brc20_prog_wrap_and_execute',
+    'Wrap BTC and deploy+execute a script (wrapAndExecute)',
+    ['brc20-prog', 'wrap-and-execute'],
+    {
+      type: 'object',
+      properties: {
+        amount: { type: 'number', description: 'Amount of BTC to wrap (in satoshis)' },
+        script: { type: 'string', description: 'Script bytecode to deploy and execute (hex-encoded)' },
+        from: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Addresses to source UTXOs from',
+        },
+        change: { type: 'string', description: 'Change address' },
+        fee_rate: { type: 'number', description: 'Fee rate in sat/vB' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        trace: { type: 'boolean', description: 'Enable transaction tracing' },
+        mine: { type: 'boolean', description: 'Mine a block after broadcasting (regtest only)' },
+        auto_confirm: { type: 'boolean', description: 'Automatically confirm the transaction preview' },
+        use_slipstream: { type: 'boolean', description: 'Use MARA Slipstream service' },
+        use_rebar: { type: 'boolean', description: 'Use Rebar Shield' },
+        rebar_tier: { type: 'number', description: 'Rebar fee tier (1 or 2)' },
+        resume: { type: 'string', description: 'Resume from existing commit transaction' },
+      },
+      required: ['amount', 'script'],
+    }
+  );
+
+  // Wrap and execute2
+  createSimpleTool(
+    'brc20_prog_wrap_and_execute2',
+    'Wrap BTC and call an existing contract (wrapAndExecute2)',
+    ['brc20-prog', 'wrap-and-execute2'],
+    {
+      type: 'object',
+      properties: {
+        amount: { type: 'number', description: 'Amount of BTC to wrap (in satoshis)' },
+        target: { type: 'string', description: 'Target contract address for wrapAndExecute2' },
+        signature: { type: 'string', description: 'Function signature to call on target' },
+        calldata: { type: 'string', description: 'Calldata arguments as comma-separated values', default: '' },
+        from: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Addresses to source UTXOs from',
+        },
+        change: { type: 'string', description: 'Change address' },
+        fee_rate: { type: 'number', description: 'Fee rate in sat/vB' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        trace: { type: 'boolean', description: 'Enable transaction tracing' },
+        mine: { type: 'boolean', description: 'Mine a block after broadcasting (regtest only)' },
+        auto_confirm: { type: 'boolean', description: 'Automatically confirm the transaction preview' },
+        use_slipstream: { type: 'boolean', description: 'Use MARA Slipstream service' },
+        use_rebar: { type: 'boolean', description: 'Use Rebar Shield' },
+        rebar_tier: { type: 'number', description: 'Rebar fee tier (1 or 2)' },
+        resume: { type: 'string', description: 'Resume from existing commit transaction' },
+      },
+      required: ['amount', 'target', 'signature'],
+    }
+  );
+
+  // Query tools (no wallet needed)
+  createPositionalTool(
+    'brc20_prog_signer_address',
+    'Get FrBTC signer address for the current network',
+    ['brc20-prog', 'signer-address'],
+    [],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createPositionalTool(
+    'brc20_prog_get_contract_deploys',
+    'Get contract deployments made by an address',
+    ['brc20-prog', 'get-contract-deploys'],
+    ['address'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Address or address identifier' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['address'],
+    }
+  );
+
+  createPositionalTool(
+    'brc20_prog_get_code',
+    'Get contract bytecode (eth_getCode)',
+    ['brc20-prog', 'get-code'],
+    ['address'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Contract address (0x prefixed hex)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['address'],
+    }
+  );
+
+  createSimpleTool(
+    'brc20_prog_call',
+    'Call a contract function (eth_call)',
+    ['brc20-prog', 'call'],
+    {
+      type: 'object',
+      properties: {
+        to: { type: 'string', description: 'Contract address (0x prefixed hex)' },
+        data: { type: 'string', description: 'Calldata (0x prefixed hex)' },
+        from: { type: 'string', description: 'From address (optional, 0x prefixed hex)' },
+        block: { type: 'string', description: 'Block number or "latest" (optional)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['to', 'data'],
+    }
+  );
+
+  createPositionalTool(
+    'brc20_prog_get_balance',
+    'Get frBTC balance (eth_getBalance)',
+    ['brc20-prog', 'get-balance'],
+    ['address'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Address (0x prefixed hex)' },
+        block: { type: 'string', description: 'Block number or "latest"', default: 'latest' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['address'],
+    }
+  );
+
+  createSimpleTool(
+    'brc20_prog_estimate_gas',
+    'Estimate gas for a transaction (eth_estimateGas)',
+    ['brc20-prog', 'estimate-gas'],
+    {
+      type: 'object',
+      properties: {
+        to: { type: 'string', description: 'Contract address (0x prefixed hex)' },
+        data: { type: 'string', description: 'Calldata (0x prefixed hex)' },
+        from: { type: 'string', description: 'From address (optional, 0x prefixed hex)' },
+        block: { type: 'string', description: 'Block number or "latest" (optional)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['to', 'data'],
+    }
+  );
+
+  createSimpleTool(
+    'brc20_prog_block_number',
+    'Get current block number (eth_blockNumber)',
+    ['brc20-prog', 'block-number'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createPositionalTool(
+    'brc20_prog_get_block_by_number',
+    'Get block by number (eth_getBlockByNumber)',
+    ['brc20-prog', 'get-block-by-number'],
+    ['block'],
+    {
+      type: 'object',
+      properties: {
+        block: { type: 'string', description: 'Block number (hex or decimal) or "latest"' },
+        full: { type: 'boolean', description: 'Include full transaction details' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['block'],
+    }
+  );
+
+  createPositionalTool(
+    'brc20_prog_get_block_by_hash',
+    'Get block by hash (eth_getBlockByHash)',
+    ['brc20-prog', 'get-block-by-hash'],
+    ['hash'],
+    {
+      type: 'object',
+      properties: {
+        hash: { type: 'string', description: 'Block hash (0x prefixed hex)' },
+        full: { type: 'boolean', description: 'Include full transaction details' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hash'],
+    }
+  );
+
+  createPositionalTool(
+    'brc20_prog_get_transaction_count',
+    'Get transaction count/nonce (eth_getTransactionCount)',
+    ['brc20-prog', 'get-transaction-count'],
+    ['address'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Address (0x prefixed hex)' },
+        block: { type: 'string', description: 'Block number or "latest"', default: 'latest' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['address'],
+    }
+  );
+
+  createPositionalTool(
+    'brc20_prog_get_transaction',
+    'Get transaction by hash (eth_getTransactionByHash)',
+    ['brc20-prog', 'get-transaction'],
+    ['hash'],
+    {
+      type: 'object',
+      properties: {
+        hash: { type: 'string', description: 'Transaction hash (0x prefixed hex)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hash'],
+    }
+  );
+
+  createPositionalTool(
+    'brc20_prog_get_transaction_receipt',
+    'Get transaction receipt (eth_getTransactionReceipt)',
+    ['brc20-prog', 'get-transaction-receipt'],
+    ['hash'],
+    {
+      type: 'object',
+      properties: {
+        hash: { type: 'string', description: 'Transaction hash (0x prefixed hex)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hash'],
+    }
+  );
+
+  createSimpleTool(
+    'brc20_prog_get_storage_at',
+    'Get storage at a specific location (eth_getStorageAt)',
+    ['brc20-prog', 'get-storage-at'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Contract address (0x prefixed hex)' },
+        position: { type: 'string', description: 'Storage position (0x prefixed hex)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['address', 'position'],
+    }
+  );
+
+  createSimpleTool(
+    'brc20_prog_get_logs',
+    'Get logs (eth_getLogs)',
+    ['brc20-prog', 'get-logs'],
+    {
+      type: 'object',
+      properties: {
+        from_block: { type: 'string', description: 'From block (hex or decimal)' },
+        to_block: { type: 'string', description: 'To block (hex or decimal)' },
+        address: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Filter by address (can be specified multiple times)',
+        },
+        topics: { type: 'string', description: 'Filter by topics (JSON array format)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'brc20_prog_chain_id',
+    'Get chain ID (eth_chainId)',
+    ['brc20-prog', 'chain-id'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'brc20_prog_gas_price',
+    'Get gas price (eth_gasPrice)',
+    ['brc20-prog', 'gas-price'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'brc20_prog_version',
+    'Get BRC20-Prog version (brc20_version)',
+    ['brc20-prog', 'version'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createPositionalTool(
+    'brc20_prog_get_receipt_by_inscription',
+    'Get transaction receipt by inscription ID',
+    ['brc20-prog', 'get-receipt-by-inscription'],
+    ['inscription_id'],
+    {
+      type: 'object',
+      properties: {
+        inscription_id: { type: 'string', description: 'Inscription ID (e.g., "txid:i0")' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['inscription_id'],
+    }
+  );
+
+  createPositionalTool(
+    'brc20_prog_get_inscription_by_tx',
+    'Get inscription ID by transaction hash',
+    ['brc20-prog', 'get-inscription-by-tx'],
+    ['tx_hash'],
+    {
+      type: 'object',
+      properties: {
+        tx_hash: { type: 'string', description: 'Transaction hash (0x prefixed hex)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['tx_hash'],
+    }
+  );
+
+  createPositionalTool(
+    'brc20_prog_get_inscription_by_contract',
+    'Get inscription ID by contract address',
+    ['brc20-prog', 'get-inscription-by-contract'],
+    ['address'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Contract address (0x prefixed hex)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['address'],
+    }
+  );
+
+  createSimpleTool(
+    'brc20_prog_brc20_balance',
+    'Get BRC20 balance (brc20_balance)',
+    ['brc20-prog', 'brc20-balance'],
+    {
+      type: 'object',
+      properties: {
+        pkscript: { type: 'string', description: 'Bitcoin pkscript (hex)' },
+        ticker: { type: 'string', description: 'BRC20 ticker symbol' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['pkscript', 'ticker'],
+    }
+  );
+
+  createPositionalTool(
+    'brc20_prog_trace_transaction',
+    'Get transaction trace (debug_traceTransaction)',
+    ['brc20-prog', 'trace-transaction'],
+    ['hash'],
+    {
+      type: 'object',
+      properties: {
+        hash: { type: 'string', description: 'Transaction hash (0x prefixed hex)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hash'],
+    }
+  );
+
+  createSimpleTool(
+    'brc20_prog_txpool_content',
+    'Get txpool content (txpool_content)',
+    ['brc20-prog', 'txpool-content'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'brc20_prog_client_version',
+    'Get client version (web3_clientVersion)',
+    ['brc20-prog', 'client-version'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'brc20_prog_unwrap',
+    'Get pending unwraps from BRC20-Prog FrBTC contract',
+    ['brc20-prog', 'unwrap'],
+    {
+      type: 'object',
+      properties: {
+        block_tag: { type: 'string', description: 'Block tag to query' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        experimental_asm: { type: 'boolean', description: 'Use experimental EVM bytecode assembler' },
+        experimental_sol: { type: 'boolean', description: 'Use experimental Solidity-compiled bytecode' },
+      },
+    }
+  );
+}

--- a/alkanes-mcp-server/src/tools/dataapi.ts
+++ b/alkanes-mcp-server/src/tools/dataapi.ts
@@ -1,0 +1,269 @@
+/**
+ * DataAPI tools
+ */
+
+import { createSimpleTool, createPositionalTool } from './helpers.js';
+
+export function registerDataApiTools(): void {
+  createSimpleTool(
+    'dataapi_get_alkanes',
+    'Get all alkanes',
+    ['dataapi', 'get-alkanes'],
+    {
+      type: 'object',
+      properties: {
+        limit: { type: 'number', description: 'Limit results' },
+        offset: { type: 'number', description: 'Offset results' },
+        sort_by: { type: 'string', description: 'Sort by field' },
+        order: { type: 'string', description: 'Sort order' },
+        search: { type: 'string', description: 'Search query' },
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+    }
+  );
+
+  createPositionalTool(
+    'dataapi_get_alkanes_by_address',
+    'Get alkanes for an address',
+    ['dataapi', 'get-alkanes-by-address'],
+    ['address'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Address to query' },
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+      required: ['address'],
+    }
+  );
+
+  createPositionalTool(
+    'dataapi_get_alkane_details',
+    'Get alkane details',
+    ['dataapi', 'get-alkane-details'],
+    ['id'],
+    {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Alkane ID in format BLOCK:TX' },
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+      required: ['id'],
+    }
+  );
+
+  createSimpleTool(
+    'dataapi_get_pools',
+    'Get all pools (defaults to factory 4:65522)',
+    ['dataapi', 'get-pools'],
+    {
+      type: 'object',
+      properties: {
+        factory: { type: 'string', description: 'Factory ID in format BLOCK:TX', default: '4:65522' },
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+    }
+  );
+
+  createPositionalTool(
+    'dataapi_get_pool_by_id',
+    'Get pool details',
+    ['dataapi', 'get-pool-by-id'],
+    ['id'],
+    {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Pool ID in format BLOCK:TX' },
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+      required: ['id'],
+    }
+  );
+
+  createPositionalTool(
+    'dataapi_get_pool_history',
+    'Get pool history',
+    ['dataapi', 'get-pool-history'],
+    ['pool_id'],
+    {
+      type: 'object',
+      properties: {
+        pool_id: { type: 'string', description: 'Pool ID in format BLOCK:TX' },
+        category: { type: 'string', description: 'Category filter' },
+        limit: { type: 'number', description: 'Limit results' },
+        offset: { type: 'number', description: 'Offset results' },
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+      required: ['pool_id'],
+    }
+  );
+
+  createSimpleTool(
+    'dataapi_get_swap_history',
+    'Get swap history',
+    ['dataapi', 'get-swap-history'],
+    {
+      type: 'object',
+      properties: {
+        pool_id: { type: 'string', description: 'Pool ID filter' },
+        limit: { type: 'number', description: 'Limit results' },
+        offset: { type: 'number', description: 'Offset results' },
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'dataapi_get_bitcoin_price',
+    'Get Bitcoin price',
+    ['dataapi', 'get-bitcoin-price'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+    }
+  );
+
+  createPositionalTool(
+    'dataapi_get_market_chart',
+    'Get Bitcoin market chart',
+    ['dataapi', 'get-market-chart'],
+    ['days'],
+    {
+      type: 'object',
+      properties: {
+        days: { type: 'string', description: 'Number of days (1, 7, 14, 30, 90, 180, 365, max)' },
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+      required: ['days'],
+    }
+  );
+
+  createSimpleTool(
+    'dataapi_health',
+    'Health check',
+    ['dataapi', 'health'],
+    {
+      type: 'object',
+      properties: {
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+    }
+  );
+
+  createPositionalTool(
+    'dataapi_get_holders',
+    'Get holders of an alkane token',
+    ['dataapi', 'get-holders'],
+    ['alkane'],
+    {
+      type: 'object',
+      properties: {
+        alkane: { type: 'string', description: 'Alkane ID in format BLOCK:TX' },
+        page: { type: 'number', description: 'Page number', default: 1 },
+        limit: { type: 'number', description: 'Results per page', default: 100 },
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+      required: ['alkane'],
+    }
+  );
+
+  createPositionalTool(
+    'dataapi_get_holder_count',
+    'Get holder count for an alkane token',
+    ['dataapi', 'get-holder-count'],
+    ['alkane'],
+    {
+      type: 'object',
+      properties: {
+        alkane: { type: 'string', description: 'Alkane ID in format BLOCK:TX' },
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+      required: ['alkane'],
+    }
+  );
+
+  createPositionalTool(
+    'dataapi_get_address_balances',
+    'Get alkane balances for an address (with UTXO tracking)',
+    ['dataapi', 'get-address-balances'],
+    ['address'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Address or address identifier' },
+        include_outpoints: { type: 'boolean', description: 'Include individual outpoint details' },
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+      required: ['address'],
+    }
+  );
+
+  createPositionalTool(
+    'dataapi_get_outpoint_balances',
+    'Get alkane balances for a specific outpoint',
+    ['dataapi', 'get-outpoint-balances'],
+    ['outpoint'],
+    {
+      type: 'object',
+      properties: {
+        outpoint: { type: 'string', description: 'Outpoint in format TXID:VOUT' },
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+      required: ['outpoint'],
+    }
+  );
+
+  createSimpleTool(
+    'dataapi_get_block_height',
+    'Get the latest block height processed by the indexer',
+    ['dataapi', 'get-block-height'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'dataapi_get_block_hash',
+    'Get the latest block hash processed by the indexer',
+    ['dataapi', 'get-block-hash'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'dataapi_get_indexer_position',
+    'Get the indexer position (height and hash of latest processed block)',
+    ['dataapi', 'get-indexer-position'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Output raw JSON' },
+        raw_http: { type: 'boolean', description: 'Output raw HTTP response' },
+      },
+    }
+  );
+}

--- a/alkanes-mcp-server/src/tools/esplora.ts
+++ b/alkanes-mcp-server/src/tools/esplora.ts
@@ -1,0 +1,265 @@
+/**
+ * Esplora API tools
+ */
+
+import { createSimpleTool, createPositionalTool } from './helpers.js';
+
+export function registerEsploraTools(): void {
+  createSimpleTool(
+    'esplora_blocks_tip_hash',
+    'Get blocks tip hash',
+    ['esplora', 'blocks-tip-hash'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'esplora_blocks_tip_height',
+    'Get blocks tip height',
+    ['esplora', 'blocks-tip-height'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'esplora_blocks',
+    'Get blocks',
+    ['esplora', 'blocks'],
+    {
+      type: 'object',
+      properties: {
+        start_height: { type: 'number', description: 'Start height' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createPositionalTool(
+    'esplora_block_height',
+    'Get block by height',
+    ['esplora', 'block-height'],
+    ['height'],
+    {
+      type: 'object',
+      properties: {
+        height: { type: 'number', description: 'Block height' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['height'],
+    }
+  );
+
+  createPositionalTool(
+    'esplora_block',
+    'Get block',
+    ['esplora', 'block'],
+    ['hash'],
+    {
+      type: 'object',
+      properties: {
+        hash: { type: 'string', description: 'Block hash' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hash'],
+    }
+  );
+
+  createPositionalTool(
+    'esplora_block_status',
+    'Get block status',
+    ['esplora', 'block-status'],
+    ['hash'],
+    {
+      type: 'object',
+      properties: {
+        hash: { type: 'string', description: 'Block hash' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hash'],
+    }
+  );
+
+  createPositionalTool(
+    'esplora_block_txids',
+    'Get block transaction IDs',
+    ['esplora', 'block-txids'],
+    ['hash'],
+    {
+      type: 'object',
+      properties: {
+        hash: { type: 'string', description: 'Block hash' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hash'],
+    }
+  );
+
+  createPositionalTool(
+    'esplora_block_header',
+    'Get block header',
+    ['esplora', 'block-header'],
+    ['hash'],
+    {
+      type: 'object',
+      properties: {
+        hash: { type: 'string', description: 'Block hash' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hash'],
+    }
+  );
+
+  createPositionalTool(
+    'esplora_block_raw',
+    'Get raw block',
+    ['esplora', 'block-raw'],
+    ['hash'],
+    {
+      type: 'object',
+      properties: {
+        hash: { type: 'string', description: 'Block hash' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hash'],
+    }
+  );
+
+  createPositionalTool(
+    'esplora_address',
+    'Get address information',
+    ['esplora', 'address'],
+    ['params'],
+    {
+      type: 'object',
+      properties: {
+        params: { type: 'string', description: 'Address parameters' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['params'],
+    }
+  );
+
+  createPositionalTool(
+    'esplora_address_txs',
+    'Get address transactions',
+    ['esplora', 'address-txs'],
+    ['params'],
+    {
+      type: 'object',
+      properties: {
+        params: { type: 'string', description: 'Address parameters' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        exclude_coinbase: { type: 'boolean', description: 'Exclude coinbase transactions' },
+        runestone_trace: { type: 'boolean', description: 'Trace runestones' },
+      },
+      required: ['params'],
+    }
+  );
+
+  createPositionalTool(
+    'esplora_address_utxo',
+    'Get address UTXOs',
+    ['esplora', 'address-utxo'],
+    ['address'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Address' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['address'],
+    }
+  );
+
+  createPositionalTool(
+    'esplora_tx',
+    'Get transaction',
+    ['esplora', 'tx'],
+    ['txid'],
+    {
+      type: 'object',
+      properties: {
+        txid: { type: 'string', description: 'Transaction ID' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['txid'],
+    }
+  );
+
+  createPositionalTool(
+    'esplora_tx_hex',
+    'Get transaction hex',
+    ['esplora', 'tx-hex'],
+    ['txid'],
+    {
+      type: 'object',
+      properties: {
+        txid: { type: 'string', description: 'Transaction ID' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['txid'],
+    }
+  );
+
+  createPositionalTool(
+    'esplora_tx_status',
+    'Get transaction status',
+    ['esplora', 'tx-status'],
+    ['txid'],
+    {
+      type: 'object',
+      properties: {
+        txid: { type: 'string', description: 'Transaction ID' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['txid'],
+    }
+  );
+
+  createPositionalTool(
+    'esplora_broadcast',
+    'Broadcast transaction',
+    ['esplora', 'broadcast'],
+    ['tx_hex'],
+    {
+      type: 'object',
+      properties: {
+        tx_hex: { type: 'string', description: 'Transaction hex' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['tx_hex'],
+    }
+  );
+
+  createSimpleTool(
+    'esplora_mempool',
+    'Get mempool',
+    ['esplora', 'mempool'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'esplora_fee_estimates',
+    'Get fee estimates',
+    ['esplora', 'fee-estimates'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+}

--- a/alkanes-mcp-server/src/tools/espo.ts
+++ b/alkanes-mcp-server/src/tools/espo.ts
@@ -1,0 +1,228 @@
+/**
+ * ESPO tools
+ */
+
+import { createSimpleTool, createPositionalTool } from './helpers.js';
+
+export function registerEspoTools(): void {
+  createSimpleTool(
+    'espo_height',
+    'Get current ESPO indexer height',
+    ['espo', 'height'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createPositionalTool(
+    'espo_balances',
+    'Get alkanes balances for an address',
+    ['espo', 'balances'],
+    ['address'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Address to query balances for' },
+        include_outpoints: { type: 'boolean', description: 'Include outpoint details in response' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['address'],
+    }
+  );
+
+  createPositionalTool(
+    'espo_outpoints',
+    'Get outpoints containing alkanes for an address',
+    ['espo', 'outpoints'],
+    ['address'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Address to query outpoints for' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['address'],
+    }
+  );
+
+  createPositionalTool(
+    'espo_outpoint',
+    'Get alkanes balances at a specific outpoint',
+    ['espo', 'outpoint'],
+    ['outpoint'],
+    {
+      type: 'object',
+      properties: {
+        outpoint: { type: 'string', description: 'Outpoint (format: txid:vout)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['outpoint'],
+    }
+  );
+
+  createPositionalTool(
+    'espo_holders',
+    'Get holders of an alkane token',
+    ['espo', 'holders'],
+    ['alkane_id'],
+    {
+      type: 'object',
+      properties: {
+        alkane_id: { type: 'string', description: 'Alkane ID (format: block:tx)' },
+        page: { type: 'number', description: 'Page number', default: 1 },
+        limit: { type: 'number', description: 'Items per page', default: 100 },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['alkane_id'],
+    }
+  );
+
+  createPositionalTool(
+    'espo_holders_count',
+    'Get holder count for an alkane',
+    ['espo', 'holders-count'],
+    ['alkane_id'],
+    {
+      type: 'object',
+      properties: {
+        alkane_id: { type: 'string', description: 'Alkane ID (format: block:tx)' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['alkane_id'],
+    }
+  );
+
+  createPositionalTool(
+    'espo_keys',
+    'Get storage keys for an alkane contract',
+    ['espo', 'keys'],
+    ['alkane_id'],
+    {
+      type: 'object',
+      properties: {
+        alkane_id: { type: 'string', description: 'Alkane ID (format: block:tx)' },
+        page: { type: 'number', description: 'Page number', default: 1 },
+        limit: { type: 'number', description: 'Items per page', default: 100 },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['alkane_id'],
+    }
+  );
+
+  createSimpleTool(
+    'espo_ping',
+    'Ping the ESPO server',
+    ['espo', 'ping'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createSimpleTool(
+    'espo_ammdata_ping',
+    'Ping the AMM Data module',
+    ['espo', 'ammdata-ping'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createPositionalTool(
+    'espo_candles',
+    'Get OHLCV candlestick data for a pool',
+    ['espo', 'candles'],
+    ['pool'],
+    {
+      type: 'object',
+      properties: {
+        pool: { type: 'string', description: 'Pool ID (format: block:tx)' },
+        timeframe: { type: 'string', description: 'Timeframe (e.g., "10m", "1h", "1d", "1w", "1M")' },
+        side: { type: 'string', description: 'Side ("base" or "quote")' },
+        limit: { type: 'number', description: 'Items per page' },
+        page: { type: 'number', description: 'Page number' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['pool'],
+    }
+  );
+
+  createPositionalTool(
+    'espo_trades',
+    'Get trade history for a pool',
+    ['espo', 'trades'],
+    ['pool'],
+    {
+      type: 'object',
+      properties: {
+        pool: { type: 'string', description: 'Pool ID (format: block:tx)' },
+        limit: { type: 'number', description: 'Items per page' },
+        page: { type: 'number', description: 'Page number' },
+        side: { type: 'string', description: 'Side ("base" or "quote")' },
+        filter_side: { type: 'string', description: 'Filter side ("buy", "sell", or "all")' },
+        sort: { type: 'string', description: 'Sort field' },
+        dir: { type: 'string', description: 'Direction ("asc" or "desc")' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['pool'],
+    }
+  );
+
+  createSimpleTool(
+    'espo_pools',
+    'Get all pools with pagination',
+    ['espo', 'pools'],
+    {
+      type: 'object',
+      properties: {
+        limit: { type: 'number', description: 'Items per page' },
+        page: { type: 'number', description: 'Page number' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'espo_find_best_swap_path',
+    'Find the best swap path between two tokens',
+    ['espo', 'find-best-swap-path'],
+    {
+      type: 'object',
+      properties: {
+        token_in: { type: 'string', description: 'Input token (format: block:tx)' },
+        token_out: { type: 'string', description: 'Output token (format: block:tx)' },
+        mode: { type: 'string', description: 'Mode ("exact_in", "exact_out", or "implicit")' },
+        amount_in: { type: 'string', description: 'Amount in (as string to preserve precision)' },
+        amount_out: { type: 'string', description: 'Amount out (as string to preserve precision)' },
+        amount_out_min: { type: 'string', description: 'Minimum amount out' },
+        amount_in_max: { type: 'string', description: 'Maximum amount in' },
+        available_in: { type: 'string', description: 'Available amount in' },
+        fee_bps: { type: 'number', description: 'Fee in basis points' },
+        max_hops: { type: 'number', description: 'Maximum number of hops' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['token_in', 'token_out'],
+    }
+  );
+
+  createPositionalTool(
+    'espo_get_best_mev_swap',
+    'Find the best MEV swap opportunity for a token',
+    ['espo', 'get-best-mev-swap'],
+    ['token'],
+    {
+      type: 'object',
+      properties: {
+        token: { type: 'string', description: 'Token (format: block:tx)' },
+        fee_bps: { type: 'number', description: 'Fee in basis points' },
+        max_hops: { type: 'number', description: 'Maximum number of hops' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['token'],
+    }
+  );
+}

--- a/alkanes-mcp-server/src/tools/helpers.ts
+++ b/alkanes-mcp-server/src/tools/helpers.ts
@@ -1,0 +1,120 @@
+/**
+ * Helper functions for tool registration
+ */
+
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { EnvironmentConfig } from '../config.js';
+import { executeCommandJson } from '../executor.js';
+import { registerTool, type ToolHandler } from './registry.js';
+
+/**
+ * Create a simple tool that executes a CLI command
+ */
+export function createSimpleTool(
+  name: string,
+  description: string,
+  command: string[],
+  inputSchema: Tool['inputSchema'],
+  buildArgs?: (args: Record<string, unknown>) => string[]
+): void {
+  const handler: ToolHandler = async (config, args) => {
+    const cmd = [...command];
+    
+    // Add --raw if requested
+    if (args?.raw) {
+      cmd.push('--raw');
+    }
+    
+    // Build additional arguments
+    if (buildArgs) {
+      const additionalArgs = buildArgs(args);
+      cmd.push(...additionalArgs);
+    } else {
+      // Default: add all non-raw args as --key value
+      for (const [key, value] of Object.entries(args || {})) {
+        if (key === 'raw') continue;
+        if (value !== undefined && value !== null) {
+          if (typeof value === 'boolean' && value) {
+            cmd.push(`--${key.replace(/_/g, '-')}`);
+          } else if (typeof value === 'string' || typeof value === 'number') {
+            cmd.push(`--${key.replace(/_/g, '-')}`, String(value));
+          } else if (Array.isArray(value)) {
+            for (const item of value) {
+              cmd.push(`--${key.replace(/_/g, '-')}`, String(item));
+            }
+          }
+        }
+      }
+    }
+    
+    return executeCommandJson(config, cmd);
+  };
+  
+  registerTool({
+    name,
+    description,
+    inputSchema,
+    handler,
+  });
+}
+
+/**
+ * Create a tool with positional arguments
+ */
+export function createPositionalTool(
+  name: string,
+  description: string,
+  command: string[],
+  positionalArgs: string[],
+  inputSchema: Tool['inputSchema'],
+  buildFlags?: (args: Record<string, unknown>) => string[]
+): void {
+  const handler: ToolHandler = async (config, args) => {
+    const cmd = [...command];
+    
+    // Add positional arguments in order
+    for (const argName of positionalArgs) {
+      const value = args?.[argName];
+      if (value === undefined || value === null) {
+        throw new Error(`Missing required argument: ${argName}`);
+      }
+      cmd.push(String(value));
+    }
+    
+    // Add flags
+    if (buildFlags) {
+      const flags = buildFlags(args);
+      cmd.push(...flags);
+    } else {
+      // Add --raw if requested
+      if (args?.raw) {
+        cmd.push('--raw');
+      }
+      
+      // Add other boolean flags and options
+      for (const [key, value] of Object.entries(args || {})) {
+        if (positionalArgs.includes(key) || key === 'raw') continue;
+        if (value === undefined || value === null) continue;
+        
+        if (typeof value === 'boolean' && value) {
+          cmd.push(`--${key.replace(/_/g, '-')}`);
+        } else if (typeof value === 'string' || typeof value === 'number') {
+          cmd.push(`--${key.replace(/_/g, '-')}`, String(value));
+        } else if (Array.isArray(value)) {
+          for (const item of value) {
+            cmd.push(`--${key.replace(/_/g, '-')}`, String(item));
+          }
+        }
+      }
+    }
+    
+    return executeCommandJson(config, cmd);
+  };
+  
+  registerTool({
+    name,
+    description,
+    inputSchema,
+    handler,
+  });
+}

--- a/alkanes-mcp-server/src/tools/lua.ts
+++ b/alkanes-mcp-server/src/tools/lua.ts
@@ -1,0 +1,26 @@
+/**
+ * Lua script tools
+ */
+
+import { createSimpleTool } from './helpers.js';
+
+export function registerLuaTools(): void {
+  createSimpleTool(
+    'lua_evalscript',
+    'Execute a Lua script (tries cached hash first, falls back to full script)',
+    ['lua', 'evalscript'],
+    {
+      type: 'object',
+      properties: {
+        script: { type: 'string', description: 'Path to Lua script file' },
+        args: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Arguments to pass to the script',
+        },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['script'],
+    }
+  );
+}

--- a/alkanes-mcp-server/src/tools/metashrew.ts
+++ b/alkanes-mcp-server/src/tools/metashrew.ts
@@ -1,0 +1,43 @@
+/**
+ * Metashrew tools
+ */
+
+import { createSimpleTool, createPositionalTool } from './helpers.js';
+
+export function registerMetashrewTools(): void {
+  createSimpleTool(
+    'metashrew_height',
+    'Get the current block height',
+    ['metashrew', 'height'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createPositionalTool(
+    'metashrew_getblockhash',
+    'Get the block hash for a given height',
+    ['metashrew', 'getblockhash'],
+    ['height'],
+    {
+      type: 'object',
+      properties: {
+        height: { type: 'number', description: 'The block height' },
+      },
+      required: ['height'],
+    }
+  );
+
+  createSimpleTool(
+    'metashrew_getstateroot',
+    'Get the state root for a given height',
+    ['metashrew', 'getstateroot'],
+    {
+      type: 'object',
+      properties: {
+        height: { type: 'string', description: 'The block height, or "latest"' },
+      },
+    }
+  );
+}

--- a/alkanes-mcp-server/src/tools/mod.ts
+++ b/alkanes-mcp-server/src/tools/mod.ts
@@ -1,0 +1,38 @@
+/**
+ * Tool registry - exports all tools
+ */
+
+import { registerBitcoindTools } from './bitcoind.js';
+import { registerWalletTools } from './wallet.js';
+import { registerAlkanesTools } from './alkanes.js';
+import { registerBrc20ProgTools } from './brc20_prog.js';
+import { registerDataApiTools } from './dataapi.js';
+import { registerOrdTools } from './ord.js';
+import { registerOpiTools } from './opi.js';
+import { registerEsploraTools } from './esplora.js';
+import { registerMetashrewTools } from './metashrew.js';
+import { registerLuaTools } from './lua.js';
+import { registerProtorunesTools } from './protorunes.js';
+import { registerRunestoneTools } from './runestone.js';
+import { registerSubfrostTools } from './subfrost.js';
+import { registerEspoTools } from './espo.js';
+
+/**
+ * Register all tools
+ */
+export function registerAllTools(): void {
+  registerBitcoindTools();
+  registerWalletTools();
+  registerAlkanesTools();
+  registerBrc20ProgTools();
+  registerDataApiTools();
+  registerOrdTools();
+  registerOpiTools();
+  registerEsploraTools();
+  registerMetashrewTools();
+  registerLuaTools();
+  registerProtorunesTools();
+  registerRunestoneTools();
+  registerSubfrostTools();
+  registerEspoTools();
+}

--- a/alkanes-mcp-server/src/tools/opi.ts
+++ b/alkanes-mcp-server/src/tools/opi.ts
@@ -1,0 +1,266 @@
+/**
+ * OPI (Open Protocol Indexer) tools
+ */
+
+import { createSimpleTool, createPositionalTool } from './helpers.js';
+
+export function registerOpiTools(): void {
+  // BRC-20 tools
+  createSimpleTool(
+    'opi_block_height',
+    'Get current indexed block height (BRC-20)',
+    ['opi', 'block-height'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createSimpleTool(
+    'opi_extras_block_height',
+    'Get extras indexed block height (BRC-20)',
+    ['opi', 'extras-block-height'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createSimpleTool(
+    'opi_db_version',
+    'Get database version (BRC-20)',
+    ['opi', 'db-version'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createSimpleTool(
+    'opi_event_hash_version',
+    'Get event hash version (BRC-20)',
+    ['opi', 'event-hash-version'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createSimpleTool(
+    'opi_balance_on_block',
+    'Get balance at a specific block height (BRC-20)',
+    ['opi', 'balance-on-block'],
+    {
+      type: 'object',
+      properties: {
+        block_height: { type: 'number', description: 'Block height to query' },
+        pkscript: { type: 'string', description: 'Pkscript of the wallet' },
+        ticker: { type: 'string', description: 'BRC-20 ticker' },
+      },
+      required: ['block_height', 'pkscript', 'ticker'],
+    }
+  );
+
+  createSimpleTool(
+    'opi_activity_on_block',
+    'Get all BRC-20 activity for a block',
+    ['opi', 'activity-on-block'],
+    {
+      type: 'object',
+      properties: {
+        block_height: { type: 'number', description: 'Block height to query' },
+      },
+      required: ['block_height'],
+    }
+  );
+
+  createSimpleTool(
+    'opi_current_balance',
+    'Get current balance of a wallet (BRC-20)',
+    ['opi', 'current-balance'],
+    {
+      type: 'object',
+      properties: {
+        ticker: { type: 'string', description: 'BRC-20 ticker' },
+        address: { type: 'string', description: 'Bitcoin address' },
+        pkscript: { type: 'string', description: 'Pkscript of the wallet' },
+      },
+      required: ['ticker'],
+    }
+  );
+
+  createSimpleTool(
+    'opi_holders',
+    'Get holders of a BRC-20 ticker',
+    ['opi', 'holders'],
+    {
+      type: 'object',
+      properties: {
+        ticker: { type: 'string', description: 'BRC-20 ticker' },
+      },
+      required: ['ticker'],
+    }
+  );
+
+  createPositionalTool(
+    'opi_event',
+    'Get events for an inscription (BRC-20)',
+    ['opi', 'event'],
+    ['inscription_id'],
+    {
+      type: 'object',
+      properties: {
+        inscription_id: { type: 'string', description: 'Inscription ID' },
+      },
+      required: ['inscription_id'],
+    }
+  );
+
+  createSimpleTool(
+    'opi_ip',
+    'Get client IP (for debugging)',
+    ['opi', 'ip'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createPositionalTool(
+    'opi_raw',
+    'Make a raw request to OPI endpoint',
+    ['opi', 'raw'],
+    ['endpoint'],
+    {
+      type: 'object',
+      properties: {
+        endpoint: { type: 'string', description: 'Endpoint path (e.g., "v1/brc20/block_height")' },
+      },
+      required: ['endpoint'],
+    }
+  );
+
+  // Runes subcommands
+  createSimpleTool(
+    'opi_runes_block_height',
+    'Get current indexed block height (Runes)',
+    ['opi', 'runes', 'block-height'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createSimpleTool(
+    'opi_runes_current_balance',
+    'Get current Runes balance of a wallet',
+    ['opi', 'runes', 'current-balance'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Bitcoin address' },
+        pkscript: { type: 'string', description: 'Pkscript of the wallet' },
+      },
+    }
+  );
+
+  createSimpleTool(
+    'opi_runes_holders',
+    'Get holders of a Rune',
+    ['opi', 'runes', 'holders'],
+    {
+      type: 'object',
+      properties: {
+        rune_id: { type: 'string', description: 'Rune ID' },
+      },
+      required: ['rune_id'],
+    }
+  );
+
+  // Bitmap subcommands
+  createSimpleTool(
+    'opi_bitmap_block_height',
+    'Get current indexed block height (Bitmap)',
+    ['opi', 'bitmap', 'block-height'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createSimpleTool(
+    'opi_bitmap_inscription_id',
+    'Get inscription ID of a bitmap',
+    ['opi', 'bitmap', 'inscription-id'],
+    {
+      type: 'object',
+      properties: {
+        bitmap: { type: 'string', description: 'Bitmap number' },
+      },
+      required: ['bitmap'],
+    }
+  );
+
+  // POW20 subcommands
+  createSimpleTool(
+    'opi_pow20_block_height',
+    'Get current indexed block height (POW20)',
+    ['opi', 'pow20', 'block-height'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createSimpleTool(
+    'opi_pow20_current_balance',
+    'Get current POW20 balance of a wallet',
+    ['opi', 'pow20', 'current-balance'],
+    {
+      type: 'object',
+      properties: {
+        ticker: { type: 'string', description: 'POW20 ticker' },
+        address: { type: 'string', description: 'Bitcoin address' },
+        pkscript: { type: 'string', description: 'Pkscript of the wallet' },
+      },
+      required: ['ticker'],
+    }
+  );
+
+  createSimpleTool(
+    'opi_pow20_holders',
+    'Get holders of a POW20 ticker',
+    ['opi', 'pow20', 'holders'],
+    {
+      type: 'object',
+      properties: {
+        ticker: { type: 'string', description: 'POW20 ticker' },
+      },
+      required: ['ticker'],
+    }
+  );
+
+  // SNS subcommands
+  createSimpleTool(
+    'opi_sns_block_height',
+    'Get current indexed block height (SNS)',
+    ['opi', 'sns', 'block-height'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createSimpleTool(
+    'opi_sns_info',
+    'Get info about an SNS name',
+    ['opi', 'sns', 'info'],
+    {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'SNS name to query' },
+      },
+      required: ['name'],
+    }
+  );
+}

--- a/alkanes-mcp-server/src/tools/ord.ts
+++ b/alkanes-mcp-server/src/tools/ord.ts
@@ -1,0 +1,195 @@
+/**
+ * Ord tools
+ */
+
+import { createSimpleTool, createPositionalTool } from './helpers.js';
+
+export function registerOrdTools(): void {
+  createPositionalTool(
+    'ord_inscription',
+    'Get inscription by ID',
+    ['ord', 'inscription'],
+    ['id'],
+    {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'The inscription ID' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['id'],
+    }
+  );
+
+  createPositionalTool(
+    'ord_inscriptions_in_block',
+    'Get inscriptions for a block',
+    ['ord', 'inscriptions-in-block'],
+    ['hash'],
+    {
+      type: 'object',
+      properties: {
+        hash: { type: 'string', description: 'The block hash' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['hash'],
+    }
+  );
+
+  createPositionalTool(
+    'ord_address_info',
+    'Get address information',
+    ['ord', 'address-info'],
+    ['address'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'The address' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['address'],
+    }
+  );
+
+  createPositionalTool(
+    'ord_block_info',
+    'Get block information',
+    ['ord', 'block-info'],
+    ['query'],
+    {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'The block hash or height' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['query'],
+    }
+  );
+
+  createSimpleTool(
+    'ord_block_count',
+    'Get latest block count',
+    ['ord', 'block-count'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  createSimpleTool(
+    'ord_blocks',
+    'Get latest blocks',
+    ['ord', 'blocks'],
+    {
+      type: 'object',
+      properties: {
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  createPositionalTool(
+    'ord_children',
+    'Get children of an inscription',
+    ['ord', 'children'],
+    ['id'],
+    {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'The inscription ID' },
+        page: { type: 'number', description: 'Page number' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['id'],
+    }
+  );
+
+  createPositionalTool(
+    'ord_content',
+    'Get inscription content',
+    ['ord', 'content'],
+    ['id'],
+    {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'The inscription ID' },
+      },
+      required: ['id'],
+    }
+  );
+
+  createPositionalTool(
+    'ord_output',
+    'Get output information',
+    ['ord', 'output'],
+    ['outpoint'],
+    {
+      type: 'object',
+      properties: {
+        outpoint: { type: 'string', description: 'The outpoint' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['outpoint'],
+    }
+  );
+
+  createPositionalTool(
+    'ord_parents',
+    'Get parents of an inscription',
+    ['ord', 'parents'],
+    ['id'],
+    {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'The inscription ID' },
+        page: { type: 'number', description: 'Page number' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['id'],
+    }
+  );
+
+  createPositionalTool(
+    'ord_rune',
+    'Get rune information',
+    ['ord', 'rune'],
+    ['rune'],
+    {
+      type: 'object',
+      properties: {
+        rune: { type: 'string', description: 'The rune name or ID' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['rune'],
+    }
+  );
+
+  createPositionalTool(
+    'ord_sat',
+    'Get sat information',
+    ['ord', 'sat'],
+    ['sat'],
+    {
+      type: 'object',
+      properties: {
+        sat: { type: 'number', description: 'The sat number' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['sat'],
+    }
+  );
+
+  createPositionalTool(
+    'ord_tx_info',
+    'Get transaction information',
+    ['ord', 'tx-info'],
+    ['txid'],
+    {
+      type: 'object',
+      properties: {
+        txid: { type: 'string', description: 'The transaction ID' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['txid'],
+    }
+  );
+}

--- a/alkanes-mcp-server/src/tools/protorunes.ts
+++ b/alkanes-mcp-server/src/tools/protorunes.ts
@@ -1,0 +1,41 @@
+/**
+ * Protorunes tools
+ */
+
+import { createPositionalTool } from './helpers.js';
+
+export function registerProtorunesTools(): void {
+  createPositionalTool(
+    'protorunes_by_address',
+    'Get protorunes by address',
+    ['protorunes', 'by-address'],
+    ['address'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Address to query' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        block_tag: { type: 'string', description: 'Block tag to query' },
+        protocol_tag: { type: 'number', description: 'Protocol tag', default: 1 },
+      },
+      required: ['address'],
+    }
+  );
+
+  createPositionalTool(
+    'protorunes_by_outpoint',
+    'Get protorunes by outpoint',
+    ['protorunes', 'by-outpoint'],
+    ['outpoint'],
+    {
+      type: 'object',
+      properties: {
+        outpoint: { type: 'string', description: 'Outpoint to query' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        block_tag: { type: 'string', description: 'Block tag to query' },
+        protocol_tag: { type: 'number', description: 'Protocol tag', default: 1 },
+      },
+      required: ['outpoint'],
+    }
+  );
+}

--- a/alkanes-mcp-server/src/tools/registry.ts
+++ b/alkanes-mcp-server/src/tools/registry.ts
@@ -1,0 +1,60 @@
+/**
+ * Centralized tool registry
+ */
+
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import type { EnvironmentConfig } from '../config.js';
+import { executeCommandJson } from '../executor.js';
+import { formatErrorResponse, formatResponse } from '../response.js';
+
+export type ToolHandler = (
+  config: EnvironmentConfig,
+  args: Record<string, unknown>
+) => Promise<unknown>;
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Tool['inputSchema'];
+  handler: ToolHandler;
+}
+
+const tools = new Map<string, ToolDefinition>();
+
+export function registerTool(definition: ToolDefinition): void {
+  tools.set(definition.name, definition);
+}
+
+export function getTool(name: string): ToolDefinition | undefined {
+  return tools.get(name);
+}
+
+export function getAllTools(): Tool[] {
+  return Array.from(tools.values()).map((def) => ({
+    name: def.name,
+    description: def.description,
+    inputSchema: def.inputSchema,
+  }));
+}
+
+export async function executeTool(
+  name: string,
+  config: EnvironmentConfig,
+  args: Record<string, unknown>
+): Promise<{ content: Array<{ type: string; text?: string }> }> {
+  const tool = getTool(name);
+  if (!tool) {
+    throw new McpError(ErrorCode.MethodNotFound, `Tool not found: ${name}`);
+  }
+
+  try {
+    const result = await tool.handler(config, args);
+    return formatResponse(
+      { stdout: JSON.stringify(result), stderr: '', exitCode: 0, success: true },
+      true
+    );
+  } catch (error) {
+    return formatErrorResponse(error);
+  }
+}

--- a/alkanes-mcp-server/src/tools/runestone.ts
+++ b/alkanes-mcp-server/src/tools/runestone.ts
@@ -1,0 +1,37 @@
+/**
+ * Runestone tools
+ */
+
+import { createPositionalTool } from './helpers.js';
+
+export function registerRunestoneTools(): void {
+  createPositionalTool(
+    'runestone_analyze',
+    'Analyze a runestone in a transaction',
+    ['runestone', 'analyze'],
+    ['txid'],
+    {
+      type: 'object',
+      properties: {
+        txid: { type: 'string', description: 'The transaction ID' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['txid'],
+    }
+  );
+
+  createPositionalTool(
+    'runestone_trace',
+    'Trace all protostones in a runestone transaction',
+    ['runestone', 'trace'],
+    ['txid'],
+    {
+      type: 'object',
+      properties: {
+        txid: { type: 'string', description: 'The transaction ID' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+      required: ['txid'],
+    }
+  );
+}

--- a/alkanes-mcp-server/src/tools/subfrost.ts
+++ b/alkanes-mcp-server/src/tools/subfrost.ts
@@ -1,0 +1,23 @@
+/**
+ * Subfrost tools
+ */
+
+import { createSimpleTool } from './helpers.js';
+
+export function registerSubfrostTools(): void {
+  createSimpleTool(
+    'subfrost_minimum_unwrap',
+    'Calculate minimum unwrap amount based on current fee rates',
+    ['subfrost', 'minimum-unwrap'],
+    {
+      type: 'object',
+      properties: {
+        fee_rate: { type: 'number', description: 'Override fee rate in sat/vB' },
+        premium: { type: 'number', description: 'Premium percentage charged by subfrost', default: 0.001 },
+        expected_inputs: { type: 'number', description: 'Expected number of inputs', default: 10 },
+        expected_outputs: { type: 'number', description: 'Expected number of outputs', default: 10 },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+}

--- a/alkanes-mcp-server/src/tools/wallet.ts
+++ b/alkanes-mcp-server/src/tools/wallet.ts
@@ -1,0 +1,312 @@
+/**
+ * Wallet tools
+ */
+
+import { createSimpleTool, createPositionalTool } from './helpers.js';
+
+export function registerWalletTools(): void {
+  // Wallet create
+  createSimpleTool(
+    'wallet_create',
+    'Create a new wallet',
+    ['wallet', 'create'],
+    {
+      type: 'object',
+      properties: {
+        mnemonic: { type: 'string', description: 'Optional mnemonic phrase to restore from' },
+        output: { type: 'string', description: 'Output file path for the wallet' },
+      },
+    }
+  );
+
+  // Wallet addresses
+  createSimpleTool(
+    'wallet_addresses',
+    'Get addresses from the wallet',
+    ['wallet', 'addresses'],
+    {
+      type: 'object',
+      properties: {
+        ranges: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Address range specifications (e.g., "p2tr:0-1000")',
+        },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        all_networks: { type: 'boolean', description: 'Show addresses for all networks' },
+      },
+    }
+  );
+
+  // Wallet UTXOs
+  createSimpleTool(
+    'wallet_utxos',
+    'List UTXOs in the wallet',
+    ['wallet', 'utxos'],
+    {
+      type: 'object',
+      properties: {
+        addresses: { type: 'string', description: 'Address specifications' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+        include_frozen: { type: 'boolean', description: 'Include frozen UTXOs' },
+      },
+    }
+  );
+
+  // Wallet freeze
+  createPositionalTool(
+    'wallet_freeze',
+    'Freeze a UTXO',
+    ['wallet', 'freeze'],
+    ['outpoint'],
+    {
+      type: 'object',
+      properties: {
+        outpoint: { type: 'string', description: 'The outpoint of the UTXO to freeze' },
+      },
+      required: ['outpoint'],
+    }
+  );
+
+  // Wallet unfreeze
+  createPositionalTool(
+    'wallet_unfreeze',
+    'Unfreeze a UTXO',
+    ['wallet', 'unfreeze'],
+    ['outpoint'],
+    {
+      type: 'object',
+      properties: {
+        outpoint: { type: 'string', description: 'The outpoint of the UTXO to unfreeze' },
+      },
+      required: ['outpoint'],
+    }
+  );
+
+  // Wallet sign
+  createPositionalTool(
+    'wallet_sign',
+    'Sign a PSBT',
+    ['wallet', 'sign'],
+    ['psbt'],
+    {
+      type: 'object',
+      properties: {
+        psbt: { type: 'string', description: 'The PSBT to sign, as a base64 string' },
+      },
+      required: ['psbt'],
+    }
+  );
+
+  // Wallet send
+  createPositionalTool(
+    'wallet_send',
+    'Send a transaction',
+    ['wallet', 'send'],
+    ['address', 'amount'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'The address to send to' },
+        amount: { type: 'string', description: 'The amount to send in BTC (e.g., 0.0001)' },
+        fee_rate: { type: 'number', description: 'The fee rate in sat/vB' },
+        send_all: { type: 'boolean', description: 'Send all funds' },
+        from: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'The addresses to send from',
+        },
+        lock_alkanes: { type: 'boolean', description: 'Skip UTXOs that have alkanes on them' },
+        change_address: { type: 'string', description: 'The change address' },
+        use_rebar: { type: 'boolean', description: 'Use Rebar Shield' },
+        rebar_tier: { type: 'number', description: 'Rebar fee tier (1 or 2)' },
+        auto_confirm: { type: 'boolean', description: 'Automatically confirm the transaction' },
+      },
+      required: ['address', 'amount'],
+    }
+  );
+
+  // Wallet balance
+  createSimpleTool(
+    'wallet_balance',
+    'Get the balance of the wallet',
+    ['wallet', 'balance'],
+    {
+      type: 'object',
+      properties: {
+        addresses: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'The addresses to get the balance for',
+        },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  // Wallet history
+  createSimpleTool(
+    'wallet_history',
+    'Get the history of the wallet',
+    ['wallet', 'history'],
+    {
+      type: 'object',
+      properties: {
+        count: { type: 'number', description: 'The number of transactions to get', default: 10 },
+        address: { type: 'string', description: 'The address to get the history for' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    }
+  );
+
+  // Wallet create-tx
+  createPositionalTool(
+    'wallet_create_tx',
+    'Create a transaction',
+    ['wallet', 'create-tx'],
+    ['address', 'amount'],
+    {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'The address to send to' },
+        amount: { type: 'number', description: 'The amount to send in satoshis' },
+        fee_rate: { type: 'number', description: 'The fee rate in sat/vB' },
+        send_all: { type: 'boolean', description: 'Send all funds' },
+        from: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'The addresses to send from',
+        },
+        change_address: { type: 'string', description: 'The change address' },
+      },
+      required: ['address', 'amount'],
+    }
+  );
+
+  // Wallet sign-tx
+  createSimpleTool(
+    'wallet_sign_tx',
+    'Sign a transaction',
+    ['wallet', 'sign-tx'],
+    {
+      type: 'object',
+      properties: {
+        tx_hex: { type: 'string', description: 'The transaction hex to sign' },
+        from_file: { type: 'string', description: 'Read transaction hex from file' },
+        truncate_excess_vsize: { type: 'string', description: 'Truncate excess inputs to fit size limit' },
+        split_max_vsize: { type: 'string', description: 'Split transaction into multiple transactions' },
+      },
+    },
+    (args) => {
+      const flags: string[] = [];
+      if (args.from_file) {
+        flags.push('--from-file', String(args.from_file));
+      } else if (args.tx_hex) {
+        flags.push(String(args.tx_hex));
+      }
+      if (args.truncate_excess_vsize) {
+        flags.push('--truncate-excess-vsize', String(args.truncate_excess_vsize));
+      }
+      if (args.split_max_vsize) {
+        flags.push('--split-max-vsize', String(args.split_max_vsize));
+      }
+      return flags;
+    }
+  );
+
+  // Wallet decode-tx
+  createSimpleTool(
+    'wallet_decode_tx',
+    'Decode a transaction to view its details',
+    ['wallet', 'decode-tx'],
+    {
+      type: 'object',
+      properties: {
+        tx_hex: { type: 'string', description: 'Transaction hex to decode' },
+        file: { type: 'string', description: 'Read transaction hex from file' },
+        raw: { type: 'boolean', description: 'Show raw JSON output' },
+      },
+    },
+    (args) => {
+      const flags: string[] = [];
+      if (args.file) {
+        flags.push('--file', String(args.file));
+      } else if (args.tx_hex) {
+        flags.push(String(args.tx_hex));
+      }
+      return flags;
+    }
+  );
+
+  // Wallet broadcast-tx
+  createPositionalTool(
+    'wallet_broadcast_tx',
+    'Broadcast a transaction',
+    ['wallet', 'broadcast-tx'],
+    ['tx_hex'],
+    {
+      type: 'object',
+      properties: {
+        tx_hex: { type: 'string', description: 'The transaction hex to broadcast' },
+      },
+      required: ['tx_hex'],
+    }
+  );
+
+  // Wallet estimate-fee
+  createSimpleTool(
+    'wallet_estimate_fee',
+    'Estimate the fee for a transaction',
+    ['wallet', 'estimate-fee'],
+    {
+      type: 'object',
+      properties: {
+        target: { type: 'number', description: 'The target number of blocks for confirmation', default: 6 },
+      },
+    }
+  );
+
+  // Wallet fee-rates
+  createSimpleTool(
+    'wallet_fee_rates',
+    'Get the current fee rates',
+    ['wallet', 'fee-rates'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  // Wallet sync
+  createSimpleTool(
+    'wallet_sync',
+    'Sync the wallet with the blockchain',
+    ['wallet', 'sync'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  // Wallet backup
+  createSimpleTool(
+    'wallet_backup',
+    'Backup the wallet',
+    ['wallet', 'backup'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+
+  // Wallet mnemonic
+  createSimpleTool(
+    'wallet_mnemonic',
+    'Get the mnemonic for the wallet',
+    ['wallet', 'mnemonic'],
+    {
+      type: 'object',
+      properties: {},
+    }
+  );
+}

--- a/alkanes-mcp-server/src/utils.ts
+++ b/alkanes-mcp-server/src/utils.ts
@@ -1,0 +1,69 @@
+/**
+ * Utility functions
+ */
+
+import { homedir } from 'os';
+import { resolve } from 'path';
+
+/**
+ * Expand ~ in file paths
+ */
+export function expandPath(path: string): string {
+  if (path.startsWith('~/')) {
+    return resolve(homedir(), path.slice(2));
+  }
+  if (path === '~') {
+    return homedir();
+  }
+  return path;
+}
+
+/**
+ * Sanitize file path to prevent directory traversal
+ */
+export function sanitizePath(path: string): string {
+  const expanded = expandPath(path);
+  const resolved = resolve(expanded);
+  
+  // Prevent directory traversal
+  if (resolved.includes('..')) {
+    throw new Error(`Invalid path: ${path}`);
+  }
+  
+  return resolved;
+}
+
+/**
+ * Build command arguments array from options object
+ */
+export function buildArgs(options: Record<string, unknown>): string[] {
+  const args: string[] = [];
+
+  for (const [key, value] of Object.entries(options)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    const flag = `--${key.replace(/_/g, '-')}`;
+
+    if (typeof value === 'boolean') {
+      if (value) {
+        args.push(flag);
+      }
+    } else if (typeof value === 'string') {
+      args.push(flag, value);
+    } else if (typeof value === 'number') {
+      args.push(flag, value.toString());
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item === 'string') {
+          args.push(flag, item);
+        }
+      }
+    } else {
+      args.push(flag, JSON.stringify(value));
+    }
+  }
+
+  return args;
+}

--- a/alkanes-mcp-server/tsconfig.json
+++ b/alkanes-mcp-server/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022"],
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/crates/alkanes-cli/src/commands.rs
+++ b/crates/alkanes-cli/src/commands.rs
@@ -139,6 +139,9 @@ pub enum Commands {
     /// ESPO subcommands (alkanes balance indexer with PostgreSQL backend)
     #[command(subcommand)]
     Espo(EspoCommands),
+    /// MCP server management
+    #[command(subcommand)]
+    Mcp(McpCommands),
     /// Decode a PSBT (Partially Signed Bitcoin Transaction) without calling bitcoind
     Decodepsbt {
         /// PSBT as base64 string
@@ -2497,6 +2500,8 @@ impl Commands {
             Commands::Subfrost(_) => false,
             // ESPO queries don't need wallet
             Commands::Espo(_) => false,
+            // MCP commands don't need wallet
+            Commands::Mcp(_) => false,
             // PSBT decoding doesn't need wallet
             Commands::Decodepsbt { .. } => false,
         }
@@ -2561,3 +2566,38 @@ impl WalletCommands {
     }
 }
 
+/// MCP server management subcommands
+#[derive(Subcommand, Debug, Clone, Serialize, Deserialize)]
+pub enum McpCommands {
+    /// Install and build the MCP server
+    Install {
+        /// Force reinstall even if already installed
+        #[arg(long)]
+        force: bool,
+    },
+    /// Generate MCP configuration from current CLI settings
+    Configure {
+        /// Output file path (default: ~/.cursor/mcp.json)
+        #[arg(long)]
+        output: Option<String>,
+        /// Environment name (default: current provider)
+        #[arg(long)]
+        environment: Option<String>,
+    },
+    /// Start the MCP server
+    Start {
+        /// Run in background
+        #[arg(long)]
+        background: bool,
+    },
+    /// Check MCP server status
+    Status,
+    /// Stop a running MCP server
+    Stop,
+    /// Complete setup (install + configure + verify)
+    Setup {
+        /// Force reinstall
+        #[arg(long)]
+        force: bool,
+    },
+}

--- a/crates/alkanes-cli/src/main.rs
+++ b/crates/alkanes-cli/src/main.rs
@@ -13,7 +13,8 @@ use serde_json::json;
 
 mod commands;
 mod pretty_print;
-use commands::{Alkanes, AlkanesExecute, Commands, DeezelCommands, MetashrewCommands, Protorunes, Runestone, WalletCommands, DataApiCommand, SubfrostCommands, OpiCommands};
+mod mcp;
+use commands::{Alkanes, AlkanesExecute, Commands, DeezelCommands, MetashrewCommands, Protorunes, Runestone, WalletCommands, DataApiCommand, SubfrostCommands, OpiCommands, McpCommands};
 use alkanes_cli_common::alkanes;
 use pretty_print::*;
 
@@ -80,6 +81,11 @@ async fn main() -> Result<()> {
         return execute_opi_command(&args, cmd.clone()).await;
     }
 
+    // Handle MCP commands early (they don't need the System trait)
+    if let Commands::Mcp(ref cmd) = args.command {
+        return execute_mcp_command(&args, cmd.clone()).await;
+    }
+
     // Convert DeezelCommands to Args
     let alkanes_args = alkanes_cli_common::commands::Args::from(&args);
 
@@ -122,6 +128,10 @@ async fn execute_command<T: System + SystemOrd + UtxoProvider>(system: &mut T, c
         Commands::Opi(_) => {
             // OPI is handled in main() because it doesn't need the System trait
             unreachable!("OPI commands should be handled in main()")
+        }
+        Commands::Mcp(_) => {
+            // MCP is handled in main() because it doesn't need the System trait
+            unreachable!("MCP commands should be handled in main()")
         }
         Commands::Subfrost(cmd) => execute_subfrost_command(system.provider(), cmd).await,
         Commands::Espo(cmd) => execute_espo_command(system.provider(), cmd.into()).await,
@@ -5367,6 +5377,33 @@ async fn execute_brc20prog_command<T: System>(system: &mut T, command: commands:
             Ok(())
         }
     }
+}
+
+async fn execute_mcp_command(args: &DeezelCommands, command: McpCommands) -> Result<()> {
+    use crate::mcp;
+    
+    match command {
+        McpCommands::Install { force } => {
+            mcp::install_mcp_server(force)?;
+        }
+        McpCommands::Configure { output, environment } => {
+            mcp::generate_mcp_config(args, output, environment)?;
+        }
+        McpCommands::Status => {
+            mcp::check_mcp_status()?;
+        }
+        McpCommands::Start { background: _ } => {
+            anyhow::bail!("MCP server start not yet implemented. The server is managed by Cursor.");
+        }
+        McpCommands::Stop => {
+            anyhow::bail!("MCP server stop not yet implemented. The server is managed by Cursor.");
+        }
+        McpCommands::Setup { force } => {
+            mcp::setup_mcp(args, force)?;
+        }
+    }
+    
+    Ok(())
 }
 
 async fn execute_espo_command(

--- a/crates/alkanes-cli/src/mcp.rs
+++ b/crates/alkanes-cli/src/mcp.rs
@@ -1,0 +1,434 @@
+//! MCP server management commands
+
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::str;
+
+use crate::commands::DeezelCommands;
+
+/// Get the absolute path to the current alkanes-cli binary
+pub fn get_cli_binary_path() -> Result<PathBuf> {
+    let exe_path = env::current_exe()
+        .context("Failed to get current executable path")?;
+    
+    // Canonicalize to get absolute path
+    let absolute_path = exe_path
+        .canonicalize()
+        .context("Failed to canonicalize executable path")?;
+    
+    Ok(absolute_path)
+}
+
+/// Get the workspace root directory (parent of crates/)
+pub fn get_workspace_root() -> Result<PathBuf> {
+    let current_dir = env::current_dir()?;
+    let mut path = current_dir.as_path();
+    
+    // Walk up the directory tree to find Cargo.toml with [workspace]
+    while let Some(parent) = path.parent() {
+        let cargo_toml = parent.join("Cargo.toml");
+        if cargo_toml.exists() {
+            let content = fs::read_to_string(&cargo_toml)?;
+            if content.contains("[workspace]") {
+                return Ok(parent.to_path_buf());
+            }
+        }
+        path = parent;
+    }
+    
+    // Fallback: assume we're in the workspace root
+    Ok(current_dir)
+}
+
+/// Get the MCP server directory path
+pub fn get_mcp_server_dir() -> Result<PathBuf> {
+    let workspace_root = get_workspace_root()?;
+    Ok(workspace_root.join("alkanes-mcp-server"))
+}
+
+/// Check if Node.js is installed
+pub fn check_nodejs() -> Result<bool> {
+    let output = Command::new("node")
+        .arg("--version")
+        .output();
+    
+    match output {
+        Ok(_) => Ok(true),
+        Err(_) => Ok(false),
+    }
+}
+
+/// Check if npm is installed
+pub fn check_npm() -> Result<bool> {
+    let output = Command::new("npm")
+        .arg("--version")
+        .output();
+    
+    match output {
+        Ok(_) => Ok(true),
+        Err(_) => Ok(false),
+    }
+}
+
+/// Install and build the MCP server
+pub fn install_mcp_server(force: bool) -> Result<()> {
+    println!("Installing MCP server...");
+    
+    // Check prerequisites
+    if !check_nodejs()? {
+        anyhow::bail!("Node.js is not installed. Please install Node.js first.");
+    }
+    
+    if !check_npm()? {
+        anyhow::bail!("npm is not installed. Please install npm first.");
+    }
+    
+    let mcp_dir = get_mcp_server_dir()?;
+    
+    if !mcp_dir.exists() {
+        anyhow::bail!("MCP server directory not found at: {}", mcp_dir.display());
+    }
+    
+    let dist_file = mcp_dir.join("dist").join("index.js");
+    if dist_file.exists() && !force {
+        println!("MCP server already built. Use --force to reinstall.");
+        return Ok(());
+    }
+    
+    // Run npm install
+    println!("Running npm install...");
+    let install_status = Command::new("npm")
+        .arg("install")
+        .current_dir(&mcp_dir)
+        .status()
+        .context("Failed to run npm install")?;
+    
+    if !install_status.success() {
+        anyhow::bail!("npm install failed");
+    }
+    
+    // Run npm run build
+    println!("Building MCP server...");
+    let build_status = Command::new("npm")
+        .arg("run")
+        .arg("build")
+        .current_dir(&mcp_dir)
+        .status()
+        .context("Failed to run npm run build")?;
+    
+    if !build_status.success() {
+        anyhow::bail!("npm run build failed");
+    }
+    
+    // Verify build succeeded
+    if !dist_file.exists() {
+        anyhow::bail!("Build failed: dist/index.js not found");
+    }
+    
+    println!("✓ MCP server installed and built successfully!");
+    Ok(())
+}
+
+/// Expand ~ in file paths
+fn expand_home(path: &str) -> PathBuf {
+    if path.starts_with("~/") {
+        if let Ok(home) = env::var("HOME") {
+            return PathBuf::from(home).join(&path[2..]);
+        }
+    }
+    PathBuf::from(path)
+}
+
+/// Generate MCP configuration from current CLI settings
+pub fn generate_mcp_config(
+    args: &DeezelCommands,
+    output: Option<String>,
+    environment: Option<String>,
+) -> Result<()> {
+    println!("Generating MCP configuration...");
+    
+    // Get paths
+    let cli_binary_path = get_cli_binary_path()?;
+    let mcp_dir = get_mcp_server_dir()?;
+    let mcp_server_path = mcp_dir.join("dist").join("index.js");
+    
+    if !mcp_server_path.exists() {
+        anyhow::bail!(
+            "MCP server not built. Run 'alkanes-cli mcp install' first."
+        );
+    }
+    
+    // Determine environment name
+    let env_name = environment.unwrap_or_else(|| args.provider.clone());
+    
+    // Build environment configuration
+    let mut env_config = json!({
+        "cli_path": cli_binary_path.to_string_lossy(),
+        "provider": args.provider,
+    });
+    
+    // Add optional fields
+    if let Some(wallet_file) = &args.wallet_file {
+        env_config["wallet_file"] = json!(wallet_file);
+    }
+    
+    if let Some(passphrase) = &args.passphrase {
+        // Use environment variable reference for security
+        env_config["passphrase"] = json!("${WALLET_PASSPHRASE}");
+    }
+    
+    if let Some(jsonrpc_url) = &args.jsonrpc_url {
+        env_config["jsonrpc_url"] = json!(jsonrpc_url);
+    }
+    
+    if let Some(data_api) = &args.data_api {
+        env_config["data_api"] = json!(data_api);
+    }
+    
+    if let Some(bitcoin_rpc_url) = &args.bitcoin_rpc_url {
+        env_config["bitcoin_rpc_url"] = json!(bitcoin_rpc_url);
+    }
+    
+    if let Some(esplora_api_url) = &args.esplora_api_url {
+        env_config["esplora_api_url"] = json!(esplora_api_url);
+    }
+    
+    if let Some(ord_server_url) = &args.ord_server_url {
+        env_config["ord_server_url"] = json!(ord_server_url);
+    }
+    
+    if let Some(metashrew_rpc_url) = &args.metashrew_rpc_url {
+        env_config["metashrew_rpc_url"] = json!(metashrew_rpc_url);
+    }
+    
+    if let Some(brc20_prog_rpc_url) = &args.brc20_prog_rpc_url {
+        env_config["brc20_prog_rpc_url"] = json!(brc20_prog_rpc_url);
+    }
+    
+    if let Some(opi_url) = &args.opi_url {
+        env_config["opi_url"] = json!(opi_url);
+    }
+    
+    if let Some(espo_rpc_url) = &args.espo_rpc_url {
+        env_config["espo_rpc_url"] = json!(espo_rpc_url);
+    }
+    
+    if let Some(titan_api_url) = &args.titan_api_url {
+        env_config["titan_api_url"] = json!(titan_api_url);
+    }
+    
+    if !args.jsonrpc_headers.is_empty() {
+        env_config["jsonrpc_headers"] = json!(args.jsonrpc_headers);
+    }
+    
+    if !args.opi_headers.is_empty() {
+        env_config["opi_headers"] = json!(args.opi_headers);
+    }
+    
+    // Build MCP server configuration
+    let env_name_for_key = env_name.clone();
+    let mcp_server_config = json!({
+        "environments": {
+            env_name_for_key: env_config
+        },
+        "default_environment": env_name,
+        "timeout_seconds": 600
+    });
+    
+    // Build the MCP client configuration entry
+    let mcp_client_entry = json!({
+        "command": "node",
+        "args": [mcp_server_path.to_string_lossy()],
+        "env": {
+            "MCP_SERVER_CONFIG": mcp_server_config.to_string(),
+            "WALLET_PASSPHRASE": args.passphrase.as_ref().map(|_| "${WALLET_PASSPHRASE}".to_string()).unwrap_or_else(|| "".to_string())
+        }
+    });
+    
+    // Determine output file path
+    let output_path = if let Some(output) = output {
+        expand_home(&output)
+    } else {
+        // Default to ~/.cursor/mcp.json
+        let home = env::var("HOME")
+            .context("HOME environment variable not set")?;
+        PathBuf::from(home).join(".cursor").join("mcp.json")
+    };
+    
+    // Create .cursor directory if it doesn't exist
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)
+            .context("Failed to create .cursor directory")?;
+    }
+    
+    // Read existing config or create new one
+    let mut config: Value = if output_path.exists() {
+        let content = fs::read_to_string(&output_path)
+            .context("Failed to read existing MCP config")?;
+        serde_json::from_str(&content)
+            .context("Failed to parse existing MCP config")?
+    } else {
+        json!({ "mcpServers": {} })
+    };
+    
+    // Merge alkanes-cli server entry
+    if let Some(mcp_servers) = config.get_mut("mcpServers") {
+        if let Some(servers) = mcp_servers.as_object_mut() {
+            servers.insert("alkanes-cli".to_string(), mcp_client_entry);
+        }
+    }
+    
+    // Write updated config
+    let config_json = serde_json::to_string_pretty(&config)
+        .context("Failed to serialize MCP config")?;
+    
+    fs::write(&output_path, config_json)
+        .context("Failed to write MCP config file")?;
+    
+    println!("✓ MCP configuration written to: {}", output_path.display());
+    println!("  Environment: {}", env_name);
+    println!("  CLI binary: {}", cli_binary_path.display());
+    
+    if args.passphrase.is_some() {
+        println!("  Note: Set WALLET_PASSPHRASE environment variable before using MCP server");
+    }
+    
+    Ok(())
+}
+
+/// Check MCP server status
+pub fn check_mcp_status() -> Result<()> {
+    println!("MCP Server Status");
+    println!("==================");
+    
+    // Check CLI binary
+    match get_cli_binary_path() {
+        Ok(path) => {
+            println!("✓ CLI binary: {}", path.display());
+            if !path.exists() {
+                println!("  ⚠ Warning: Binary path does not exist!");
+            }
+        }
+        Err(e) => {
+            println!("✗ Failed to get CLI binary path: {}", e);
+        }
+    }
+    
+    // Check MCP server
+    match get_mcp_server_dir() {
+        Ok(dir) => {
+            let dist_file = dir.join("dist").join("index.js");
+            if dist_file.exists() {
+                println!("✓ MCP server: {}", dist_file.display());
+            } else {
+                println!("✗ MCP server not built: {}", dist_file.display());
+                println!("  Run 'alkanes-cli mcp install' to build it");
+            }
+        }
+        Err(e) => {
+            println!("✗ Failed to get MCP server directory: {}", e);
+        }
+    }
+    
+    // Check Node.js
+    match check_nodejs() {
+        Ok(true) => {
+            let output = Command::new("node")
+                .arg("--version")
+                .output()
+                .ok();
+            if let Some(output) = output {
+                if let Ok(version) = str::from_utf8(&output.stdout) {
+                    println!("✓ Node.js: {}", version.trim());
+                }
+            }
+        }
+        Ok(false) => {
+            println!("✗ Node.js: Not installed");
+        }
+        Err(e) => {
+            println!("✗ Node.js check failed: {}", e);
+        }
+    }
+    
+    // Check npm
+    match check_npm() {
+        Ok(true) => {
+            let output = Command::new("npm")
+                .arg("--version")
+                .output()
+                .ok();
+            if let Some(output) = output {
+                if let Ok(version) = str::from_utf8(&output.stdout) {
+                    println!("✓ npm: {}", version.trim());
+                }
+            }
+        }
+        Ok(false) => {
+            println!("✗ npm: Not installed");
+        }
+        Err(e) => {
+            println!("✗ npm check failed: {}", e);
+        }
+    }
+    
+    // Check MCP config file
+    let home = env::var("HOME").ok();
+    if let Some(home) = home {
+        let config_path = PathBuf::from(home).join(".cursor").join("mcp.json");
+        if config_path.exists() {
+            println!("✓ MCP config: {}", config_path.display());
+            
+            // Try to read and show if alkanes-cli is configured
+            if let Ok(content) = fs::read_to_string(&config_path) {
+                if let Ok(config_json) = serde_json::from_str::<Value>(&content) {
+                    if let Some(servers) = config_json.get("mcpServers") {
+                        if let Some(alkanes_cli) = servers.get("alkanes-cli") {
+                            println!("  ✓ alkanes-cli server configured");
+                        } else {
+                            println!("  ⚠ alkanes-cli server not configured");
+                            println!("    Run 'alkanes-cli mcp configure' to configure it");
+                        }
+                    }
+                }
+            }
+        } else {
+            println!("✗ MCP config: Not found at {}", config_path.display());
+            println!("  Run 'alkanes-cli mcp configure' to create it");
+        }
+    }
+    
+    Ok(())
+}
+
+/// Complete setup (install + configure + verify)
+pub fn setup_mcp(args: &DeezelCommands, force: bool) -> Result<()> {
+    println!("Setting up MCP server...\n");
+    
+    // Step 1: Install
+    println!("[1/3] Installing MCP server...");
+    install_mcp_server(force)?;
+    println!();
+    
+    // Step 2: Configure
+    println!("[2/3] Configuring MCP server...");
+    generate_mcp_config(args, None, None)?;
+    println!();
+    
+    // Step 3: Verify
+    println!("[3/3] Verifying setup...");
+    check_mcp_status()?;
+    println!();
+    
+    println!("✓ MCP server setup complete!");
+    println!("\nNext steps:");
+    println!("1. Set WALLET_PASSPHRASE environment variable (if using passphrase)");
+    println!("2. Restart Cursor to load the MCP server");
+    println!("3. The alkanes-cli tools will be available in Cursor");
+    
+    Ok(())
+}

--- a/crates/alkanes-cli/src/mcp.rs
+++ b/crates/alkanes-cli/src/mcp.rs
@@ -229,23 +229,21 @@ pub fn generate_mcp_config(
         env_config["opi_headers"] = json!(args.opi_headers);
     }
     
-    // Build MCP server configuration
+    // Build environments JSON (as string for env var)
     let env_name_for_key = env_name.clone();
-    let mcp_server_config = json!({
-        "environments": {
-            env_name_for_key: env_config
-        },
-        "default_environment": env_name,
-        "timeout_seconds": 600
+    let environments = json!({
+        env_name_for_key: env_config
     });
-    
-    // Build the MCP client configuration entry
+
+    // Build the MCP client configuration entry with individual env keys
     let mcp_client_entry = json!({
         "command": "node",
         "args": [mcp_server_path.to_string_lossy()],
         "env": {
-            "MCP_SERVER_CONFIG": mcp_server_config.to_string(),
-            "WALLET_PASSPHRASE": args.passphrase.as_ref().map(|_| "${WALLET_PASSPHRASE}".to_string()).unwrap_or_else(|| "".to_string())
+            "environments": environments.to_string(),
+            "default_environment": env_name,
+            "timeout_seconds": "600",
+            "WALLET_PASSPHRASE": args.passphrase.as_ref().map(|_| "".to_string()).unwrap_or_else(|| "".to_string())
         }
     });
     
@@ -275,9 +273,17 @@ pub fn generate_mcp_config(
         json!({ "mcpServers": {} })
     };
     
-    // Merge alkanes-cli server entry
+    // Check for and fix legacy MCP_SERVER_CONFIG format
     if let Some(mcp_servers) = config.get_mut("mcpServers") {
         if let Some(servers) = mcp_servers.as_object_mut() {
+            if let Some(existing_alkanes) = servers.get("alkanes-cli") {
+                if let Some(existing_env) = existing_alkanes.get("env") {
+                    if existing_env.get("MCP_SERVER_CONFIG").is_some() {
+                        println!("⚠ Detected legacy MCP_SERVER_CONFIG format, migrating to individual env keys...");
+                        // The new entry will replace the old one below
+                    }
+                }
+            }
             servers.insert("alkanes-cli".to_string(), mcp_client_entry);
         }
     }


### PR DESCRIPTION
## Summary

- Add Model Context Protocol (MCP) server integration to alkanes-cli
- Add /esm/ endpoint for browser ES module imports  
- Support colon-separated arguments in alkanes simulate command
- Add automatic defaults and alkanesChangeAddress to TypeScript SDK
- Add testnet and regtest WASM indexers
- CI/CD improvements for pkg-alkanes-build project
- Various bug fixes and enhancements

### MCP Server Integration

This PR adds full MCP server support to enable alkanes-cli as an MCP tool provider in supported editors like Cursor.

**New MCP commands:**
- `alkanes-cli mcp install` - Install and build the MCP server
- `alkanes-cli mcp configure` - Generate MCP configuration from CLI settings
- `alkanes-cli mcp status` - Check server status and configuration
- `alkanes-cli mcp setup` - Complete automated setup (install + configure + verify)

**Features:**
- Node.js-based MCP server wrapping all alkanes-cli commands
- Automatic configuration generation from current CLI settings
- Support for multiple environments with configurable defaults
- Exposes Bitcoin, Alkanes, Protorunes, BRC20, and protocol tools to AI assistants

### Other Enhancements

- Browser ES module support via /esm/ endpoint
- Improved TypeScript SDK with automatic defaults
- Additional WASM builds for testnet and regtest
- Enhanced command parsing for colon-separated arguments

## Test plan

- [ ] Build and verify MCP server installation
- [ ] Test MCP configuration generation
- [ ] Verify all MCP tools are properly exposed
- [ ] Test browser ES module imports
- [ ] Verify TypeScript SDK changes
- [ ] Run existing test suites


🤖 Generated with [Claude Code](https://claude.com/claude-code)