### PR TITLE
Fix: Resolve to_addresses and change_address in presign reveal PSBT

### DIFF
--- a/crates/alkanes-cli-common/src/alkanes/execute.rs
+++ b/crates/alkanes-cli-common/src/alkanes/execute.rs
@@ -2606,8 +2606,10 @@ impl<'a> EnhancedAlkanesExecutor<'a> {
         let mut outputs = Vec::new();
 
         // Add recipient outputs
+        use crate::traits::AddressResolver;
         for to_addr in &params.to_addresses {
-            let addr = bitcoin::Address::from_str(to_addr)?
+            let resolved_addr = self.provider.resolve_all_identifiers(to_addr).await?;
+            let addr = bitcoin::Address::from_str(&resolved_addr)?
                 .require_network(self.provider.get_network())?;
             outputs.push(bitcoin::TxOut {
                 value: bitcoin::Amount::from_sat(546),
@@ -2628,7 +2630,8 @@ impl<'a> EnhancedAlkanesExecutor<'a> {
             WalletProvider::get_address(self.provider).await?
         };
 
-        let addr = bitcoin::Address::from_str(&change_addr_str)?
+        let resolved_change_addr = self.provider.resolve_all_identifiers(&change_addr_str).await?;
+        let addr = bitcoin::Address::from_str(&resolved_change_addr)?
             .require_network(self.provider.get_network())?;
 
         // Calculate reveal fee based on actual transaction size


### PR DESCRIPTION
## Problem

In `build_reveal_psbt_for_presign()`, both `to_addresses` and `change_address` parameters were being used directly with `Address::from_str()` without first resolving them through `resolve_all_identifiers()`.

This caused two issues:
1. Symbolic addresses (e.g., `'p2tr:0'`, `'p2wpkh:0'`) would fail to resolve properly
2. When passing explicit Bitcoin addresses from browser wallets, the addresses were not being resolved correctly, leading to funds being sent to incorrect outputs

## Root Cause

The `build_reveal_psbt_for_presign()` function in `/crates/alkanes-cli-common/src/alkanes/execute.rs` (lines 2609-2616 and 2631-2632) was inconsistent with other parts of the codebase that properly call `resolve_all_identifiers()` before parsing addresses:
- Alkanes change address handling (line 764)
- From addresses resolution (line 1002)
- Regular execution paths (lines 1338 and 1350)

## Solution

This PR adds address resolution through `resolve_all_identifiers()` to ensure consistency across the codebase.

### Changes:
- ✅ Added `use crate::traits::AddressResolver` import in the function
- ✅ Call `resolve_all_identifiers()` for each address in `to_addresses` before parsing
- ✅ Call `resolve_all_identifiers()` for `change_address` before parsing

## Testing

This fix was validated by testing BTC→frBTC wrapping with browser wallets (OYL wallet) on regtest network. Before this fix, transaction outputs were incorrectly going to the SDK's dummy wallet address instead of the user's addresses.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>