### PR TITLE
fix(ordinals): honor ordinals_strategy in alkanesExecuteWithStrings + split small inscribed UTXOs with extra clean inputs

### DIFF
--- a/crates/alkanes-cli-common/src/alkanes/execute.rs
+++ b/crates/alkanes-cli-common/src/alkanes/execute.rs
@@ -1072,18 +1072,65 @@ impl<'a> EnhancedAlkanesExecutor<'a> {
                             }
                         }
 
-                        // Build split transaction PSBT (alkane-aware)
-                        let (split_psbt_result, split_fee_result, clean_outpoints, alkane_outpoints) =
-                            self.build_split_psbt(&plans, &funding_utxos_with_txout, fee_rate_sat_vb, params, &split_utxo_alkanes).await?;
-
-                        // Replace inscribed UTXOs with clean UTXOs from split
-                        let mut new_outpoints = Vec::new();
+                        // Compute clean extras the split-tx may consume. A
+                        // UTXO is a valid extra if it's already in the
+                        // selected set (so we know its TxOut data), is NOT
+                        // inscribed (not in `plans`), and carries NO alkanes
+                        // (not in `per_utxo_alkanes` — spending it as a fee
+                        // input would burn user tokens).
+                        //
+                        // The split-tx pulls from this set as needed when
+                        // small inscribed UTXOs can't self-fund the split.
                         let inscribed_outpoints: std::collections::HashSet<OutPoint> =
                             plans.iter().map(|p| p.outpoint).collect();
+                        let alkane_outpoints_in_selection: std::collections::HashSet<OutPoint> =
+                            utxo_selection.per_utxo_alkanes.keys().copied().collect();
+                        let extra_funding_utxos: Vec<(OutPoint, TxOut)> = funding_utxos_with_txout
+                            .iter()
+                            .filter(|(op, _)| {
+                                !inscribed_outpoints.contains(op)
+                                    && !alkane_outpoints_in_selection.contains(op)
+                            })
+                            .cloned()
+                            .collect();
 
-                        // Keep non-inscribed UTXOs
+                        log::info!(
+                            "Split-tx extras candidates: {} clean UTXOs available (selected: {}, inscribed: {}, alkane-bearing: {})",
+                            extra_funding_utxos.len(),
+                            utxo_selection.outpoints.len(),
+                            inscribed_outpoints.len(),
+                            alkane_outpoints_in_selection.len(),
+                        );
+
+                        // Build split transaction PSBT (alkane-aware, extras-aware)
+                        let (
+                            split_psbt_result,
+                            split_fee_result,
+                            clean_outpoints,
+                            alkane_outpoints,
+                            consumed_extra_outpoints,
+                        ) = self.build_split_psbt(
+                            &plans,
+                            &funding_utxos_with_txout,
+                            &extra_funding_utxos,
+                            fee_rate_sat_vb,
+                            params,
+                            &split_utxo_alkanes,
+                        ).await?;
+
+                        // Replace inscribed UTXOs with clean UTXOs from split.
+                        // Also remove any extras consumed by the split — those
+                        // outpoints are now spent in the split tx and can't
+                        // appear in the main tx's input list.
+                        let consumed_extras_set: std::collections::HashSet<OutPoint> =
+                            consumed_extra_outpoints.iter().copied().collect();
+                        let mut new_outpoints = Vec::new();
+
+                        // Keep non-inscribed, non-consumed UTXOs
                         for outpoint in &utxo_selection.outpoints {
-                            if !inscribed_outpoints.contains(outpoint) {
+                            if !inscribed_outpoints.contains(outpoint)
+                                && !consumed_extras_set.contains(outpoint)
+                            {
                                 new_outpoints.push(*outpoint);
                             }
                         }
@@ -1114,8 +1161,13 @@ impl<'a> EnhancedAlkanesExecutor<'a> {
                             utxo_selection.per_utxo_alkanes.insert(*outpoint, alkanes.clone());
                         }
 
-                        log::info!("🔀 Split transaction built: {} clean BTC UTXOs + {} clean alkane UTXOs replace {} inscribed UTXOs",
-                            plans.len(), alkane_outpoints.len(), inscribed_outpoints.len());
+                        log::info!(
+                            "🔀 Split transaction built: {} clean BTC UTXOs + {} clean alkane UTXOs replace {} inscribed UTXOs ({} extras consumed)",
+                            plans.len(),
+                            alkane_outpoints.len(),
+                            inscribed_outpoints.len(),
+                            consumed_extras_set.len(),
+                        );
 
                         (Some(split_psbt_result), Some(split_fee_result), new_outpoints)
                     }
@@ -2645,23 +2697,44 @@ impl<'a> EnhancedAlkanesExecutor<'a> {
         Ok(tx)
     }
 
-    /// Build a split PSBT to protect inscribed UTXOs
+    /// Build a split PSBT to protect inscribed UTXOs.
     ///
-    /// Returns (split_psbt, split_fee, clean_outpoints)
-    /// The clean_outpoints are the UTXOs that can be used for funding after the split
-    /// Build a split PSBT that separates inscribed sats from clean sats.
-    /// When UTXOs being split carry alkanes, adds a protostone OP_RETURN to route
-    /// alkanes to dedicated clean alkane outputs (preventing alkane loss during split).
+    /// Inputs:
+    ///   - `plans`: per-inscribed-UTXO breakdown (safe + clean amounts).
+    ///   - `funding_utxos`: TxOut data for the inscribed inputs (used to look
+    ///     up scripts/values on the inputs being split).
+    ///   - `extra_funding_utxos`: clean (no inscriptions, no alkanes) UTXOs
+    ///     from elsewhere in the wallet that the builder may consume to cover
+    ///     fees or top up clean outputs that fall below dust. Pre-filtered by
+    ///     the caller — anything in here is safe to add as an additional input.
+    ///   - `split_utxo_alkanes`: alkane balances on inscribed UTXOs (for
+    ///     alkane-aware splits with OP_RETURN routing).
     ///
-    /// Returns: (psbt, fee, clean_btc_outpoints, clean_alkane_outpoints_with_balances)
+    /// Returns:
+    ///   - The split PSBT.
+    ///   - Estimated fee (sats).
+    ///   - Clean BTC outpoints from the split tx (one per plan + an optional
+    ///     consolidated extras-funded change output).
+    ///   - Clean alkane outpoints with their balances.
+    ///   - List of `extra_funding_utxos` outpoints that were consumed as
+    ///     additional inputs. The caller MUST remove these from the main tx's
+    ///     input list, since they're now spent in the split tx.
+    ///
+    /// Why extra_funding_utxos exists: most ordinal mints land on small
+    /// (~546-1500 sat) inscribed UTXOs because that minimizes inscriber cost.
+    /// Those UTXOs can't self-fund the split (safe output + clean output +
+    /// fee > utxo_value), so without external top-up, `Preserve` strategy
+    /// fails for the very inscribed UTXOs users actually hold. With external
+    /// top-up, small inscribed UTXOs split fine.
     async fn build_split_psbt(
         &mut self,
         plans: &[SplitPlan],
         funding_utxos: &[(OutPoint, TxOut)],
+        extra_funding_utxos: &[(OutPoint, TxOut)],
         fee_rate: f32,
         params: &EnhancedExecuteParams,
         split_utxo_alkanes: &alloc::collections::BTreeMap<OutPoint, Vec<(AlkaneId, u64)>>,
-    ) -> Result<(Psbt, u64, Vec<OutPoint>, Vec<(OutPoint, Vec<(AlkaneId, u64)>)>)> {
+    ) -> Result<(Psbt, u64, Vec<OutPoint>, Vec<(OutPoint, Vec<(AlkaneId, u64)>)>, Vec<OutPoint>)> {
         use bitcoin::transaction::Version;
 
         // Get safe address for split outputs
@@ -2686,6 +2759,10 @@ impl<'a> EnhancedAlkanesExecutor<'a> {
         let mut input_txouts = Vec::new();
         let mut clean_outpoints = Vec::new();
         let mut total_input_value = 0u64;
+        // Tracks how much each plan's clean output was inflated above its
+        // natural `clean_amount` (because the natural amount was below dust).
+        // The total inflation is owed to extras and pulled later.
+        let mut clean_topup_owed: u64 = 0;
 
         for (idx, plan) in plans.iter().enumerate() {
             // Find the TxOut for this input
@@ -2710,9 +2787,20 @@ impl<'a> EnhancedAlkanesExecutor<'a> {
                 script_pubkey: safe_address.script_pubkey(),
             });
 
-            // Clean output (funding sats go here)
+            // Clean output (funding sats from the inscribed UTXO go here).
+            // If the inscribed UTXO's clean remainder is below dust, top up
+            // to DUST_LIMIT — the missing sats come from extras. If the
+            // remainder is zero (utxo_value == safe_amount + 1 etc.), we
+            // still emit a dust output so the caller has a usable funding
+            // UTXO at the canonical odd-index position; same top-up logic.
+            let clean_value = if plan.clean_amount < DUST_LIMIT {
+                clean_topup_owed += DUST_LIMIT - plan.clean_amount;
+                DUST_LIMIT
+            } else {
+                plan.clean_amount
+            };
             outputs.push(TxOut {
-                value: bitcoin::Amount::from_sat(plan.clean_amount),
+                value: bitcoin::Amount::from_sat(clean_value),
                 script_pubkey: safe_address.script_pubkey(),
             });
 
@@ -2801,23 +2889,95 @@ impl<'a> EnhancedAlkanesExecutor<'a> {
                 aggregated_alkanes.len(), alkane_output_index);
         }
 
-        // Estimate fee (account for extra outputs if alkane-aware)
-        let estimated_vsize = 10 + (inputs.len() * 68) + (outputs.len() * 43);
-        let estimated_fee = (fee_rate * estimated_vsize as f32).ceil() as u64;
+        // Compute total output value already committed (alkane DUST_LIMIT
+        // outputs are the only non-OP_RETURN extras beyond the per-plan
+        // safe+clean pairs).
+        let total_output_value: u64 = outputs.iter()
+            .map(|o| o.value.to_sat())
+            .sum();
 
-        // Adjust the last clean BTC output to account for fee
-        // The last clean BTC output is at index (plans.len() * 2 - 1), before any alkane/OP_RETURN outputs
-        let last_clean_btc_idx = plans.len() * 2 - 1;
-        if let Some(last_clean_output) = outputs.get_mut(last_clean_btc_idx) {
-            if last_clean_output.value.to_sat() > estimated_fee + DUST_LIMIT {
-                last_clean_output.value = bitcoin::Amount::from_sat(
-                    last_clean_output.value.to_sat() - estimated_fee
-                );
-            } else {
-                return Err(AlkanesError::Wallet(
-                    "Not enough funds in split to cover fee".to_string()
-                ));
+        // Pull additional clean inputs (a) to cover any clean-output top-ups
+        // forced by below-dust inscribed UTXOs, (b) to cover the split-tx
+        // fee, and (c) to add a residual change output if the extras over-fund.
+        //
+        // We over-pull conservatively: each extra input adds ~68 vbytes which
+        // grows the fee, so the simplest correct approach is "add inputs
+        // until total_input_value >= total_output_value + fee_with_one_more_input,
+        // then iterate fee until stable." Two passes through extras at most.
+        let mut consumed_extras: Vec<OutPoint> = Vec::new();
+        let mut extras_iter = extra_funding_utxos.iter();
+
+        // Helper: recompute estimated fee based on current input/output counts.
+        // P2TR input: ~68 vbytes; P2TR output: ~43 vbytes; tx overhead: ~10 vbytes.
+        let recompute_fee = |inputs_len: usize, outputs_len: usize| -> u64 {
+            let vsize = 10 + inputs_len * 68 + outputs_len * 43;
+            (fee_rate * vsize as f32).ceil() as u64
+        };
+
+        // Initial fee estimate (no residual change output yet).
+        let mut estimated_fee = recompute_fee(inputs.len(), outputs.len());
+
+        // Required: total_input_value >= total_output_value + estimated_fee.
+        // Difference is what we must pull from extras (or from inscribed-UTXO
+        // headroom that isn't already accounted for in clean outputs).
+        //
+        // Inscribed UTXOs have already contributed `total_input_value` worth.
+        // Clean outputs were sized at (plan.clean_amount or DUST_LIMIT topup).
+        // If `clean_topup_owed > 0`, that headroom must come from extras too.
+        //
+        // Pull extras one at a time until satisfied.
+        loop {
+            let needed = total_output_value
+                .saturating_add(estimated_fee)
+                .saturating_sub(total_input_value);
+            if needed == 0 {
+                break;
             }
+
+            // Need more — try to pull next extra.
+            let Some((extra_op, extra_txout)) = extras_iter.next() else {
+                return Err(AlkanesError::Wallet(format!(
+                    "Not enough clean funds to split inscribed UTXOs: need {} more sats \
+                     (output total {} + fee {} - inscribed inputs {}). \
+                     Wallet has no additional clean UTXOs available — either fund the \
+                     wallet with more BTC or use --ordinals-strategy burn (destroys \
+                     inscriptions).",
+                    needed, total_output_value, estimated_fee, total_input_value
+                )));
+            };
+
+            inputs.push(bitcoin::TxIn {
+                previous_output: *extra_op,
+                script_sig: ScriptBuf::new(),
+                sequence: bitcoin::Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: bitcoin::Witness::new(),
+            });
+            input_txouts.push(extra_txout.clone());
+            total_input_value += extra_txout.value.to_sat();
+            consumed_extras.push(*extra_op);
+
+            // Recompute fee with the extra input.
+            estimated_fee = recompute_fee(inputs.len(), outputs.len());
+        }
+
+        // If extras over-funded, emit a residual change output so the
+        // surplus isn't burned as fee. Only emit once we know we have
+        // sufficient surplus to clear DUST_LIMIT after the marginal output's
+        // own fee cost (one extra output = ~43 vbytes).
+        let surplus = total_input_value - total_output_value - estimated_fee;
+        if surplus >= DUST_LIMIT + (fee_rate * 43.0).ceil() as u64 {
+            let residual_fee_delta = (fee_rate * 43.0).ceil() as u64;
+            let residual_value = surplus - residual_fee_delta;
+            outputs.push(TxOut {
+                value: bitcoin::Amount::from_sat(residual_value),
+                script_pubkey: safe_address.script_pubkey(),
+            });
+            estimated_fee += residual_fee_delta;
+            // Track this residual as a clean outpoint usable by the main tx.
+            clean_outpoints.push(OutPoint {
+                txid: bitcoin::Txid::from_byte_array([0u8; 32]), // placeholder, set below
+                vout: (outputs.len() - 1) as u32,
+            });
         }
 
         // Build the unsigned transaction
@@ -2853,13 +3013,18 @@ impl<'a> EnhancedAlkanesExecutor<'a> {
             outpoint.txid = txid;
         }
 
-        log::info!("Built split PSBT: {} inputs → {} outputs ({}+alkane:{}, fee: {} sats)",
-            plans.len(), psbt.unsigned_tx.output.len(),
-            plans.len() * 2, // safe+clean pairs
+        log::info!(
+            "Built split PSBT: {} inputs ({} inscribed + {} extras) → {} outputs (alkane:{}, top-up owed: {} sats, fee: {})",
+            psbt.unsigned_tx.input.len(),
+            plans.len(),
+            consumed_extras.len(),
+            psbt.unsigned_tx.output.len(),
             if has_alkanes { "1+OP_RETURN" } else { "0" },
-            estimated_fee);
+            clean_topup_owed,
+            estimated_fee,
+        );
 
-        Ok((psbt, estimated_fee, clean_outpoints, alkane_outpoints_with_balances))
+        Ok((psbt, estimated_fee, clean_outpoints, alkane_outpoints_with_balances, consumed_extras))
     }
 
     async fn build_commit_psbt(

--- a/crates/alkanes-cli-common/src/ordinals.rs
+++ b/crates/alkanes-cli-common/src/ordinals.rs
@@ -316,26 +316,19 @@ impl<'a, P: OrdProvider + EsploraProvider> OrdinalsHandler<'a, P> {
         outpoint: OutPoint,
         utxo_value: u64,
         inscriptions: &[InscriptionInfo],
-        fee_rate: f32,
+        _fee_rate: f32,
     ) -> Option<SplitPlan> {
         if inscriptions.is_empty() {
             return None;
         }
 
-        // Find the highest offset among all inscriptions
-        // We need to send all sats up to and including this sat to the safe output
         let max_offset = inscriptions.iter().map(|i| i.sat_offset).max().unwrap_or(0);
+        let safe_amount = (max_offset + 1).max(DUST_LIMIT);
 
-        // Safe amount = offset + 1 (because offset is 0-indexed)
-        // This ensures the inscribed sat goes to the first output (safe)
-        let safe_amount = max_offset + 1;
-
-        // Ensure safe amount is at least dust limit
-        let safe_amount = safe_amount.max(DUST_LIMIT);
-
-        // Calculate clean amount (remaining sats)
+        // Hard requirement: at least one sat past the inscription offset.
+        // Fee + dust top-up are handled by the split-tx builder via extra
+        // clean inputs from elsewhere in the wallet.
         if utxo_value <= safe_amount {
-            // Not enough sats after protecting inscriptions
             log::warn!(
                 "UTXO has {} sats but inscription at offset {} requires {} sats for safe output - cannot split",
                 utxo_value, max_offset, safe_amount
@@ -343,23 +336,11 @@ impl<'a, P: OrdProvider + EsploraProvider> OrdinalsHandler<'a, P> {
             return None;
         }
 
-        // Estimate split tx fee (1 input, 2 outputs, ~140 vB for p2tr)
-        let estimated_split_fee = (fee_rate * 140.0).ceil() as u64;
-
-        let clean_amount = utxo_value.saturating_sub(safe_amount).saturating_sub(estimated_split_fee);
-
-        // Ensure clean amount is at least dust limit + some buffer for actual funding
-        if clean_amount < DUST_LIMIT * 2 {
-            log::warn!(
-                "After protecting inscriptions and fees, only {} sats remain - not enough for funding",
-                clean_amount
-            );
-            return None;
-        }
+        let clean_amount = utxo_value - safe_amount;
 
         log::info!(
-            "Split plan: {} sats → safe({}) + clean({}) + fee(~{})",
-            utxo_value, safe_amount, clean_amount, estimated_split_fee
+            "Split plan: {} sats → safe({}) + clean({}) (extra inputs may be pulled to cover fee/dust)",
+            utxo_value, safe_amount, clean_amount
         );
 
         Some(SplitPlan {
@@ -763,12 +744,27 @@ pub async fn trace_pending_utxo_inscriptions_with_provider(
     Ok(traced_inscriptions)
 }
 
-/// Calculate how to split a UTXO to protect inscriptions (standalone function)
+/// Calculate how to split a UTXO to protect inscriptions (standalone function).
+///
+/// Returns the inscribed-UTXO breakdown only: safe (inscription) and clean
+/// (remainder). The split-tx builder is responsible for pulling additional
+/// clean inputs from elsewhere in the wallet to cover fees and dust thresholds —
+/// this function does NOT require the inscribed UTXO to self-fund the split.
+/// That requirement was overly strict: most ordinal mints land on small UTXOs
+/// (~546-1500 sats) precisely because that minimizes inscriber cost, leaving
+/// no headroom for both a safe output AND a usable clean output AND the
+/// split-tx fee. With external funding, those small inscribed UTXOs split
+/// fine.
+///
+/// The only hard requirement is `utxo_value > safe_amount` — there must be
+/// at least one sat past the inscription offset for the clean output to
+/// exist. If `clean_amount` ends up below dust, the builder will top it up
+/// from extra funding (and pay the fee from extras as well).
 pub fn calculate_split(
     outpoint: OutPoint,
     utxo_value: u64,
     inscriptions: &[InscriptionInfo],
-    fee_rate: f32,
+    _fee_rate: f32,
 ) -> Option<SplitPlan> {
     if inscriptions.is_empty() {
         return None;
@@ -785,20 +781,11 @@ pub fn calculate_split(
         return None;
     }
 
-    let estimated_split_fee = (fee_rate * 140.0).ceil() as u64;
-    let clean_amount = utxo_value.saturating_sub(safe_amount).saturating_sub(estimated_split_fee);
-
-    if clean_amount < DUST_LIMIT * 2 {
-        log::warn!(
-            "After protecting inscriptions and fees, only {} sats remain - not enough for funding",
-            clean_amount
-        );
-        return None;
-    }
+    let clean_amount = utxo_value - safe_amount;
 
     log::info!(
-        "Split plan: {} sats → safe({}) + clean({}) + fee(~{})",
-        utxo_value, safe_amount, clean_amount, estimated_split_fee
+        "Split plan: {} sats → safe({}) + clean({}) (extra inputs may be pulled to cover fee/dust)",
+        utxo_value, safe_amount, clean_amount
     );
 
     Some(SplitPlan {

--- a/crates/alkanes-web-sys/src/provider.rs
+++ b/crates/alkanes-web-sys/src/provider.rs
@@ -1084,7 +1084,7 @@ impl WebProvider {
             };
 
             // Parse options (from_addresses, change_address, etc.)
-            let (trace_enabled, mine_enabled, auto_confirm, raw_output, from_addresses, change_address, alkanes_change_address, split_transactions) = if let Some(opts_json) = &options_json {
+            let (trace_enabled, mine_enabled, auto_confirm, raw_output, from_addresses, change_address, alkanes_change_address, ordinals_strategy, mempool_indexer, split_transactions) = if let Some(opts_json) = &options_json {
                 let opts: serde_json::Value = serde_json::from_str(opts_json)
                     .map_err(|e| JsValue::from_str(&format!("Invalid options JSON: {}", e)))?;
 
@@ -1103,6 +1103,16 @@ impl WebProvider {
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
 
+                // Parse ordinals_strategy (mirrors alkanesExecuteFull). Without this,
+                // the field was hardcoded to Default::default() (= Exclude) and any
+                // browser caller passing "preserve" silently saw inscribed UTXOs
+                // reject the whole flow even when clean UTXOs were available.
+                let ord_strategy: alkanes_cli_common::alkanes::types::OrdinalsStrategy = opts.get("ordinals_strategy")
+                    .and_then(|v| serde_json::from_value(v.clone()).ok())
+                    .unwrap_or_default();
+
+                let mempool_idx = opts.get("mempool_indexer").and_then(|v| v.as_bool()).unwrap_or(false);
+
                 let split_tx = opts.get("split_transactions")
                     .or_else(|| opts.get("splitTransactions"))
                     .and_then(|v| v.as_bool())
@@ -1116,10 +1126,12 @@ impl WebProvider {
                     from_addrs,
                     change_addr,
                     alkanes_change_addr,
+                    ord_strategy,
+                    mempool_idx,
                     split_tx,
                 )
             } else {
-                (false, false, true, false, None, None, None, false)
+                (false, false, true, false, None, None, None, Default::default(), false, false)
             };
 
             let params = EnhancedExecuteParams {
@@ -1135,8 +1147,8 @@ impl WebProvider {
                 trace_enabled,
                 mine_enabled,
                 auto_confirm,
-                ordinals_strategy: Default::default(),
-                mempool_indexer: false,
+                ordinals_strategy,
+                mempool_indexer,
                 split_transactions,
                 known_pending_tx_hexes: Vec::new(),
             };


### PR DESCRIPTION
## Summary

Two related bugs preventing browser-wallet swaps/wraps when the user holds inscribed UTXOs in the same address as their clean BTC.

### 1. `alkanesExecuteWithStrings` was discarding `ordinals_strategy`

The WASM binding for browser-wallet flows hardcoded:

```rust
ordinals_strategy: Default::default(),  // = Exclude
mempool_indexer: false,
```

…regardless of what the JS caller passed in `options_json`. Its sibling binding `alkanesExecuteFull` already parses both fields correctly (line 1211-1215 in this file). This PR copies that pattern verbatim into `alkanesExecuteWithStrings`.

**Behavior change:** zero for callers that don't set `ordinals_strategy` (`unwrap_or_default()` preserves the previous `Exclude` default). Callers that DID set it — like the subfrost-appx browser-wallet flow passing `"preserve"` — now have it honored end-to-end.

### 2. `build_split_psbt` couldn't fund splits from external inputs

`Preserve` strategy is supposed to split inscribed UTXOs into a "safe" output (holding the inscription) and a "clean" output (used as funding). But the builder spent **only the inscribed UTXO** as its single input and tried to satisfy `safe_amount + clean_amount + fee` from that alone.

`calculate_split` enforced this upstream by returning `None` whenever `clean_amount < DUST_LIMIT * 2` (1092 sats). Most ordinal mints land on small inscribed UTXOs (~546–1500 sats) precisely because that minimizes inscriber cost — which means most user-held inscriptions trip this gate. Result was the misleading error:

> UTXO X contains inscriptions but cannot be safely split. Please use a different UTXO or use --ordinals-strategy burn.

…even when the wallet had thousands of clean sats sitting next door.

**Fix:**
- `calculate_split` now only requires `utxo_value > safe_amount` (one sat past the inscription offset). Fee + dust top-ups are the builder's responsibility.
- `build_split_psbt` accepts a new `extra_funding_utxos: &[(OutPoint, TxOut)]` param — clean (no inscriptions, no alkanes) UTXOs from elsewhere in the selected set that the builder may consume to cover fees and dust top-ups. Iterates inputs until `total_input_value >= total_output_value + estimated_fee`, recomputing the fee each iteration (each extra ~68 vbytes).
- Per-plan clean outputs that fall below `DUST_LIMIT` are topped up to 546 sats; the missing sats come from extras.
- When extras over-fund, emits a residual change output back to the safe address so surplus isn't burned as fee.
- Returns `consumed_extra_outpoints` so the caller removes them from the main tx's input list (otherwise the main tx would try to spend already-spent outpoints).

The caller in `EnhancedAlkanesExecutor::execute` pre-filters the selected UTXO set into clean extras (drops inscribed and alkane-bearing outpoints) and removes consumed extras from `new_outpoints` after the split builds.

When extras run out the builder errors with a clearer message that names the actual shortfall:

> Not enough clean funds to split inscribed UTXOs: need N more sats (output total X + fee Y - inscribed inputs Z). Wallet has no additional clean UTXOs available — either fund the wallet with more BTC or use --ordinals-strategy burn (destroys inscriptions).

## Why two changes in one PR

They're independent bug-fixes but symptomatic of the same scenario (browser-wallet user with mixed inscribed + clean UTXOs). Either alone would leave the user blocked:

- Just commit 1 → `Preserve` reaches the SDK, but small inscribed UTXOs still fail the dust-limit pre-check in `calculate_split`.
- Just commit 2 → split builder works correctly, but JS callers still can't request `Preserve` so the new code path is unreachable.

Happy to split into two PRs if you'd prefer.

## Test plan

- [x] `cargo check -p alkanes-web-sys --target wasm32-unknown-unknown` — clean (pre-existing 25 warnings, none new)
- [x] `wasm-pack build --target bundler --release` — clean, 11.1 MB optimized binary, new diagnostic strings present in the binary
- [x] Built tarball, installed in subfrost-appx (browser app), wired into UniSat taproot wallet
- [x] Mainnet wrap-swap submitted: tx [`5fce1c21…`](https://mempool.space/tx/5fce1c211135efe6e71f9e5debfd4c3796705d520f180f422db1684697b2c564) accepted into mempool. Selector picked a clean UTXO and skipped the inscription entirely — single-tx flow, no split needed. Confirms commit 1 is doing its job (no false rejection on the post-selection ord-check).
- [x] Existing `test_calculate_split_basic` and `test_sat_flow_calculation` still pass (they reproduce math inline rather than calling `calculate_split` directly; relaxed dust check doesn't change behavior for the 10000-sat fixture they use).
- [ ] An end-to-end test exercising the new "extras pulled" code path (split builder consuming additional clean inputs) would be ideal — happy to add in a follow-up if maintainers prefer, since the current test infrastructure is sparse around `build_split_psbt`.

## Backwards compatibility

- **API surface change:** `build_split_psbt` gains a new `extra_funding_utxos` parameter and an additional return tuple element (`consumed_extra_outpoints`). It's a private method on `EnhancedAlkanesExecutor`, called from exactly one place in this file — no external breakage.
- **JSON wire format:** unchanged. The fields parsed by commit 1 (`ordinals_strategy`, `mempool_indexer`) were already documented and parsed by `alkanesExecuteFull`; this PR brings `alkanesExecuteWithStrings` to parity.
- **Default behavior:** unchanged. `unwrap_or_default()` preserves the previous defaults for callers that don't set the new fields.

## Risk

Low. Both changes are additive on the success path. The split builder's extras-pulling loop is bounded by the size of `extra_funding_utxos` and recomputes the fee on each iteration. Worst case (extras exhausted before satisfying fee): we error with a more accurate message than the previous code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)