### PR TITLE
chore(web-sys): bump trigger to publish prefetched_utxos.alkanes SDK

### DIFF
--- a/crates/alkanes-web-sys/Cargo.toml
+++ b/crates/alkanes-web-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "alkanes-web-sys"
 version.workspace = true
 edition = "2021"
-# Rebuild trigger: walletSignPsbtBase64 for keystore RBF
+# Rebuild trigger: prefetched_utxos.alkanes — skip per-outpoint protorunesbyoutpoint fanout
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false


### PR DESCRIPTION
PR #256 merged the alkane-balance prefetch extension (\`PrefetchedUtxo.alkanes\`, \`build_prefetched_alkanes_map\`, short-circuits in both \`select_utxos\` fanouts) but the merge commit only touched \`crates/alkanes-cli-common/**\`, which falls outside the \`publish-npm.yml\` path filter (\`ts-sdk/**\`, \`crates/alkanes-web-sys/**\`, \`prod_wasms/**\`). The TS SDK CDN therefore still serves the pre-#256 build.

Bumping the rebuild trigger comment in \`crates/alkanes-web-sys/Cargo.toml\` so the path filter matches and the publish workflow fires, producing a fresh \`https://pkg.alkanes.build/dist/@alkanes/ts-sdk?v=0.1.5-<sha>\` build that includes the alkane prefetch.

No semantic change to web-sys itself — same pattern used in \`b0342a72\`, \`28cb1eaa\`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)