### PR TITLE
fix(ts-sdk): regenerate lockfile + build walletconnect subpath entry

### DIFF
--- a/ts-sdk/package-lock.json
+++ b/ts-sdk/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@alkanes/ts-sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkanes/ts-sdk",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.1.1",
+        "@subfrost/walletconnect": "file:../../subfrost-mobile/ts-sdk",
         "bip32": "^4.0.0",
         "bip39": "^3.1.0",
         "bitcoinjs-lib": "^6.1.7",
@@ -50,6 +51,26 @@
         "@oyl/sdk": {
           "optional": true
         }
+      }
+    },
+    "../../subfrost-mobile/ts-sdk": {
+      "name": "@subfrost/walletconnect",
+      "version": "0.1.0",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "walletconnect-cli": "bin/walletconnect-cli.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.5",
+        "@types/ws": "^8.5.13",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2066,6 +2087,10 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@subfrost/walletconnect": {
+      "resolved": "../../subfrost-mobile/ts-sdk",
+      "link": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/ts-sdk/package.json
+++ b/ts-sdk/package.json
@@ -44,7 +44,7 @@
     "build": "npm run build:wasm && npm run build:vendor && npm run build:ts && npm run build:cli",
     "build:wasm": "cd ../crates/alkanes-web-sys && wasm-pack build --target bundler --out-dir ../../ts-sdk/build/wasm && cd ../../ts-sdk && cp -r build/wasm/* wasm/",
     "build:vendor": "node scripts/vendor-wasms.js",
-    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:ts": "tsup src/index.ts src/walletconnect/index.ts --format cjs,esm --clean && printf 'export * from \"@subfrost/walletconnect\";\\n' > dist/walletconnect/index.d.ts",
     "build:cli": "tsup src/cli/index.ts --config none --format cjs --target node18 --platform node --out-dir dist --entry.cli=src/cli/index.ts --no-dts --external '../wasm/*' --external '@alkanes/ts-sdk/wasm' --external '*/wasm/*'",
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
     "cli:dev": "npm run build:cli && node dist/cli.js",

--- a/ts-sdk/tsup.config.ts
+++ b/ts-sdk/tsup.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  // `src/walletconnect/index.ts` is a thin re-export of
+  // `@subfrost/walletconnect` — it needs its own build entry so the
+  // `./walletconnect` subpath export declared in package.json resolves
+  // to a real `dist/walletconnect/index.{js,mjs}` file. tsup preserves
+  // the source-relative directory structure for array entries, so
+  // `src/walletconnect/index.ts` lands at `dist/walletconnect/index.*`
+  // automatically.
+  entry: ['src/index.ts', 'src/walletconnect/index.ts'],
   format: ['cjs', 'esm'],
   dts: false, // Disabled due to WASM module resolution issues - types available via source
   clean: true,


### PR DESCRIPTION
## Summary

Unblocks the `publish-npm.yml` workflow which has been failing since `e9ed0e03` ("feat(alkanes-cli): add wc subcommand + @alkanes/ts-sdk walletconnect re-export"), **and** produces the `dist/walletconnect/` output the package.json declares but the build never actually emitted.

## Lockfile mismatch

`e9ed0e03` added `"@subfrost/walletconnect": "file:../../subfrost-mobile/ts-sdk"` to `ts-sdk/package.json` but did not regenerate `ts-sdk/package-lock.json`. CI runs `npm ci` (lockfile-strict) and fails with:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
          package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: @subfrost/walletconnect@ from lock file
```

See failed run [26373690517](https://github.com/kungfuflex/alkanes-rs/actions/runs/26373690517). Last successful build was `?v=0.1.6-9b13d8e` (the commit immediately before `e9ed0e03`). Every push to develop since has either failed publish-npm or not retriggered it, because subsequent commits don't touch the workflow's watched paths.

**Fix**: ran `npm install --package-lock-only` from `ts-sdk/` (with `subfrost-mobile` checked out as a sibling so the `file:../..` path resolves), committing the resulting +27/-2 line lockfile delta.

## Missing build entry for walletconnect subpath

Separate latent bug also introduced by `e9ed0e03`: `package.json` declares an export at `"./walletconnect"` pointing to `./dist/walletconnect/index.{mjs,js,d.ts}`, but `tsup.config.ts` kept its original `entry: ['src/index.ts']` — and `build:ts` overrode it again with a positional `src/index.ts` arg. Result: even with the lockfile fix, the published tarball would have the export declaration but no actual files at that path. Consumers calling `import { WalletConnectSession } from '@alkanes/ts-sdk/walletconnect'` would error at module resolution.

**Fix**:
- `tsup.config.ts`: add `src/walletconnect/index.ts` as a second entry. tsup preserves source-relative directory structure for array entries, so the output lands at `dist/walletconnect/index.{js,mjs}` automatically.
- `package.json` `build:ts`: pass both entries on the CLI (positional args override the config's entry list, so both arrays need to match). Append a one-liner that writes `dist/walletconnect/index.d.ts` as a 41-byte type re-export shim — tsup has `dts: false` (existing reason: WASM module resolution), so `.d.ts` emission isn't automatic.

## Local verification

```bash
cd ts-sdk
rm -rf node_modules && npm ci                       # succeeds (was EUSAGE)
rm -rf dist && npm run build:ts                     # produces:
  # dist/index.{js,mjs}                  (existing 1.53 MB main bundle)
  # dist/walletconnect/index.{js,mjs}    (105 B / 1.03 KB re-export shim)
  # dist/walletconnect/index.d.ts        (41 B type re-export)
```

The walletconnect shim is just `export * from "@subfrost/walletconnect"` — no bundle bloat. `@subfrost/walletconnect` stays external per the existing `external`/`noExternal` config (it's not listed in `noExternal`).

## Out of scope

- No version bumps
- No changes to `src/walletconnect/index.ts` itself
- Pure "unblock CI + make the declared export resolve to real files"

## Test plan
- [ ] publish-npm CI run on this PR head succeeds
- [ ] After merge, `https://pkg.alkanes.build/dist/@alkanes/ts-sdk?v=0.1.6-<merge-sha>` 200's
- [ ] Tarball contains `dist/walletconnect/index.{js,mjs,d.ts}`
- [ ] Downstream consumer can `import { WalletConnectSession, DappRelay } from '@alkanes/ts-sdk/walletconnect'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)