### PR TITLE
feat(envelope): BIP-110-resistant hashlock deploy envelope

### DIFF
--- a/crates/alkanes-support/src/envelope.rs
+++ b/crates/alkanes-support/src/envelope.rs
@@ -12,6 +12,7 @@ use {
     bitcoin::psbt,
     bitcoin::script,
     bitcoin::script::Script,
+    bitcoin::hashes::{sha256, Hash},
     bitcoin::secp256k1::{Secp256k1, XOnlyPublicKey},
     bitcoin::taproot::{ControlBlock, LeafVersion, TaprootBuilder, TaprootSpendInfo},
     bitcoin::transaction::Transaction,
@@ -28,6 +29,18 @@ pub(crate) const PROTOCOL_ID: [u8; 3] = *b"BIN";
 pub(crate) const PROTOCOL_ID: [u8; 3] = *b"ZAK"; // Zcash Alkanes
 
 pub(crate) const BODY_TAG: [u8; 0] = [];
+
+/// Maximum size, in bytes, of a single witness stack element / data push under
+/// BIP-110 ("Reduced Data Temporary Softfork"). Hashlock preimages are chunked to
+/// this bound so a reveal stays consensus-valid if BIP-110 ever activates.
+pub const HASHLOCK_MAX_ELEMENT_SIZE: usize = 256;
+
+/// BIP-341 NUMS ("nothing-up-my-sleeve") x-only point. Used as the unspendable
+/// taproot internal key for hashlock commits so the only spend path is the leaf.
+pub(crate) const NUMS_INTERNAL_KEY: [u8; 32] = [
+    0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35, 0xe9, 0x7a, 0x5e,
+    0x07, 0x8a, 0x5a, 0x0f, 0x28, 0xec, 0x96, 0xd5, 0x47, 0xbf, 0xee, 0x9a, 0xce, 0x80, 0x3a, 0xc0,
+];
 
 pub type Result<T> = std::result::Result<T, script::Error>;
 pub type RawEnvelope = Envelope<Vec<Vec<u8>>>;
@@ -172,6 +185,80 @@ impl RawEnvelope {
         witness.push(script);
         witness.push([]);
         witness
+    }
+
+    /// Build a BIP-110-resistant "hashlock" reveal leaf for an already-compressed
+    /// payload, plus the ordered preimages (preimage `j` is the SHA256 preimage of
+    /// the `j`-th gate, in script order). The leaf is
+    /// `(OP_SHA256 <h> OP_EQUALVERIFY){n} <reveal_key> OP_CHECKSIG` — an HTLC-shaped
+    /// tapscript with no OP_IF and every push <= 256 bytes. No protocol marker is
+    /// embedded; the indexer recognises it structurally (see `crate::witness`).
+    pub fn hashlock_reveal_script(
+        compressed_payload: &[u8],
+        reveal_key: &XOnlyPublicKey,
+    ) -> (script::ScriptBuf, Vec<Vec<u8>>) {
+        let preimages: Vec<Vec<u8>> = compressed_payload
+            .chunks(HASHLOCK_MAX_ELEMENT_SIZE)
+            .map(|chunk| chunk.to_vec())
+            .collect();
+        let mut builder = script::Builder::new();
+        for preimage in &preimages {
+            let hash = sha256::Hash::hash(preimage);
+            builder = builder
+                .push_opcode(opcodes::all::OP_SHA256)
+                .push_slice::<&script::PushBytes>(
+                    hash.as_byte_array().as_slice().try_into().unwrap(),
+                )
+                .push_opcode(opcodes::all::OP_EQUALVERIFY);
+        }
+        builder = builder
+            .push_slice::<&script::PushBytes>(
+                reveal_key.serialize().as_slice().try_into().unwrap(),
+            )
+            .push_opcode(opcodes::all::OP_CHECKSIG);
+        (builder.into_script(), preimages)
+    }
+
+    pub(crate) fn nums_internal_key() -> XOnlyPublicKey {
+        XOnlyPublicKey::from_slice(&NUMS_INTERNAL_KEY).expect("valid NUMS x-only key")
+    }
+
+    /// Construct a complete Taproot script-path witness carrying `payload` via the
+    /// hashlock envelope. Mirrors `to_witness`: `should_compress` gzip-compresses the
+    /// payload first (the runtime expects a gzip stream). The signature slot is left
+    /// empty — sufficient for indexing/parsing; a real broadcaster must re-sign over
+    /// the taproot sighash.
+    pub fn hashlock_witness(payload: Vec<u8>, should_compress: bool) -> Result<Witness> {
+        let compressed = if should_compress {
+            compress(payload).map_err(|_| script::Error::EarlyEndOfScript)?
+        } else {
+            payload
+        };
+        let internal_key = Self::nums_internal_key();
+        // Disguise/spend key; not required to be spendable for indexing purposes.
+        let reveal_key = internal_key;
+        let (leaf, preimages) = Self::hashlock_reveal_script(&compressed, &reveal_key);
+
+        let secp = Secp256k1::new();
+        let spend_info = TaprootBuilder::new()
+            .add_leaf(0, leaf.clone())
+            .map_err(|_| script::Error::EarlyEndOfScript)?
+            .finalize(&secp, internal_key)
+            .map_err(|_| script::Error::EarlyEndOfScript)?;
+        let control_block = spend_info
+            .control_block(&(leaf.clone(), LeafVersion::TapScript))
+            .ok_or(script::Error::EarlyEndOfScript)?;
+
+        let mut witness = Witness::new();
+        // Stack inputs, bottom-first: the signature, then the preimages in reverse
+        // script order (the LIFO stack feeds the first SHA256 gate from the top).
+        witness.push([]); // empty signature placeholder
+        for preimage in preimages.iter().rev() {
+            witness.push(preimage);
+        }
+        witness.push(leaf.as_bytes());
+        witness.push(control_block.serialize());
+        Ok(witness)
     }
     
     /// Create a scriptSig envelope (for Zcash/Dogecoin-style inscriptions)

--- a/crates/alkanes-support/src/witness.rs
+++ b/crates/alkanes-support/src/witness.rs
@@ -1,19 +1,200 @@
 use crate::envelope::RawEnvelope;
+use bitcoin::blockdata::opcodes;
+use bitcoin::blockdata::script::{Instruction, Script};
 use bitcoin::blockdata::transaction::Transaction;
+use bitcoin::blockdata::witness::Witness;
+use bitcoin::hashes::{sha256, Hash};
+use std::collections::HashMap;
 
+/// gzip stream magic. Alkanes payloads are always gzip-compressed before chunking,
+/// so this disambiguates a real hashlock/HTLC spend from a data envelope.
+const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
+
+/// Upper bound on hashlock gates parsed from a single leaf (DoS guard).
+const HASHLOCK_MAX_GATES: usize = 1 << 20;
+
+/// Extract the `i`-th contract payload carried in `tx`'s witnesses.
+///
+/// Recognises, in order:
+///   1. the legacy ord-style `OP_FALSE OP_IF <"BIN"> ... OP_ENDIF` envelope
+///      (grandfathered; may become unminable if BIP-110 activates), then
+///   2. the BIP-110-resistant hashlock envelope (see docs/OPERATION-HASHLOCK).
+///
+/// Both return the still-gzip-compressed payload; callers decompress. Back-compatible:
+/// when only legacy envelopes are present this returns exactly what it always did.
 pub fn find_witness_payload(tx: &Transaction, i: usize) -> Option<Vec<u8>> {
-    let envelopes = RawEnvelope::from_transaction(tx);
-    if envelopes.len() <= i {
-        None
-    } else {
-        Some(
-            envelopes[i]
+    let mut payloads: Vec<Vec<u8>> = RawEnvelope::from_transaction(tx)
+        .into_iter()
+        .map(|envelope| {
+            envelope
                 .payload
-                .clone()
                 .into_iter()
                 .skip(1)
                 .flatten()
-                .collect(),
-        )
+                .collect::<Vec<u8>>()
+        })
+        .collect();
+    for input in &tx.input {
+        if let Some(payload) = parse_hashlock_witness(&input.witness) {
+            payloads.push(payload);
+        }
+    }
+    payloads.into_iter().nth(i)
+}
+
+/// Parse a single input's witness as a hashlock envelope, returning the reassembled
+/// (still-compressed) payload, or `None` if it is not a hashlock data carrier.
+fn parse_hashlock_witness(witness: &Witness) -> Option<Vec<u8>> {
+    let leaf = witness.tapscript()?;
+    let gates = match_hashlock_leaf(leaf)?;
+    // Map sha256(element) -> element over every witness stack element. The signature,
+    // leaf script and control block simply never match a gate hash and are ignored,
+    // which makes recovery independent of witness ordering, the annex, and the sig.
+    let mut by_hash: HashMap<[u8; 32], Vec<u8>> = HashMap::new();
+    for element in witness.iter() {
+        by_hash.insert(sha256::Hash::hash(element).to_byte_array(), element.to_vec());
+    }
+    let mut payload = Vec::new();
+    for gate in &gates {
+        payload.extend_from_slice(by_hash.get(gate)?);
+    }
+    if payload.len() >= 2 && payload[0..2] == GZIP_MAGIC {
+        Some(payload)
+    } else {
+        None
+    }
+}
+
+/// Match `(OP_SHA256 <32-byte> OP_EQUALVERIFY){n>=1} <32|33-byte> OP_CHECKSIG` and
+/// return the ordered 32-byte hash gates. Any deviation yields `None`.
+fn match_hashlock_leaf(script: &Script) -> Option<Vec<[u8; 32]>> {
+    let mut gates: Vec<[u8; 32]> = Vec::new();
+    let mut instructions = script.instructions();
+    loop {
+        match instructions.next() {
+            Some(Ok(Instruction::Op(op))) if op == opcodes::all::OP_SHA256 => {
+                let push = match instructions.next() {
+                    Some(Ok(Instruction::PushBytes(bytes))) if bytes.len() == 32 => bytes,
+                    _ => return None,
+                };
+                match instructions.next() {
+                    Some(Ok(Instruction::Op(op))) if op == opcodes::all::OP_EQUALVERIFY => {}
+                    _ => return None,
+                }
+                let mut gate = [0u8; 32];
+                gate.copy_from_slice(push.as_bytes());
+                gates.push(gate);
+                if gates.len() > HASHLOCK_MAX_GATES {
+                    return None;
+                }
+            }
+            Some(Ok(Instruction::PushBytes(bytes))) if bytes.len() == 32 || bytes.len() == 33 => {
+                // terminal `<pubkey> OP_CHECKSIG`
+                match instructions.next() {
+                    Some(Ok(Instruction::Op(op))) if op == opcodes::all::OP_CHECKSIG => {}
+                    _ => return None,
+                }
+                if instructions.next().is_some() {
+                    return None;
+                }
+                return if gates.is_empty() { None } else { Some(gates) };
+            }
+            _ => return None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{RawEnvelope, NUMS_INTERNAL_KEY};
+    use crate::gz::decompress;
+    use bitcoin::absolute::LockTime;
+    use bitcoin::secp256k1::XOnlyPublicKey;
+    use bitcoin::transaction::Version;
+    use bitcoin::{OutPoint, ScriptBuf, Sequence, Transaction, TxIn, Witness};
+
+    fn tx_with_witness(witness: Witness) -> Transaction {
+        Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness,
+            }],
+            output: vec![],
+        }
+    }
+
+    #[test]
+    fn hashlock_roundtrip_multi_chunk() {
+        // > 256 bytes so the payload spans several preimages.
+        let raw: Vec<u8> = (0..1000u32).map(|i| (i % 251) as u8).collect();
+        let witness = RawEnvelope::hashlock_witness(raw.clone(), true).unwrap();
+        let tx = tx_with_witness(witness);
+        let payload = find_witness_payload(&tx, 0).expect("hashlock payload");
+        assert_eq!(&payload[0..2], &GZIP_MAGIC);
+        assert_eq!(decompress(payload).unwrap(), raw);
+    }
+
+    #[test]
+    fn hashlock_roundtrip_chunk_boundaries() {
+        for len in [0usize, 1, 255, 256, 257, 512, 513] {
+            let raw: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+            let witness = RawEnvelope::hashlock_witness(raw.clone(), true).unwrap();
+            let tx = tx_with_witness(witness);
+            let payload =
+                find_witness_payload(&tx, 0).unwrap_or_else(|| panic!("len {len} not found"));
+            assert_eq!(decompress(payload).unwrap(), raw, "len {len}");
+        }
+    }
+
+    #[test]
+    fn hashlock_is_bip110_clean() {
+        let raw = vec![7u8; 1500];
+        let witness = RawEnvelope::hashlock_witness(raw, true).unwrap();
+        let elements: Vec<Vec<u8>> = witness.iter().map(|e| e.to_vec()).collect();
+        // layout: [sig, preimages.., leaf, control_block]
+        let leaf = Script::from_bytes(&elements[elements.len() - 2]);
+        for instruction in leaf.instructions() {
+            match instruction.unwrap() {
+                Instruction::Op(op) => {
+                    assert_ne!(op, opcodes::all::OP_IF);
+                    assert_ne!(op, opcodes::all::OP_NOTIF);
+                }
+                Instruction::PushBytes(bytes) => assert!(bytes.len() <= 256),
+            }
+        }
+        // every data stack element (everything but the leaf + control block) <= 256 bytes
+        for element in &elements[..elements.len() - 2] {
+            assert!(element.len() <= 256);
+        }
+    }
+
+    #[test]
+    fn real_htlc_is_not_recognized() {
+        // A genuine 1-hop hashlock whose preimage is NOT a gzip stream must not be
+        // mistaken for a data envelope.
+        let preimage = [0xABu8; 32];
+        let reveal_key = XOnlyPublicKey::from_slice(&NUMS_INTERNAL_KEY).unwrap();
+        let (leaf, _) = RawEnvelope::hashlock_reveal_script(&preimage, &reveal_key);
+        let mut witness = Witness::new();
+        witness.push([]);
+        witness.push(preimage);
+        witness.push(leaf.as_bytes());
+        witness.push([0u8; 33]); // dummy control block
+        let tx = tx_with_witness(witness);
+        assert!(find_witness_payload(&tx, 0).is_none());
+    }
+
+    #[test]
+    fn legacy_envelope_still_recognized() {
+        let raw: Vec<u8> = (0..600u32).map(|i| (i % 251) as u8).collect();
+        let witness = RawEnvelope::from(raw.clone()).to_witness(true);
+        let tx = tx_with_witness(witness);
+        let payload = find_witness_payload(&tx, 0).expect("legacy payload");
+        assert_eq!(decompress(payload).unwrap(), raw);
     }
 }

--- a/crates/alkanes/src/tests/hashlock.rs
+++ b/crates/alkanes/src/tests/hashlock.rs
@@ -1,0 +1,66 @@
+use crate::index_block;
+use crate::tests::helpers::{self as alkane_helpers};
+use crate::tests::std::alkanes_std_test_build;
+use alkane_helpers::clear;
+use alkanes_support::cellpack::Cellpack;
+use alkanes_support::gz::compress;
+use alkanes_support::id::AlkaneId;
+use anyhow::Result;
+use metashrew_core::index_pointer::IndexPointer;
+use metashrew_support::index_pointer::KeyValuePointer;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+fn read_alkane_binary(id: &AlkaneId) -> Vec<u8> {
+    IndexPointer::from_keyword("/alkanes/")
+        .select(&id.clone().into())
+        .get()
+        .as_ref()
+        .clone()
+}
+
+/// Find the block-2 alkane id that holds exactly `target` (the deployed contract's
+/// stored, compressed bytes), skipping genesis/reserved entries that occupy block 2.
+fn id_holding(target: &[u8]) -> Option<AlkaneId> {
+    for tx in 0u128..16 {
+        let id = AlkaneId { block: 2, tx };
+        if !target.is_empty() && read_alkane_binary(&id) == target {
+            return Some(id);
+        }
+    }
+    None
+}
+
+/// A contract deployed via the BIP-110-resistant hashlock envelope must be indexed and
+/// stored byte-for-byte identically to one deployed via the legacy OP_FALSE OP_IF
+/// envelope. Drives the in-memory (qubitcoin-backed) indexer end to end. Opcode 0 is the
+/// test contract's `initialize` (a clean success); the deploy persists only if the
+/// witness payload was extracted and decompressed correctly.
+#[wasm_bindgen_test]
+fn test_hashlock_deploy_parity() -> Result<()> {
+    let block_height = 0;
+    let wasm = alkanes_std_test_build::get_bytes();
+    let compressed = compress(wasm.clone())?;
+    let cellpack = Cellpack {
+        target: AlkaneId { block: 1, tx: 0 },
+        inputs: vec![0],
+    };
+
+    // Legacy envelope deploy — locate the id holding the contract's compressed bytes.
+    clear();
+    let legacy_block = alkane_helpers::init_test_with_cellpack(cellpack.clone());
+    index_block(&legacy_block, block_height)?;
+    let deployed_id = id_holding(&compressed)
+        .expect("legacy deploy did not persist the contract bytes in block 2");
+
+    // Hashlock envelope deploy, fresh state — same bytes must land at the same id.
+    clear();
+    let hashlock_block = alkane_helpers::init_test_with_cellpack_hashlock(cellpack);
+    index_block(&hashlock_block, block_height)?;
+
+    assert_eq!(
+        read_alkane_binary(&deployed_id),
+        compressed,
+        "hashlock deploy must store the contract's compressed bytes at {deployed_id:?}"
+    );
+    Ok(())
+}

--- a/crates/alkanes/src/tests/helpers.rs
+++ b/crates/alkanes/src/tests/helpers.rs
@@ -112,6 +112,22 @@ pub fn init_test_with_cellpack(cellpack: Cellpack) -> Block {
     test_block
 }
 
+/// Like `init_test_with_cellpack`, but carries the contract wasm through the
+/// BIP-110-resistant hashlock envelope instead of the legacy OP_FALSE OP_IF envelope.
+#[cfg(test)]
+pub fn init_test_with_cellpack_hashlock(cellpack: Cellpack) -> Block {
+    let block_height = 0;
+    let mut test_block = create_block_with_coinbase_tx(block_height);
+
+    let wasm_binary = alkanes_std_test_build::get_bytes();
+    let witness = RawEnvelope::hashlock_witness(wasm_binary, true).unwrap();
+
+    test_block
+        .txdata
+        .push(create_cellpack_with_witness(witness, cellpack));
+    test_block
+}
+
 /// A struct that combines a binary and its corresponding cellpack for cleaner initialization
 #[derive(Debug, Clone)]
 pub struct BinaryAndCellpack {

--- a/crates/alkanes/src/tests/mod.rs
+++ b/crates/alkanes/src/tests/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(any(feature = "test-utils", test))]
 pub mod helpers;
+#[cfg(test)]
+pub mod hashlock;
 // `diesel_divergence_repro` references symbols (`DieselEoa`,
 // `_test_only_max_supply`, `_test_only_number_diesel_mints`) that were
 // renamed/removed from `precompile_diesel.rs` after the v3 fastpath


### PR DESCRIPTION
Adds an **alternate** witness carrier for contract bytecode that survives BIP-110 ("Reduced Data Temporary Softfork") and is statically indistinguishable from an `n`-hash HTLC tapleaf. The legacy `OP_FALSE OP_IF` envelope is still recognised, so existing deployments are unaffected — this is purely an additional deploy path.

### Why
BIP-110 bans tapscripts that *execute* `OP_IF`/`OP_NOTIF` (regardless of result) and caps pushes/witness items at 256 bytes. The legacy ord-style envelope is `OP_FALSE OP_IF <"BIN"> … OP_ENDIF` in a P2TR tapleaf, so a reveal becomes unminable during the BIP-110 window. Already-deployed contracts are grandfathered.

### How
- **Leaf:** `(OP_SHA256 <h> OP_EQUALVERIFY){n} <pubkey> OP_CHECKSIG` — no `OP_IF`, every push ≤256 B. Data rides in the witness as the hashlock **preimages** (`gzip(wasm)` sliced into ≤256 B chunks). No protocol marker is injected anywhere; every hash is content-derived, so there's no constant value to blacklist.
- **Indexer:** `find_witness_payload` tries legacy first, then hashlock — structural template match + hash-match of witness elements (no execution), accepted iff the reassembled stream is gzip (`1f 8b`). Return type unchanged, so `vm/utils.rs` is untouched.
- Recognition of *intent* still comes from the create cellpack; the witness is only consulted on a create.

### Tests
- 6 `alkanes-support` unit tests: multi-chunk round-trip, chunk boundaries `{0,1,255,256,257,512,513}`, BIP-110 lint (no OP_IF, pushes ≤256), real-HTLC rejection, legacy back-compat.
- e2e `tests/hashlock.rs::test_hashlock_deploy_parity`: deploys the same wasm via legacy and via hashlock through the in-memory indexer and asserts byte-identical storage.

All green. Same change is on `kungfuflex/bip110` (off `v2.2.0-rc.8`). Full spec: `docs/OPERATION-HASHLOCK.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)