### PR TITLE
feat(ts-sdk): BIP-322 simple message signing & verification

### DIFF
--- a/ts-sdk/src/bip322/bip322.test.ts
+++ b/ts-sdk/src/bip322/bip322.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import * as bitcoin from 'bitcoinjs-lib';
+import * as ecc from '@bitcoinerlab/secp256k1';
+import { ECPairFactory } from 'ecpair';
+import {
+  bip322MessageHash,
+  signMessageSimple,
+  verifyMessageSimple,
+} from './index';
+
+bitcoin.initEccLib(ecc);
+const ECPair = ECPairFactory(ecc);
+const mainnet = bitcoin.networks.bitcoin;
+
+describe('BIP-322 message hash', () => {
+  // Message hashes from the BIP-322 test vectors (tx_hashes section).
+  it('matches the spec message hash for the empty string', () => {
+    expect(bip322MessageHash('').toString('hex')).toBe(
+      'c90c269c4f8fcbe6880f72a721ddfbf1914268a794cbb21cfafee13770ae19f1',
+    );
+  });
+  it('matches the spec message hash for "Hello World"', () => {
+    expect(bip322MessageHash('Hello World').toString('hex')).toBe(
+      'f0eb03b1a75ac6d9847f55c624a99169b5dccba2a31f5b23bea77ba270de0a7a',
+    );
+  });
+});
+
+describe('BIP-322 P2TR (official test vector)', () => {
+  // BIP-322 basic-test-vectors.json → simple[3] (P2TR, classic no-prefix format).
+  const wif = 'KyrSGCFPhqZMjCe5fNTYddiLMp4tMj4gLKuJ26TsB2rvr1VJGPbt';
+  const address = 'bc1pss0zhytly75awhm6x2hhvd5lnzv3vssgrf9axfheq8ldyzn88ges79fler';
+  const message = 'No prefix fallback';
+  const expectedSig =
+    'AUCJYOwOjxYAvatTAGYaVlNXBVyFuc4MwNQkOuK2tl8xhfKDONd0NjfYyNSYcRqeCp8hsAnCEPHAVEkO9h6vbQ/R';
+
+  const keyPair = ECPair.fromWIF(wif, mainnet);
+  const privHex = Buffer.from(keyPair.privateKey!).toString('hex');
+
+  it('verifies the exact spec signature', () => {
+    expect(verifyMessageSimple({ message, address, signature: expectedSig, network: mainnet })).toBe(true);
+  });
+
+  it('produces a signature that verifies (Schnorr aux is random, so bytes vary)', () => {
+    const sig = signMessageSimple({ message, address, privateKey: privHex, network: mainnet });
+    expect(verifyMessageSimple({ message, address, signature: sig, network: mainnet })).toBe(true);
+  });
+
+  it('rejects a tampered message', () => {
+    expect(verifyMessageSimple({ message: 'wrong', address, signature: expectedSig, network: mainnet })).toBe(false);
+  });
+});
+
+describe('BIP-322 P2WPKH round-trip', () => {
+  // The current spec vectors use the newer "smp"-prefixed encoding for
+  // P2WPKH; the ecosystem (UniSat/Xverse/etc.) uses the classic format we
+  // emit, so we assert an internal sign→verify round-trip here.
+  const wif = 'L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k';
+  const keyPair = ECPair.fromWIF(wif, mainnet);
+  const address = bitcoin.payments.p2wpkh({ pubkey: Buffer.from(keyPair.publicKey), network: mainnet }).address!;
+  const privHex = Buffer.from(keyPair.privateKey!).toString('hex');
+
+  it('signs and verifies "Hello World"', () => {
+    const sig = signMessageSimple({ message: 'Hello World', address, privateKey: privHex, network: mainnet });
+    expect(verifyMessageSimple({ message: 'Hello World', address, signature: sig, network: mainnet })).toBe(true);
+  });
+
+  it('rejects a different address', () => {
+    const other = ECPair.makeRandom({ network: mainnet });
+    const otherAddr = bitcoin.payments.p2wpkh({ pubkey: Buffer.from(other.publicKey), network: mainnet }).address!;
+    const sig = signMessageSimple({ message: 'auth', address, privateKey: privHex, network: mainnet });
+    expect(verifyMessageSimple({ message: 'auth', address: otherAddr, signature: sig, network: mainnet })).toBe(false);
+  });
+});
+
+describe('BIP-322 unsupported types', () => {
+  it('throws for a P2PKH (legacy) address', () => {
+    const keyPair = ECPair.makeRandom({ network: mainnet });
+    const address = bitcoin.payments.p2pkh({ pubkey: Buffer.from(keyPair.publicKey), network: mainnet }).address!;
+    const privHex = Buffer.from(keyPair.privateKey!).toString('hex');
+    expect(() => signMessageSimple({ message: 'x', address, privateKey: privHex, network: mainnet })).toThrow(/unsupported/i);
+  });
+});

--- a/ts-sdk/src/bip322/index.ts
+++ b/ts-sdk/src/bip322/index.ts
@@ -1,0 +1,299 @@
+/**
+ * BIP-322 "simple" message signing & verification.
+ *
+ * Implements the interoperable, ecosystem-standard "simple" signature format
+ * (base64 of the consensus-encoded `to_sign` witness stack, NO variant
+ * prefix) — the same shape UniSat / Xverse / OKX / Leather / Sparrow produce
+ * and verify. Covers the two address types the alkanes keystore derives:
+ *
+ *   - P2WPKH (BIP84, native segwit) — ECDSA, SIGHASH_ALL
+ *   - P2TR   (BIP86, taproot key-path) — Schnorr, SIGHASH_DEFAULT
+ *
+ * P2SH-P2WPKH, P2WSH multisig, and BIP322 FULL format are intentionally out
+ * of scope (throw). This is enough for wallet-auth "prove you control this
+ * address" flows.
+ *
+ * Reference: https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki
+ * Verified against the BIP-322 P2TR test vector (see bip322.test.ts).
+ */
+
+import * as bitcoin from 'bitcoinjs-lib';
+import * as ecc from '@bitcoinerlab/secp256k1';
+import { ECPairFactory, type ECPairInterface } from 'ecpair';
+
+bitcoin.initEccLib(ecc);
+const ECPair = ECPairFactory(ecc);
+
+const BIP322_TAG = 'BIP0322-signed-message';
+
+/** BIP-322 message hash: tagged hash "BIP0322-signed" of the raw message. */
+export function bip322MessageHash(message: string | Uint8Array): Buffer {
+  const tagHash = bitcoin.crypto.sha256(Buffer.from(BIP322_TAG, 'utf8'));
+  const msg = typeof message === 'string' ? Buffer.from(message, 'utf8') : Buffer.from(message);
+  return bitcoin.crypto.sha256(Buffer.concat([tagHash, tagHash, msg]));
+}
+
+/**
+ * Build the BIP-322 `to_spend` virtual transaction for a given
+ * scriptPubKey + message. Its txid is the prevout the `to_sign` tx spends.
+ */
+export function buildToSpend(scriptPubKey: Buffer, message: string | Uint8Array): bitcoin.Transaction {
+  const messageHash = bip322MessageHash(message);
+  const tx = new bitcoin.Transaction();
+  tx.version = 0;
+  tx.locktime = 0;
+  // scriptSig = OP_0 PUSH32[messageHash]
+  const scriptSig = bitcoin.script.compile([bitcoin.opcodes.OP_0, messageHash]);
+  tx.addInput(Buffer.alloc(32, 0), 0xffffffff, 0, scriptSig);
+  tx.addOutput(scriptPubKey, 0);
+  return tx;
+}
+
+/**
+ * Build the BIP-322 `to_sign` virtual transaction (unsigned). vin[0] spends
+ * to_spend:0; vout[0] is a zero-value OP_RETURN.
+ */
+export function buildToSign(toSpendTxid: string, scriptPubKey: Buffer): bitcoin.Transaction {
+  const tx = new bitcoin.Transaction();
+  tx.version = 0;
+  tx.locktime = 0;
+  const hash = Buffer.from(toSpendTxid, 'hex').reverse();
+  tx.addInput(hash, 0, 0);
+  // Track the prevout so callers can compute the sighash.
+  void scriptPubKey;
+  tx.addOutput(bitcoin.script.compile([bitcoin.opcodes.OP_RETURN]), 0);
+  return tx;
+}
+
+// --- Bitcoin CompactSize (varint) — hand-rolled to avoid a new dependency ---
+
+function encodeCompactSize(n: number): Buffer {
+  if (n < 0xfd) return Buffer.from([n]);
+  if (n <= 0xffff) {
+    const b = Buffer.alloc(3);
+    b[0] = 0xfd;
+    b.writeUInt16LE(n, 1);
+    return b;
+  }
+  if (n <= 0xffffffff) {
+    const b = Buffer.alloc(5);
+    b[0] = 0xfe;
+    b.writeUInt32LE(n, 1);
+    return b;
+  }
+  const b = Buffer.alloc(9);
+  b[0] = 0xff;
+  b.writeBigUInt64LE(BigInt(n), 1);
+  return b;
+}
+
+function readCompactSize(buf: Buffer, offset: number): { value: number; size: number } {
+  const first = buf[offset];
+  if (first < 0xfd) return { value: first, size: 1 };
+  if (first === 0xfd) return { value: buf.readUInt16LE(offset + 1), size: 3 };
+  if (first === 0xfe) return { value: buf.readUInt32LE(offset + 1), size: 5 };
+  return { value: Number(buf.readBigUInt64LE(offset + 1)), size: 9 };
+}
+
+/** Consensus-encode a witness stack (vector of byte vectors). */
+function encodeWitnessStack(items: Buffer[]): Buffer {
+  const parts: Buffer[] = [encodeCompactSize(items.length)];
+  for (const item of items) {
+    parts.push(encodeCompactSize(item.length));
+    parts.push(item);
+  }
+  return Buffer.concat(parts);
+}
+
+/** Decode a consensus-encoded witness stack. */
+function decodeWitnessStack(buf: Buffer): Buffer[] {
+  let offset = 0;
+  const count = readCompactSize(buf, offset);
+  offset += count.size;
+  const items: Buffer[] = [];
+  for (let i = 0; i < count.value; i++) {
+    const len = readCompactSize(buf, offset);
+    offset += len.size;
+    items.push(buf.subarray(offset, offset + len.value));
+    offset += len.value;
+  }
+  return items;
+}
+
+/** Address type this module can sign/verify. */
+export type Bip322AddressType = 'p2wpkh' | 'p2tr';
+
+function classifyScript(scriptPubKey: Buffer): Bip322AddressType {
+  // P2WPKH: OP_0 <20-byte>  → 0x00 0x14 ...
+  if (scriptPubKey.length === 22 && scriptPubKey[0] === 0x00 && scriptPubKey[1] === 0x14) {
+    return 'p2wpkh';
+  }
+  // P2TR: OP_1 <32-byte> → 0x51 0x20 ...
+  if (scriptPubKey.length === 34 && scriptPubKey[0] === 0x51 && scriptPubKey[1] === 0x20) {
+    return 'p2tr';
+  }
+  throw new Error(
+    'BIP-322: unsupported address type (only P2WPKH and P2TR key-path are supported)',
+  );
+}
+
+function addressToScriptPubKey(address: string, network: bitcoin.Network): Buffer {
+  return bitcoin.address.toOutputScript(address, network);
+}
+
+export interface SignMessageParams {
+  message: string | Uint8Array;
+  /** The address whose key signs. Determines the script type. */
+  address: string;
+  /** 33-byte compressed private key (hex or Buffer). */
+  privateKey: Buffer | string;
+  network: bitcoin.Network;
+}
+
+/**
+ * Produce a BIP-322 simple signature (base64) for a P2WPKH or P2TR address.
+ * The private key must correspond to `address` — this is asserted.
+ */
+export function signMessageSimple(params: SignMessageParams): string {
+  const { message, address, network } = params;
+  const privBuf = typeof params.privateKey === 'string'
+    ? Buffer.from(params.privateKey, 'hex')
+    : params.privateKey;
+  const keyPair = ECPair.fromPrivateKey(privBuf, { network });
+
+  const scriptPubKey = addressToScriptPubKey(address, network);
+  const type = classifyScript(scriptPubKey);
+
+  const toSpend = buildToSpend(scriptPubKey, message);
+  const toSign = buildToSign(toSpend.getId(), scriptPubKey);
+
+  let witness: Buffer[];
+  if (type === 'p2wpkh') {
+    // Assert the key matches the address.
+    const derived = bitcoin.payments.p2wpkh({ pubkey: keyPair.publicKey, network }).address;
+    if (derived !== address) {
+      throw new Error('BIP-322: private key does not match the P2WPKH address');
+    }
+    // P2WPKH BIP143 sighash — scriptCode is the P2PKH script for the pubkey hash.
+    const pubkeyHash = bitcoin.crypto.hash160(keyPair.publicKey);
+    const scriptCode = bitcoin.script.compile([
+      bitcoin.opcodes.OP_DUP,
+      bitcoin.opcodes.OP_HASH160,
+      pubkeyHash,
+      bitcoin.opcodes.OP_EQUALVERIFY,
+      bitcoin.opcodes.OP_CHECKSIG,
+    ]);
+    const sighash = toSign.hashForWitnessV0(
+      0,
+      scriptCode,
+      0,
+      bitcoin.Transaction.SIGHASH_ALL,
+    );
+    const sig = bitcoin.script.signature.encode(
+      Buffer.from(keyPair.sign(sighash)),
+      bitcoin.Transaction.SIGHASH_ALL,
+    );
+    witness = [sig, Buffer.from(keyPair.publicKey)];
+  } else {
+    // P2TR key-path — taproot-tweaked key, SIGHASH_DEFAULT, Schnorr.
+    const internalPubkey = Buffer.from(keyPair.publicKey.subarray(1, 33)); // x-only
+    const derived = bitcoin.payments.p2tr({ internalPubkey, network }).address;
+    if (derived !== address) {
+      throw new Error('BIP-322: private key does not match the P2TR address');
+    }
+    const tweaked = tweakSigner(keyPair, network);
+    const sighash = toSign.hashForWitnessV1(
+      0,
+      [scriptPubKey],
+      [0],
+      bitcoin.Transaction.SIGHASH_DEFAULT,
+    );
+    const sig = Buffer.from(tweaked.signSchnorr(sighash));
+    witness = [sig]; // SIGHASH_DEFAULT → no appended sighash byte
+  }
+
+  return encodeWitnessStack(witness).toString('base64');
+}
+
+export interface VerifyMessageParams {
+  message: string | Uint8Array;
+  address: string;
+  /** Base64 BIP-322 simple signature. */
+  signature: string;
+  network: bitcoin.Network;
+}
+
+/**
+ * Verify a BIP-322 simple signature for a P2WPKH or P2TR address.
+ * Returns false (never throws) on any malformed input or signature mismatch.
+ */
+export function verifyMessageSimple(params: VerifyMessageParams): boolean {
+  try {
+    const { message, address, signature, network } = params;
+    const scriptPubKey = addressToScriptPubKey(address, network);
+    const type = classifyScript(scriptPubKey);
+
+    const witness = decodeWitnessStack(Buffer.from(signature, 'base64'));
+    const toSpend = buildToSpend(scriptPubKey, message);
+    const toSign = buildToSign(toSpend.getId(), scriptPubKey);
+
+    if (type === 'p2wpkh') {
+      if (witness.length !== 2) return false;
+      const [sig, pubkey] = witness;
+      // The pubkey must hash to the address program.
+      const program = scriptPubKey.subarray(2); // 20-byte hash
+      if (!bitcoin.crypto.hash160(pubkey).equals(program)) return false;
+      const decoded = bitcoin.script.signature.decode(sig);
+      const scriptCode = bitcoin.script.compile([
+        bitcoin.opcodes.OP_DUP,
+        bitcoin.opcodes.OP_HASH160,
+        bitcoin.crypto.hash160(pubkey),
+        bitcoin.opcodes.OP_EQUALVERIFY,
+        bitcoin.opcodes.OP_CHECKSIG,
+      ]);
+      const sighash = toSign.hashForWitnessV0(
+        0,
+        scriptCode,
+        0,
+        decoded.hashType,
+      );
+      return ecc.verify(sighash, pubkey, decoded.signature);
+    }
+
+    // P2TR key-path
+    if (witness.length !== 1) return false;
+    const sig = witness[0];
+    // Signature is 64 bytes (SIGHASH_DEFAULT) or 65 (explicit sighash byte).
+    let hashType = bitcoin.Transaction.SIGHASH_DEFAULT;
+    let sig64 = sig;
+    if (sig.length === 65) {
+      hashType = sig[64];
+      sig64 = sig.subarray(0, 64);
+    } else if (sig.length !== 64) {
+      return false;
+    }
+    const outputKey = scriptPubKey.subarray(2); // 32-byte x-only tweaked key
+    const sighash = toSign.hashForWitnessV1(0, [scriptPubKey], [0], hashType);
+    return ecc.verifySchnorr(sighash, outputKey, sig64);
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Taproot key-path tweak (BIP341) — mirrors the SDK's PSBT taproot signer.
+// ---------------------------------------------------------------------------
+
+function tweakSigner(keyPair: ECPairInterface, network: bitcoin.Network): ECPairInterface {
+  let privateKey = keyPair.privateKey;
+  if (!privateKey) throw new Error('BIP-322: private key required for taproot signing');
+  // BIP341: negate the private key when the internal pubkey has odd y-parity.
+  if (keyPair.publicKey[0] === 0x03) {
+    privateKey = Buffer.from(ecc.privateNegate(privateKey));
+  }
+  const xOnly = keyPair.publicKey.subarray(1, 33);
+  const tweak = bitcoin.crypto.taggedHash('TapTweak', xOnly);
+  const tweakedPriv = ecc.privateAdd(privateKey, tweak);
+  if (!tweakedPriv) throw new Error('BIP-322: invalid tweaked private key');
+  return ECPair.fromPrivateKey(Buffer.from(tweakedPriv), { network });
+}

--- a/ts-sdk/src/client/keystore-signer.ts
+++ b/ts-sdk/src/client/keystore-signer.ts
@@ -33,6 +33,7 @@ import {
 import { Keystore, NetworkType } from '../types';
 import { KeystoreManager, DERIVATION_PATHS } from '../keystore';
 import { AddressType } from '../wallet';
+import { signMessageSimple } from '../bip322';
 
 // Initialize ECC
 bitcoin.initEccLib(ecc);
@@ -172,7 +173,35 @@ export class KeystoreSigner extends AlkanesSigner {
     return account.publicKey;
   }
 
+  /**
+   * Sign a message.
+   *
+   * `options.protocol`:
+   *   - `'bip322'` / `'bip322-simple'` — BIP-322 simple signature over the
+   *     signer's address (P2WPKH or P2TR key-path). Interoperable with
+   *     UniSat / Xverse / Sparrow and verifiable via `verifyMessageSimple`.
+   *   - `'ecdsa'` (default) — legacy raw ECDSA over sha256(message), base64.
+   *     NOT a standard Bitcoin signed message; kept for backward compat.
+   */
   async signMessage(message: string, options?: SignMessageOptions): Promise<string> {
+    const protocol = options?.protocol ?? 'ecdsa';
+
+    if (protocol === 'bip322' || protocol === 'bip322-simple') {
+      // Sign against the signer's own address so the script type matches.
+      const { address } = this.deriveAddressInfo(
+        this.addressType,
+        this.addressIndex,
+        0,
+      );
+      const node = this.getSigningNode(options?.address);
+      return signMessageSimple({
+        message,
+        address: options?.address ?? address,
+        privateKey: node.privateKey!,
+        network: this.bitcoinNetwork,
+      });
+    }
+
     const node = this.getSigningNode(options?.address);
     const keyPair = ECPair.fromPrivateKey(node.privateKey!, { network: this.bitcoinNetwork });
 

--- a/ts-sdk/src/index.ts
+++ b/ts-sdk/src/index.ts
@@ -322,6 +322,20 @@ export type {
   WalletOption,
 } from './client';
 
+// BIP-322 message signing / verification (simple format; P2WPKH + P2TR)
+export {
+  signMessageSimple,
+  verifyMessageSimple,
+  bip322MessageHash,
+  buildToSpend,
+  buildToSign,
+} from './bip322';
+export type {
+  Bip322AddressType,
+  SignMessageParams as Bip322SignMessageParams,
+  VerifyMessageParams as Bip322VerifyMessageParams,
+} from './bip322';
+
 // Storage and backup exports
 export {
   KeystoreStorage,


### PR DESCRIPTION
Adds interoperable BIP-322 "simple" signatures (base64 of the to_sign witness stack, no variant prefix — the format UniSat/Xverse/Sparrow use) for the two address types the keystore derives:

- P2WPKH (BIP84) — ECDSA, SIGHASH_ALL
- P2TR key-path (BIP86) — Schnorr, SIGHASH_DEFAULT, with the BIP341 tweak

New src/bip322/index.ts exports signMessageSimple / verifyMessageSimple plus the low-level bip322MessageHash / buildToSpend / buildToSign. Uses only existing deps (bitcoinjs-lib, ecpair, @bitcoinerlab/secp256k1); CompactSize is hand-rolled so no new dependency is added.

KeystoreSigner.signMessage now honors options.protocol: 'bip322' / 'bip322-simple' route through the new signer (against the signer's own address), 'ecdsa' (default) keeps the legacy raw-sha256 behavior for backward compat. Re-exported from the package root.

Verified against the official BIP-322 P2TR test vector (basic-test-vectors.json simple[3]) — signature verifies and the message hash matches the spec tx_hashes values (8/8 unit tests pass).