### PR TITLE
feat(alkanes-cli): `upload` — attest/verify a BuildInfo to the explorer (no curl)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ dependencies = [
  "async-trait",
  "bip39",
  "bitcoin 0.32.7",
+ "bytes",
  "chrono",
  "colored",
  "hex",
@@ -474,6 +475,7 @@ dependencies = [
  "smallvec",
  "tabled",
  "thiserror 1.0.69",
+ "tlsfetch-h2-client",
  "tokio",
  "url",
 ]
@@ -2082,6 +2084,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.17",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,7 +2418,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -2385,6 +2426,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitcoin"
@@ -3380,6 +3430,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version 0.4.1",
  "subtle",
@@ -3476,6 +3527,20 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -3711,6 +3776,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "educe"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3743,6 +3832,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -5944,6 +6035,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6044,6 +6144,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "papergrid"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6126,6 +6250,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -6227,12 +6361,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
+ "pkcs5",
  "spki",
 ]
 
@@ -6402,6 +6547,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6493,7 +6647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.2",
@@ -7070,6 +7224,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7323,6 +7491,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
+ "sha2",
  "signature",
  "spki",
  "subtle",
@@ -7416,6 +7585,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7487,12 +7665,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-rustcrypto"
+version = "0.0.2-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12052947763ab8515f753315357599e9b0b4dab3b8ba15f30f725fe6d025557"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "chacha20poly1305",
+ "crypto-common",
+ "der",
+ "digest 0.10.7",
+ "ecdsa",
+ "ed25519-dalek",
+ "hmac",
+ "p256",
+ "p384",
+ "paste",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "rsa",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "sec1",
+ "sha2",
+ "signature",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -8734,6 +8953,24 @@ dependencies = [
  "tokio",
  "wasm-bindgen-test",
  "web-time",
+]
+
+[[package]]
+name = "tlsfetch-h2-client"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "log",
+ "rcgen",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "rustls-rustcrypto",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-rustls",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -10893,10 +11130,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.17",
+ "time",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,11 @@ members = [
     "vendor/tlsfetch-events",
     "vendor/tlsfetch-transport",
     "vendor/tlsfetch-ws",
+    # Minimal native HTTP/2 client (tokio-rustls, server-auth) for the
+    # alkanes-cli reproducible-build `upload` path. Vendored + trimmed
+    # from kungfuflex/tlsfetch. Standalone: does NOT inherit tlsfetch's
+    # rustls/h2 [patch.crates-io] forks (no persona ClientHello here).
+    "vendor/tlsfetch-h2-client",
     "vendor/qubitcoin-crypto",
     "vendor/qubitcoin-primitives",
     "vendor/qubitcoin-serialize",

--- a/crates/alkanes-cli-common/src/buildinfo/mod.rs
+++ b/crates/alkanes-cli-common/src/buildinfo/mod.rs
@@ -6,6 +6,7 @@
 pub mod cli;
 pub mod formula;
 pub mod schema;
+pub mod upload;
 pub mod wasm;
 
 pub use schema::*;

--- a/crates/alkanes-cli-common/src/buildinfo/upload.rs
+++ b/crates/alkanes-cli-common/src/buildinfo/upload.rs
@@ -1,0 +1,175 @@
+//! Shared, transport-free types for the reproducible-build `upload` path.
+//!
+//! These structs mirror the explorer `/api/v1/<key>/{attest,verify}` request
+//! contract and know how to derive themselves from a [`BuildInfo`]. They carry
+//! NO HTTP dependency — the actual POST (via the vendored tlsfetch h2 client)
+//! lives in `alkanes-cli-sys` under a native feature gate, so `alkanes-web-sys`
+//! (which also depends on `alkanes-cli-common`) never pulls the client stack.
+
+use super::schema::BuildInfo;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Body for `POST /api/v1/<key>/attest` — record a human/CLI verdict for an
+/// alkane. `block`/`tx` are STRINGS (the explorer ingest rejects integers).
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct AttestRequest {
+    pub block: String,
+    pub tx: String,
+    pub wasm_sha256: String,
+    pub repo_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subdir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rustc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alkanes_rev: Option<String>,
+    pub verdict: String,
+    pub match_pct: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    /// The FULL BuildInfo, forward-compatible: the explorer ingest is being
+    /// extended to persist it. Sent now (ignored until that lands).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest: Option<Value>,
+}
+
+/// Body for `POST /api/v1/<key>/verify` — hand the verifier the full fixture set
+/// so it can rebuild + diff in-sandbox.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct VerifyRequest {
+    /// `block:tx`.
+    pub alkane: String,
+    pub repo_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subdir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rustc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alkanes_rev: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clang_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub home_dir: Option<String>,
+    /// crates.io-index-archive commit frozen to the build date (time-machine mode).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub freeze_commit: Option<String>,
+    /// The alkanes-rs (or template) git dep URL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_url: Option<String>,
+    /// `bare` | `rev` — how the git-dep source-id must be spelled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_source_form: Option<String>,
+    /// Extra build-env exports (`KEY=VALUE`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub build_env: Vec<String>,
+    /// A source typo that must be re-introduced to reproduce byte-exactly, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub typo_fix: Option<String>,
+    /// The full BuildInfo, forward-compatible (see `AttestRequest::manifest`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest: Option<Value>,
+}
+
+/// Split `block:tx` → (`"block"`, `"tx"`) strings; defaults `"0"`/`"0"`.
+fn split_id(id: Option<&str>) -> (String, String) {
+    id.and_then(|s| s.split_once(':'))
+        .map(|(b, t)| (b.to_string(), t.to_string()))
+        .unwrap_or_else(|| ("0".to_string(), "0".to_string()))
+}
+
+/// Best-effort alkanes-rs revision: an explicit git-dep on alkanes, else the
+/// build's own commit when the repo IS alkanes-rs.
+fn alkanes_rev(bi: &BuildInfo) -> Option<String> {
+    if let Some(gd) = bi
+        .git_deps
+        .iter()
+        .find(|g| g.url.contains("alkanes-rs") || g.url.contains("alkanes-runtime") || g.url.contains("/alkanes"))
+    {
+        return Some(gd.rev.clone());
+    }
+    if bi.source.repo.as_deref().map(|r| r.contains("alkanes-rs")).unwrap_or(false) {
+        return bi.source.commit.clone();
+    }
+    None
+}
+
+fn joined_note(bi: &BuildInfo) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(r) = &bi.result {
+        if let Some(n) = &r.note {
+            parts.push(n.clone());
+        }
+    }
+    parts.extend(bi.notes.iter().cloned());
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" | "))
+    }
+}
+
+impl AttestRequest {
+    /// Derive an attest body from a `BuildInfo`. `verdict`/`match_pct` come from
+    /// `result` when present; callers may override afterwards.
+    pub fn from_buildinfo(bi: &BuildInfo) -> Self {
+        let (block, tx) = split_id(bi.identity.alkane_id.as_deref());
+        let (verdict, match_pct) = bi
+            .result
+            .as_ref()
+            .map(|r| (r.verdict.clone(), r.normalized_match_pct))
+            .unwrap_or_else(|| ("verified".to_string(), 100.0));
+        AttestRequest {
+            block,
+            tx,
+            wasm_sha256: bi.identity.target_sha256.clone(),
+            repo_url: bi.source.repo.clone().unwrap_or_default(),
+            commit: bi.source.commit.clone(),
+            subdir: bi.source.subdir.clone(),
+            rustc: Some(bi.toolchain.rustc_version.clone()).filter(|s| !s.is_empty()),
+            alkanes_rev: alkanes_rev(bi),
+            verdict,
+            match_pct,
+            note: joined_note(bi),
+            manifest: serde_json::to_value(bi).ok(),
+        }
+    }
+}
+
+impl VerifyRequest {
+    /// Derive a verify body (full fixture set) from a `BuildInfo`.
+    pub fn from_buildinfo(bi: &BuildInfo) -> Self {
+        let git = bi
+            .git_deps
+            .iter()
+            .find(|g| g.url.contains("alkanes"))
+            .or_else(|| bi.git_deps.first());
+        VerifyRequest {
+            alkane: bi.identity.alkane_id.clone().unwrap_or_default(),
+            repo_url: bi.source.repo.clone().unwrap_or_default(),
+            commit: bi.source.commit.clone(),
+            package: bi.source.package.clone(),
+            subdir: bi.source.subdir.clone(),
+            rustc: Some(bi.toolchain.rustc_version.clone()).filter(|s| !s.is_empty()),
+            alkanes_rev: alkanes_rev(bi),
+            clang_version: bi.c_toolchain.as_ref().map(|c| c.version.clone()).filter(|s| !s.is_empty()),
+            home_dir: Some(bi.environment.home.clone()).filter(|s| !s.is_empty()),
+            freeze_commit: bi.registry.archive_commit.clone(),
+            git_url: git.map(|g| g.url.clone()),
+            git_source_form: git.map(|g| g.source_form.clone()),
+            build_env: bi.environment.build_env.clone(),
+            typo_fix: bi
+                .notes
+                .iter()
+                .find(|n| n.to_lowercase().contains("typo"))
+                .cloned(),
+            manifest: serde_json::to_value(bi).ok(),
+        }
+    }
+}

--- a/crates/alkanes-cli-sys/Cargo.toml
+++ b/crates/alkanes-cli-sys/Cargo.toml
@@ -27,6 +27,13 @@ tabled = { workspace = true }
 anyhow = { workspace = true }
 prost = { workspace = true }
 
+# ── native reproducible-build `upload` path (feature `attest-upload`) ──
+# Optional so the default build (and any non-native consumer) doesn't
+# pull the h2/TLS client. NO curl, NO reqwest — the vendored tlsfetch
+# h2 client does a plain server-auth h2 POST.
+tlsfetch-h2-client = { path = "../../vendor/tlsfetch-h2-client", optional = true }
+bytes = { version = "1", optional = true }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "io-util"] }
 
@@ -37,3 +44,9 @@ tokio = { workspace = true, features = ["macros", "rt", "sync"] }
 # Default-on persistent sqlite cache. Disable with `--no-default-features`.
 default = ["cache-sqlite"]
 cache-sqlite = ["alkanes-cli-common/cache-sqlite"]
+# Native reproducible-build `upload` path: POST a BuildInfo JSON to the
+# explorer `/api/v1/<key>/{attest,verify}` endpoints over the vendored
+# tlsfetch h2 client. Opt-in — enabled by the `alkanes-cli` binary, NOT
+# by `alkanes-web-sys` (which shares alkanes-cli-common but not this
+# crate), so the web build never pulls the HTTP/TLS stack.
+attest-upload = ["dep:tlsfetch-h2-client", "dep:bytes"]

--- a/crates/alkanes-cli-sys/src/attest_upload.rs
+++ b/crates/alkanes-cli-sys/src/attest_upload.rs
@@ -1,0 +1,121 @@
+//! The durable, no-curl `upload` path for the reproducible-build workbench.
+//!
+//! POSTs a [`BuildInfo`] JSON to the explorer as an attestation (default) or a
+//! full rebuild-verify request, over the vendored `tlsfetch-h2-client` (native
+//! HTTP/2 on tokio-rustls). NO curl, NO reqwest. Native-only — gated behind the
+//! `attest-upload` feature so `alkanes-web-sys` (which shares `alkanes-cli-common`
+//! but not this crate) never pulls the client stack.
+//!
+//! The shared request/response types live in `alkanes-cli-common` (transport-free);
+//! this module only adds the HTTP.
+
+use alkanes_cli_common::buildinfo::schema::BuildInfo;
+use alkanes_cli_common::buildinfo::upload::{AttestRequest, VerifyRequest};
+use anyhow::{anyhow, Context, Result};
+use bytes::Bytes;
+use std::time::Duration;
+use tlsfetch_h2_client::H2Client;
+
+/// Explorer basepath used when `--explorer-url` is omitted.
+pub const DEFAULT_EXPLORER_URL: &str = "https://explorer.subfrost.io";
+
+/// Load `build_info_path`, derive the attest (default) or verify body, and POST
+/// it to `<explorer_url>/api/v1/<api_key>/{attest,verify}`.
+pub async fn run_upload(
+    build_info_path: &str,
+    api_key: &str,
+    explorer_url: Option<&str>,
+    verify: bool,
+) -> Result<()> {
+    let raw = std::fs::read_to_string(build_info_path)
+        .with_context(|| format!("read BuildInfo JSON {build_info_path}"))?;
+    let bi: BuildInfo =
+        serde_json::from_str(&raw).with_context(|| "parse BuildInfo JSON".to_string())?;
+
+    let base = explorer_url.unwrap_or(DEFAULT_EXPLORER_URL).trim_end_matches('/');
+    let parsed = url::Url::parse(base).with_context(|| format!("parse explorer-url {base}"))?;
+    if parsed.scheme() != "https" {
+        return Err(anyhow!(
+            "explorer-url must be https (the h2 client is TLS-only): {base}"
+        ));
+    }
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| anyhow!("explorer-url has no host: {base}"))?
+        .to_string();
+    let port = parsed.port().unwrap_or(443);
+    let base_path = parsed.path().trim_end_matches('/'); // "" or "/subpath"
+    let action = if verify { "verify" } else { "attest" };
+    let path = format!("{base_path}/api/v1/{api_key}/{action}");
+
+    let (body_json, summary) = if verify {
+        let req = VerifyRequest::from_buildinfo(&bi);
+        let summary = format!("verify alkane={}", req.alkane);
+        (serde_json::to_vec(&req)?, summary)
+    } else {
+        let req = AttestRequest::from_buildinfo(&bi);
+        let summary = format!(
+            "attest {}:{} verdict={} match={:.1}%",
+            req.block, req.tx, req.verdict, req.match_pct
+        );
+        if req.repo_url.is_empty() {
+            return Err(anyhow!(
+                "BuildInfo has no source.repo — the explorer requires repo_url"
+            ));
+        }
+        (serde_json::to_vec(&req)?, summary)
+    };
+
+    let config =
+        tlsfetch_h2_client::server_auth_config().map_err(|e| anyhow!("build tls config: {e}"))?;
+    let client = H2Client::new(config, Duration::from_secs(45));
+    let headers = vec![
+        ("content-type".to_string(), "application/json".to_string()),
+        ("accept".to_string(), "application/json".to_string()),
+        (
+            "user-agent".to_string(),
+            format!("alkanes-cli/{}-buildinfo-upload", env!("CARGO_PKG_VERSION")),
+        ),
+    ];
+
+    // Redact the key in the logged URL.
+    eprintln!(
+        "[upload] POST https://{host}:{port}{base_path}/api/v1/<key>/{action}  ({summary}, {} bytes)",
+        body_json.len()
+    );
+
+    let resp = client
+        .post(&host, port, &path, &headers, Bytes::from(body_json))
+        .await
+        .map_err(|e| anyhow!("h2 POST to {host} failed: {e}"))?;
+
+    let body_str = String::from_utf8_lossy(&resp.body);
+    println!("{}", body_str.trim());
+
+    match resp.status {
+        200 | 201 => {
+            // For verify, surface a run_id if the server returned one.
+            if verify {
+                if let Some(run_id) = serde_json::from_str::<serde_json::Value>(&body_str)
+                    .ok()
+                    .and_then(|v| v.get("run_id").and_then(|r| r.as_str()).map(str::to_string))
+                {
+                    println!("verify run_id={run_id} (poll the explorer for the rebuild+diff result)");
+                }
+            }
+            println!("OK: upload accepted (HTTP {}) — {}", resp.status, summary);
+            Ok(())
+        }
+        401 | 403 => Err(anyhow!(
+            "FAIL: HTTP {} — the API key was rejected. Attest/verify is admin-gated: \
+             check the key is a valid `sfadm_…` admin key with attest rights.\nserver: {}",
+            resp.status,
+            body_str.trim()
+        )),
+        s => Err(anyhow!(
+            "FAIL: HTTP {} — upload rejected by the explorer.\nserver: {}",
+            s,
+            body_str.trim()
+        )),
+    }
+}

--- a/crates/alkanes-cli-sys/src/lib.rs
+++ b/crates/alkanes-cli-sys/src/lib.rs
@@ -15,6 +15,8 @@ use alkanes_cli_common::commands::*;
 pub mod utils;
 pub mod keystore;
 pub mod pretty_print;
+#[cfg(feature = "attest-upload")]
+pub mod attest_upload;
 use alkanes_cli_common::alkanes::AlkanesInspectConfig;
 use utils::*;
 use keystore::{KeystoreManager, KeystoreCreateParams};

--- a/crates/alkanes-cli/Cargo.toml
+++ b/crates/alkanes-cli/Cargo.toml
@@ -23,7 +23,7 @@ icmp = ["alkanes-cli-common/icmp"]
 sha2 = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 alkanes-cli-common = { path = "../alkanes-cli-common", features = ["std", "wc-signer", "wc-signer-native"] }
-alkanes-cli-sys = { path = "../alkanes-cli-sys" }
+alkanes-cli-sys = { path = "../alkanes-cli-sys", features = ["attest-upload"] }
 subfrost-wc = { path = "../../vendor/subfrost-wc", features = ["relay-client"] }
 async-trait = { workspace = true }
 dirs = "5.0"

--- a/crates/alkanes-cli/src/commands.rs
+++ b/crates/alkanes-cli/src/commands.rs
@@ -168,6 +168,23 @@ pub enum Commands {
     /// emit the canonical BuildInfo JSON. Offline unless fetching an on-chain target.
     #[command(subcommand)]
     BuildInfo(alkanes_cli_common::buildinfo::cli::BuildInfoCommands),
+    /// Upload a BuildInfo JSON to the explorer as an attestation (default) or a
+    /// full rebuild-verify request. POSTs over the vendored tlsfetch h2 client
+    /// (no curl, no reqwest). Attest is admin-gated (needs an `sfadm_…` key).
+    Upload {
+        /// Path to a BuildInfo JSON (as emitted by `build-info`).
+        build_info: String,
+        /// Explorer API key. `sfadm_…` admin key for attest/verify.
+        #[arg(long)]
+        api_key: String,
+        /// Explorer base URL. Defaults to https://explorer.subfrost.io.
+        #[arg(long)]
+        explorer_url: Option<String>,
+        /// Instead of attest, POST the full fixture set to `/verify` so the
+        /// server rebuilds + diffs in-sandbox.
+        #[arg(long)]
+        verify: bool,
+    },
 }
 
 /// Lua script subcommands
@@ -3349,6 +3366,8 @@ impl Commands {
             Commands::Decodepsbt { .. } => false,
             // build-info workbench doesn't need wallet
             Commands::BuildInfo(_) => false,
+            // upload just POSTs a JSON artifact — no wallet
+            Commands::Upload { .. } => false,
         }
     }
 }

--- a/crates/alkanes-cli/src/main.rs
+++ b/crates/alkanes-cli/src/main.rs
@@ -99,6 +99,19 @@ async fn main() -> Result<()> {
         .await;
     }
 
+    // Reproducible-build `upload` — POST a BuildInfo JSON to the explorer
+    // attest/verify endpoints over the vendored tlsfetch h2 client. No wallet /
+    // System needed, so handle it early too.
+    if let Commands::Upload { build_info, api_key, explorer_url, verify } = &args.command {
+        return alkanes_cli_sys::attest_upload::run_upload(
+            build_info,
+            api_key,
+            explorer_url.as_deref(),
+            *verify,
+        )
+        .await;
+    }
+
     // Convert DeezelCommands to Args
     let alkanes_args = alkanes_cli_common::commands::Args::from(&args);
 
@@ -157,6 +170,10 @@ async fn execute_command<T: System + SystemOrd + UtxoProvider>(system: &mut T, c
         Commands::BuildInfo(_) => {
             // build-info is handled in main() because it doesn't need the System trait
             unreachable!("BuildInfo commands should be handled in main()")
+        }
+        Commands::Upload { .. } => {
+            // upload is handled in main() because it doesn't need the System trait
+            unreachable!("Upload command should be handled in main()")
         }
         Commands::Subfrost(cmd) => execute_subfrost_command(system.provider(), cmd).await,
         Commands::Espo(cmd) => execute_espo_command(system.provider(), cmd.into()).await,

--- a/vendor/tlsfetch-h2-client/Cargo.toml
+++ b/vendor/tlsfetch-h2-client/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "tlsfetch-h2-client"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Minimal native HTTP/2 client over tokio-rustls (server-auth). Vendored from kungfuflex/tlsfetch (crates/tlsfetch-h2-client) for the alkanes-cli reproducible-build `upload` path. Trimmed: the PKCS#12/mTLS helper is dropped (not needed for attest/verify) and a `server_auth_config()` helper added. NO curl, NO reqwest."
+
+# Vendored, standalone (does NOT inherit the tlsfetch workspace's
+# [patch.crates-io] rustls/h2 forks): this consumer only does a plain
+# server-auth h2 POST and never touches the persona ClientHello mutator
+# or the SETTINGS-order hook, so stock `rustls` + stock `h2` are used.
+# If a future explorer endpoint fingerprint-gates the upload, swap this
+# for tlsfetch-common's persona `HttpClient` (which DOES require the
+# rustls-tlsfetch fork + a workspace [patch.crates-io] rustls = ...).
+
+[dependencies]
+h2 = "0.4"
+tokio = { version = "1", features = ["rt", "net", "io-util", "macros", "time", "sync"] }
+tokio-rustls = { version = "0.26", default-features = false }
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12"] }
+rustls-pki-types = { version = "1", features = ["web"] }
+# Pure-Rust CryptoProvider — installed explicitly via
+# `builder_with_provider` so the client never depends on a
+# process-global rustls default provider being present.
+rustls-rustcrypto = "0.0.2-alpha"
+webpki-roots = "0.26"
+http = "1"
+bytes = "1"
+thiserror = "2"
+log = "0.4"
+
+[dev-dependencies]
+rcgen = "0.14"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/vendor/tlsfetch-h2-client/src/lib.rs
+++ b/vendor/tlsfetch-h2-client/src/lib.rs
@@ -1,0 +1,268 @@
+//! `tlsfetch-h2-client` — minimal native HTTP/2 client over tokio-rustls.
+//!
+//! Vendored from `kungfuflex/tlsfetch` (`crates/tlsfetch-h2-client`) for the
+//! alkanes-cli reproducible-build `upload` path. Purpose-built for a one-shot
+//! POST → response round-trip against a public-internet, h2-speaking endpoint
+//! (e.g. `explorer.subfrost.io/api/v1/<key>/attest`). NO curl, NO reqwest.
+//!
+//! Differences from the upstream crate:
+//!   * The PKCS#12 / mTLS `config_from_pkcs12` helper is dropped — the attest
+//!     endpoint is bearer-key-gated, not client-cert-gated.
+//!   * A [`server_auth_config`] convenience is added: it installs the pure-Rust
+//!     `rustls-rustcrypto` CryptoProvider explicitly (via `builder_with_provider`)
+//!     so the client never relies on a process-global rustls default provider.
+//!
+//! This client does plain server-auth TLS (webpki roots) — it does NOT emit a
+//! persona/JA3 ClientHello. For the attest/verify endpoints that is sufficient
+//! (they gate on the admin bearer key, not on TLS fingerprint). If a future
+//! endpoint fingerprint-gates the POST, switch to `tlsfetch-common`'s persona
+//! `HttpClient` (which requires the `rustls-tlsfetch` fork + a workspace
+//! `[patch.crates-io] rustls = ...`).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use h2::client::SendRequest;
+use http::{HeaderMap, HeaderName, HeaderValue, Method, Request, Uri};
+use rustls::pki_types::ServerName;
+use rustls::{ClientConfig, RootCertStore};
+use thiserror::Error;
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+
+// ----- public types ---------------------------------------------------------
+
+/// Errors raised by the client. String-payload variants wrap
+/// underlying-crate errors without committing to their types at the
+/// public surface.
+#[derive(Debug, Error)]
+pub enum H2Error {
+    #[error("connect: {0}")]
+    Connect(String),
+    #[error("tls: {0}")]
+    Tls(String),
+    #[error("invalid DNS name: {0}")]
+    InvalidDnsName(String),
+    #[error("alpn mismatch (peer chose {got:?}, wanted h2)")]
+    AlpnMismatch { got: Option<Vec<u8>> },
+    #[error("h2 handshake: {0}")]
+    Handshake(String),
+    #[error("send: {0}")]
+    Send(String),
+    #[error("recv: {0}")]
+    Recv(String),
+    #[error("build request: {0}")]
+    BuildRequest(String),
+    #[error("timeout")]
+    Timeout,
+    #[error("rustls config: {0}")]
+    Config(String),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// A response from [`H2Client::post`]. Headers are flattened to a
+/// `(String, String)` vec so callers can scan for keys without
+/// depending on `http::HeaderMap`.
+#[derive(Debug, Clone)]
+pub struct H2Response {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Bytes,
+}
+
+impl H2Response {
+    /// Look up a header by (case-insensitive) name. Returns the first match.
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
+    }
+}
+
+/// The client. Cheap to clone (everything is `Arc`).
+#[derive(Clone)]
+pub struct H2Client {
+    config: Arc<ClientConfig>,
+    timeout: Duration,
+}
+
+impl H2Client {
+    /// Wrap a rustls `ClientConfig` so it can drive POSTs. ALPN `h2`
+    /// is forced on if the caller left `alpn_protocols` empty.
+    ///
+    /// `timeout` is the per-call deadline covering the whole
+    /// connect → handshake → send → drain pipeline.
+    pub fn new(mut config: ClientConfig, timeout: Duration) -> Self {
+        if config.alpn_protocols.is_empty() {
+            config.alpn_protocols = vec![b"h2".to_vec()];
+        }
+        Self {
+            config: Arc::new(config),
+            timeout,
+        }
+    }
+
+    /// POST `body` to `https://{host}:{port}{path}` and drain the response.
+    /// Headers are inserted as-is. The whole call is bounded by `timeout`.
+    pub async fn post(
+        &self,
+        host: &str,
+        port: u16,
+        path: &str,
+        headers: &[(String, String)],
+        body: Bytes,
+    ) -> Result<H2Response, H2Error> {
+        let fut = self.do_post(host, port, path, headers, body);
+        match tokio::time::timeout(self.timeout, fut).await {
+            Ok(res) => res,
+            Err(_) => Err(H2Error::Timeout),
+        }
+    }
+
+    async fn do_post(
+        &self,
+        host: &str,
+        port: u16,
+        path: &str,
+        headers: &[(String, String)],
+        body: Bytes,
+    ) -> Result<H2Response, H2Error> {
+        // 1. TCP connect.
+        let tcp = TcpStream::connect((host, port))
+            .await
+            .map_err(|e| H2Error::Connect(e.to_string()))?;
+        tcp.set_nodelay(true).map_err(H2Error::Io)?;
+
+        // 2. TLS handshake with ALPN h2.
+        let connector = TlsConnector::from(self.config.clone());
+        let server_name: ServerName<'static> = ServerName::try_from(host.to_string())
+            .map_err(|e| H2Error::InvalidDnsName(e.to_string()))?;
+        let tls = connector
+            .connect(server_name, tcp)
+            .await
+            .map_err(|e| H2Error::Tls(e.to_string()))?;
+
+        // Confirm ALPN landed on h2 (else the h2 codec would speak
+        // gibberish at an h1 peer).
+        let alpn = tls.get_ref().1.alpn_protocol().map(|s| s.to_vec());
+        if alpn.as_deref() != Some(b"h2") {
+            return Err(H2Error::AlpnMismatch { got: alpn });
+        }
+
+        // 3. h2 client handshake.
+        let (h2, h2_conn) = h2::client::handshake(tls)
+            .await
+            .map_err(|e| H2Error::Handshake(e.to_string()))?;
+
+        let conn_task = tokio::spawn(async move {
+            let _ = h2_conn.await;
+        });
+
+        // 4. Build + send the request, drain the response.
+        let resp = self.send_and_drain(h2, host, path, headers, body).await;
+
+        // 5. Let the connection driver exit cleanly (bounded).
+        let _ = tokio::time::timeout(Duration::from_secs(1), conn_task).await;
+
+        resp
+    }
+
+    async fn send_and_drain(
+        &self,
+        h2: SendRequest<Bytes>,
+        host: &str,
+        path: &str,
+        headers: &[(String, String)],
+        body: Bytes,
+    ) -> Result<H2Response, H2Error> {
+        let uri: Uri = format!("https://{}{}", host, path)
+            .parse()
+            .map_err(|e: http::uri::InvalidUri| H2Error::BuildRequest(e.to_string()))?;
+        let mut builder = Request::builder().method(Method::POST).uri(uri);
+        for (k, v) in headers {
+            let name = HeaderName::try_from(k.as_str())
+                .map_err(|e| H2Error::BuildRequest(format!("header name {k}: {e}")))?;
+            let val = HeaderValue::try_from(v.as_str())
+                .map_err(|e| H2Error::BuildRequest(format!("header value for {k}: {e}")))?;
+            builder = builder.header(name, val);
+        }
+        let req = builder
+            .body(())
+            .map_err(|e| H2Error::BuildRequest(e.to_string()))?;
+
+        let mut h2 = h2
+            .ready()
+            .await
+            .map_err(|e| H2Error::Send(format!("ready: {e}")))?;
+        let body_empty = body.is_empty();
+        let (response_fut, mut send_stream) = h2
+            .send_request(req, body_empty)
+            .map_err(|e| H2Error::Send(format!("send_request: {e}")))?;
+
+        if !body_empty {
+            send_stream
+                .send_data(body, true)
+                .map_err(|e| H2Error::Send(format!("send_data: {e}")))?;
+        }
+
+        let resp = response_fut
+            .await
+            .map_err(|e| H2Error::Recv(format!("response: {e}")))?;
+
+        let status = resp.status().as_u16();
+        let headers_out = flatten_headers(resp.headers());
+
+        let mut body_stream = resp.into_body();
+        let mut buf: Vec<u8> = Vec::with_capacity(1024);
+        while let Some(chunk) = body_stream.data().await {
+            let chunk = chunk.map_err(|e| H2Error::Recv(format!("body_chunk: {e}")))?;
+            let _ = body_stream.flow_control().release_capacity(chunk.len());
+            buf.extend_from_slice(&chunk);
+        }
+        let _trailers = body_stream.trailers().await.ok();
+
+        drop(body_stream);
+        drop(send_stream);
+        drop(h2);
+
+        Ok(H2Response {
+            status,
+            headers: headers_out,
+            body: Bytes::from(buf),
+        })
+    }
+}
+
+fn flatten_headers(map: &HeaderMap) -> Vec<(String, String)> {
+    let mut out = Vec::with_capacity(map.len());
+    for (k, v) in map.iter() {
+        if let Ok(s) = v.to_str() {
+            out.push((k.as_str().to_string(), s.to_string()));
+        }
+    }
+    out
+}
+
+/// A `RootCertStore` populated with the webpki-roots trust anchors —
+/// the standard public-internet trust set.
+pub fn webpki_root_store() -> RootCertStore {
+    let mut store = RootCertStore::empty();
+    store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    store
+}
+
+/// Build a server-auth-only `ClientConfig` (no client cert) that trusts the
+/// webpki public roots, installing the pure-Rust `rustls-rustcrypto`
+/// CryptoProvider explicitly so no process-global rustls default is required.
+pub fn server_auth_config() -> Result<ClientConfig, H2Error> {
+    let provider = Arc::new(rustls_rustcrypto::provider());
+    let config = ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| H2Error::Config(format!("protocol versions: {e}")))?
+        .with_root_certificates(webpki_root_store())
+        .with_no_client_auth();
+    Ok(config)
+}


### PR DESCRIPTION
Adds the missing **`upload`** half of the reproducible-build workbench (the `build-info`/`reverse`/`build`/`verify` stack + BuildInfo 1.0.0 schema landed in #287).

```
alkanes-cli upload <build-info.json> --api-key <KEY> [--explorer-url URL] [--verify]
```

- **Default = attest**: `POST <explorer-url>/api/v1/<KEY>/attest` with `{block,tx,wasm_sha256,repo_url,commit,subdir,rustc,alkanes_rev,verdict,match_pct,note,manifest}` derived from the BuildInfo. The **full BuildInfo rides as `manifest`** (forward-compatible — the ingest ignores it until the parent's persistence change lands).
- **`--verify`**: POSTs the full fixture set to `/verify` so the server rebuilds + diffs in-sandbox (surfaces a `run_id`).
- `--explorer-url` defaults to `https://explorer.subfrost.io`. `401/403` print a helpful admin-key message.

### Placement (web stays lean)
- Shared **transport-free** request types (`AttestRequest` / `VerifyRequest`, each with `from_buildinfo`) live in **alkanes-cli-common** (wasm-clean serde) — `alkanes-web-sys`, which also depends on cli-common, gains **no HTTP**.
- The HTTP lives in **alkanes-cli-sys** behind a **default-OFF `attest-upload`** feature (enabled only by the `alkanes-cli` binary) — the web build and `alkanes-contract-indexer` stay lean.

### HTTP client — NO curl, NO reqwest
POSTs over a vendored, trimmed tlsfetch h2 client (`vendor/tlsfetch-h2-client`, from `kungfuflex/tlsfetch`): a plain server-auth HTTP/2 client on `tokio-rustls`. It is **standalone** — it does NOT inherit tlsfetch's rustls/h2 `[patch.crates-io]` forks, so there is **zero patch surgery on the alkanes-rs workspace**. The attest endpoint is bearer-key-gated (not TLS-fingerprint-gated), so no persona ClientHello is needed — proven by a live 200. If a future endpoint fingerprint-gates the POST, swap in `tlsfetch-common`'s persona `HttpClient` (which does require the `rustls-tlsfetch` fork + a workspace rustls patch).

### Verified end-to-end
A real attest of **every** reproduced alkane against `explorer.subfrost.io` returns **HTTP 200** with `verified_via` set; a bad key returns **401** with the guidance message:

| alkane | verdict | HTTP |
|---|---|---|
| 2:0 | reproducible | 200 |
| 2:1–2:14 | reproducible | 200 |
| 2:15/2:16/4:797 | reproducible | 200 |
| 4:9200 | reproducible | 200 |
| 4:76 | verified (cross-host residual) | 200 |

### Tandem main PR
This PR targets **develop** (where #287 lives). A separate PR carries the build-info stack + this commit onto **main** (main lacks the build-info CLI). See that PR / the reviewer notes for the exact ancestry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)