### PR TITLE
feat: publish canonical marketplace commitments

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,25 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  marketplace-canonical-producer:
+    name: Marketplace canonical producer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@1.86.0
+      - name: Test canonical producer
+        run: cargo test -p alkanes-contract-indexer
+      - name: Test canonical transforms
+        run: cargo test -p alkanes-trace-transform --lib
+      - name: Check producer binaries
+        run: cargo check -p alkanes-contract-indexer --bins
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/crates/alkanes-contract-indexer/build.rs
+++ b/crates/alkanes-contract-indexer/build.rs
@@ -1,0 +1,42 @@
+use std::{env, path::Path, process::Command};
+
+fn valid_revision(value: &str) -> bool {
+    matches!(value.len(), 40 | 64)
+        && value
+            .as_bytes()
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+}
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=ALKANES_PRODUCER_REVISION");
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs/heads");
+    println!("cargo:rerun-if-changed=../../.git/packed-refs");
+
+    let revision = env::var("ALKANES_PRODUCER_REVISION").ok().or_else(|| {
+        let manifest_dir = env::var("CARGO_MANIFEST_DIR").ok()?;
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(Path::new(&manifest_dir))
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        String::from_utf8(output.stdout)
+            .ok()
+            .map(|value| value.trim().to_owned())
+    });
+
+    let revision = revision.unwrap_or_else(|| {
+        panic!(
+            "a pinned producer revision is required: build from Git or set ALKANES_PRODUCER_REVISION"
+        )
+    });
+    if !valid_revision(&revision) {
+        panic!("ALKANES_PRODUCER_REVISION must be 40 or 64 lowercase hexadecimal characters");
+    }
+    println!("cargo:rustc-env=ALKANES_PRODUCER_REVISION={revision}");
+}

--- a/crates/alkanes-contract-indexer/src/canonical_commit.rs
+++ b/crates/alkanes-contract-indexer/src/canonical_commit.rs
@@ -1,0 +1,1742 @@
+//! Fail-closed publication boundary for Marketplace-consumable Alkanes state.
+//!
+//! The legacy indexer writes several derived tables in independent transactions.  A row in
+//! `MarketplaceCanonicalCommit` is therefore the visibility boundary: readers MUST ignore rows
+//! above the latest committed height.  Before a retry, rows for the uncommitted height are
+//! discarded and aggregates are rebuilt from the authoritative UTXO inventory.  Publication of
+//! the commitment, `ProcessedBlocks`, and `indexer_position` happens in one transaction.
+
+use anyhow::{Context, Result, anyhow, bail};
+use bitcoin::hashes::{Hash, HashEngine, sha256};
+use chrono::{DateTime, Utc};
+use sqlx::{PgPool, Postgres, Row, Transaction};
+use std::collections::HashSet;
+
+pub const SCHEMA_REVISION: &str = "marketplace-canonical-commit-v1";
+pub const PRODUCER_REVISION: &str = env!("ALKANES_PRODUCER_REVISION");
+pub const SERIAL_ADVISORY_LOCK_KEY: i64 = 0x414c_4b4d_5043_4331;
+pub const ZERO_BLOCK_HASH: &str =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
+const CREATE_COMMIT_TABLES: &str = r#"
+CREATE TABLE IF NOT EXISTS "MarketplaceCanonicalState" (
+    id SMALLINT PRIMARY KEY CHECK (id = 1),
+    reorg_epoch BIGINT NOT NULL CHECK (reorg_epoch >= 0)
+)
+"#;
+
+const CREATE_COMMIT_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS "MarketplaceCanonicalCommit" (
+    height BIGINT PRIMARY KEY CHECK (height >= 0),
+    block_hash TEXT NOT NULL UNIQUE CHECK (block_hash ~ '^[0-9a-f]{64}$'),
+    previous_block_hash TEXT NOT NULL CHECK (previous_block_hash ~ '^[0-9a-f]{64}$'),
+    reorg_epoch BIGINT NOT NULL CHECK (reorg_epoch >= 0),
+    producer_revision TEXT NOT NULL
+        CONSTRAINT marketplace_commit_producer_revision_check
+        CHECK (producer_revision ~ '^[0-9a-f]{40}([0-9a-f]{24})?$'),
+    schema_revision TEXT NOT NULL
+        CONSTRAINT marketplace_commit_schema_revision_check
+        CHECK (schema_revision = 'marketplace-canonical-commit-v1'),
+    trace_alkane_row_count BIGINT NOT NULL CHECK (trace_alkane_row_count >= 0),
+    trace_alkane_row_hash TEXT NOT NULL CHECK (trace_alkane_row_hash ~ '^[0-9a-f]{64}$'),
+    trace_balance_utxo_row_count BIGINT NOT NULL CHECK (trace_balance_utxo_row_count >= 0),
+    trace_balance_utxo_row_hash TEXT NOT NULL CHECK (trace_balance_utxo_row_hash ~ '^[0-9a-f]{64}$'),
+    active_inventory_count BIGINT NOT NULL CHECK (active_inventory_count >= 0),
+    active_inventory_root TEXT NOT NULL CHECK (active_inventory_root ~ '^[0-9a-f]{64}$'),
+    manifest_hash TEXT NOT NULL UNIQUE CHECK (manifest_hash ~ '^[0-9a-f]{64}$'),
+    committed_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp()
+)
+"#;
+
+const CREATE_SPEND_STAGE_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS "MarketplaceBalanceSpendStage" (
+    spend_height INTEGER NOT NULL CHECK (spend_height >= 0),
+    outpoint_txid TEXT NOT NULL CHECK (outpoint_txid ~ '^[0-9a-f]{64}$'),
+    outpoint_vout INTEGER NOT NULL CHECK (outpoint_vout >= 0),
+    PRIMARY KEY (spend_height, outpoint_txid, outpoint_vout)
+)
+"#;
+
+const ADD_SPENT_HEIGHT_COLUMN: &str = r#"
+ALTER TABLE "TraceBalanceUtxo"
+ADD COLUMN IF NOT EXISTS spent_at_height INTEGER
+"#;
+
+const ADD_SPENT_HEIGHT_CONSTRAINT: &str = r#"
+DO $constraints$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = '"TraceBalanceUtxo"'::regclass
+          AND conname = 'trace_balance_utxo_spent_height_check'
+    ) THEN
+        ALTER TABLE "TraceBalanceUtxo"
+        ADD CONSTRAINT trace_balance_utxo_spent_height_check
+        CHECK (
+            (NOT spent AND spent_at_height IS NULL) OR
+            (spent AND spent_at_height IS NOT NULL AND spent_at_height >= block_height)
+        );
+    END IF;
+END
+$constraints$
+"#;
+
+const CREATE_COMMIT_GUARD_FUNCTION: &str = r#"
+CREATE OR REPLACE FUNCTION marketplace_guard_commit_immutable()
+RETURNS trigger LANGUAGE plpgsql AS $guard$
+BEGIN
+    IF current_setting('alkanes.marketplace_rollback', true) IS DISTINCT FROM 'on' THEN
+        RAISE EXCEPTION 'MarketplaceCanonicalCommit rows are immutable; use hash-verified rollback';
+    END IF;
+    RETURN OLD;
+END
+$guard$
+"#;
+
+const CREATE_STATE_GUARD_FUNCTION: &str = r#"
+CREATE OR REPLACE FUNCTION marketplace_guard_canonical_state()
+RETURNS trigger LANGUAGE plpgsql AS $guard$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.id <> 1 OR NEW.reorg_epoch <> 0 THEN
+            RAISE EXCEPTION 'MarketplaceCanonicalState must begin at epoch zero';
+        END IF;
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'MarketplaceCanonicalState cannot be deleted';
+    END IF;
+    IF current_setting('alkanes.marketplace_rollback', true) IS DISTINCT FROM 'on'
+       OR NEW.id <> OLD.id
+       OR NEW.reorg_epoch <> OLD.reorg_epoch + 1 THEN
+        RAISE EXCEPTION 'MarketplaceCanonicalState epoch can only advance by one during rollback';
+    END IF;
+    RETURN NEW;
+END
+$guard$
+"#;
+
+const CREATE_TRACE_ALKANE_GUARD_FUNCTION: &str = r#"
+CREATE OR REPLACE FUNCTION marketplace_guard_trace_alkane_committed()
+RETURNS trigger LANGUAGE plpgsql AS $guard$
+DECLARE
+    affected_height INTEGER;
+BEGIN
+    IF current_setting('alkanes.marketplace_rollback', true) = 'on' THEN
+        IF TG_OP = 'DELETE' THEN
+            RETURN OLD;
+        END IF;
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'UPDATE' AND
+       (OLD.created_at_height IS NULL OR NEW.created_at_height IS NULL) THEN
+        RAISE EXCEPTION 'cannot mutate TraceAlkane with an unknown creation height';
+    END IF;
+    affected_height := CASE
+        WHEN TG_OP = 'INSERT' THEN NEW.created_at_height
+        WHEN TG_OP = 'DELETE' THEN OLD.created_at_height
+        ELSE LEAST(OLD.created_at_height, NEW.created_at_height)
+    END;
+    IF affected_height IS NULL OR EXISTS (
+        SELECT 1 FROM "MarketplaceCanonicalCommit" WHERE height >= affected_height
+    ) THEN
+        RAISE EXCEPTION 'cannot mutate TraceAlkane at or below a committed Marketplace height';
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END
+$guard$
+"#;
+
+const CREATE_SPEND_COMMIT_GUARD_FUNCTION: &str = r#"
+CREATE OR REPLACE FUNCTION marketplace_require_spend_commitment()
+RETURNS trigger LANGUAGE plpgsql AS $guard$
+BEGIN
+    IF NEW.spent AND OLD.spent_at_height IS DISTINCT FROM NEW.spent_at_height
+       AND NOT EXISTS (
+           SELECT 1 FROM "MarketplaceCanonicalCommit"
+           WHERE height = NEW.spent_at_height
+       ) THEN
+        RAISE EXCEPTION 'spent TraceBalanceUtxo mutation requires its canonical commitment';
+    END IF;
+    RETURN NEW;
+END
+$guard$
+"#;
+
+const CREATE_TRACE_UTXO_GUARD_FUNCTION: &str = r#"
+CREATE OR REPLACE FUNCTION marketplace_guard_trace_balance_utxo_committed()
+RETURNS trigger LANGUAGE plpgsql AS $guard$
+DECLARE
+    affected_height INTEGER;
+    publish_height INTEGER;
+    publish_height_text TEXT;
+BEGIN
+    IF current_setting('alkanes.marketplace_rollback', true) = 'on' THEN
+        IF TG_OP = 'DELETE' THEN
+            RETURN OLD;
+        END IF;
+        RETURN NEW;
+    END IF;
+    publish_height_text := current_setting('alkanes.marketplace_publish_height', true);
+    IF TG_OP = 'UPDATE' AND publish_height_text IS NOT NULL THEN
+        publish_height := publish_height_text::INTEGER;
+        IF NOT OLD.spent AND NEW.spent
+           AND OLD.spent_at_height IS NULL
+           AND NEW.spent_at_height = publish_height
+           AND publish_height >= OLD.block_height
+           AND OLD.outpoint_txid IS NOT DISTINCT FROM NEW.outpoint_txid
+           AND OLD.outpoint_vout IS NOT DISTINCT FROM NEW.outpoint_vout
+           AND OLD.address IS NOT DISTINCT FROM NEW.address
+           AND OLD.alkane_block IS NOT DISTINCT FROM NEW.alkane_block
+           AND OLD.alkane_tx IS NOT DISTINCT FROM NEW.alkane_tx
+           AND OLD.amount IS NOT DISTINCT FROM NEW.amount
+           AND OLD.block_height IS NOT DISTINCT FROM NEW.block_height
+           AND OLD.created_at IS NOT DISTINCT FROM NEW.created_at
+           AND NOT EXISTS (
+               SELECT 1 FROM "MarketplaceCanonicalCommit" WHERE height >= publish_height
+           ) THEN
+            RETURN NEW;
+        END IF;
+    END IF;
+    affected_height := CASE
+        WHEN TG_OP = 'INSERT' THEN NEW.block_height
+        WHEN TG_OP = 'DELETE' THEN OLD.block_height
+        ELSE LEAST(OLD.block_height, NEW.block_height)
+    END;
+    IF EXISTS (
+        SELECT 1 FROM "MarketplaceCanonicalCommit" WHERE height >= affected_height
+    ) THEN
+        RAISE EXCEPTION 'cannot mutate TraceBalanceUtxo at or below a committed Marketplace height';
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END
+$guard$
+"#;
+
+const CREATE_PROCESSED_BLOCK_GUARD_FUNCTION: &str = r#"
+CREATE OR REPLACE FUNCTION marketplace_guard_processed_block_committed()
+RETURNS trigger LANGUAGE plpgsql AS $guard$
+BEGIN
+    IF current_setting('alkanes.marketplace_rollback', true) = 'on' THEN
+        IF TG_OP = 'DELETE' THEN
+            RETURN OLD;
+        END IF;
+        RETURN NEW;
+    END IF;
+    IF TG_OP <> 'INSERT' THEN
+        RAISE EXCEPTION 'committed ProcessedBlocks rows are immutable';
+    END IF;
+    IF NEW."isProcessing" OR NOT EXISTS (
+        SELECT 1 FROM "MarketplaceCanonicalCommit"
+        WHERE height = NEW."blockHeight" AND block_hash = NEW."blockHash"
+    ) THEN
+        RAISE EXCEPTION 'ProcessedBlocks publication requires an exact canonical commitment';
+    END IF;
+    RETURN NEW;
+END
+$guard$
+"#;
+
+const CREATE_POSITION_GUARD_FUNCTION: &str = r#"
+CREATE OR REPLACE FUNCTION marketplace_guard_indexer_position()
+RETURNS trigger LANGUAGE plpgsql AS $guard$
+DECLARE
+    committed_previous_hash TEXT;
+BEGIN
+    IF current_setting('alkanes.marketplace_rollback', true) = 'on' THEN
+        IF TG_OP = 'DELETE' THEN
+            RETURN OLD;
+        END IF;
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'indexer_position can only be deleted by hash-verified rollback';
+    END IF;
+    SELECT previous_block_hash INTO committed_previous_hash
+    FROM "MarketplaceCanonicalCommit"
+    WHERE height = NEW.height AND block_hash = NEW.block_hash;
+    IF committed_previous_hash IS NULL THEN
+        RAISE EXCEPTION 'indexer_position must reference an exact canonical commitment';
+    END IF;
+    IF TG_OP = 'INSERT' AND NEW.height <> 0 THEN
+        RAISE EXCEPTION 'first indexer_position must publish height zero';
+    END IF;
+    IF TG_OP = 'UPDATE' AND
+       (NEW.height <> OLD.height + 1 OR committed_previous_hash <> OLD.block_hash) THEN
+        RAISE EXCEPTION 'indexer_position must advance by one hash-linked commitment';
+    END IF;
+    RETURN NEW;
+END
+$guard$
+"#;
+
+const CREATE_COMMIT_COMPLETENESS_FUNCTION: &str = r#"
+CREATE OR REPLACE FUNCTION marketplace_require_atomic_progress()
+RETURNS trigger LANGUAGE plpgsql AS $guard$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM "ProcessedBlocks"
+        WHERE "blockHeight" = NEW.height AND "blockHash" = NEW.block_hash
+          AND NOT "isProcessing"
+    ) OR NOT EXISTS (
+        SELECT 1 FROM indexer_position
+        WHERE id = 1 AND height = NEW.height AND block_hash = NEW.block_hash
+    ) OR NOT EXISTS (
+        SELECT 1 FROM "MarketplaceCanonicalState"
+        WHERE id = 1 AND reorg_epoch = NEW.reorg_epoch
+    ) THEN
+        RAISE EXCEPTION 'canonical commitment must publish matching state and progress atomically';
+    END IF;
+    RETURN NEW;
+END
+$guard$
+"#;
+
+const ADD_COMMIT_REVISION_CONSTRAINTS: &str = r#"
+DO $constraints$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = '"MarketplaceCanonicalCommit"'::regclass
+          AND conname = 'marketplace_commit_producer_revision_check'
+    ) THEN
+        ALTER TABLE "MarketplaceCanonicalCommit"
+        ADD CONSTRAINT marketplace_commit_producer_revision_check
+        CHECK (producer_revision ~ '^[0-9a-f]{40}([0-9a-f]{24})?$');
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = '"MarketplaceCanonicalCommit"'::regclass
+          AND conname = 'marketplace_commit_schema_revision_check'
+    ) THEN
+        ALTER TABLE "MarketplaceCanonicalCommit"
+        ADD CONSTRAINT marketplace_commit_schema_revision_check
+        CHECK (schema_revision = 'marketplace-canonical-commit-v1');
+    END IF;
+END
+$constraints$
+"#;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RowCommitment {
+    pub count: u64,
+    pub hash: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CanonicalCommit {
+    pub height: u64,
+    pub block_hash: String,
+    pub previous_block_hash: String,
+    pub reorg_epoch: u64,
+    pub producer_revision: String,
+    pub schema_revision: String,
+    pub trace_alkane: RowCommitment,
+    pub trace_balance_utxo: RowCommitment,
+    pub active_inventory: RowCommitment,
+    pub manifest_hash: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PrepareOutcome {
+    Ready,
+    AlreadyCommitted,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PublishOutcome {
+    Published,
+    AlreadyCommitted,
+}
+
+struct RowDigest {
+    engine: sha256::HashEngine,
+    count: u64,
+}
+
+impl RowDigest {
+    fn new(domain: &str) -> Self {
+        let mut engine = sha256::Hash::engine();
+        put_field(&mut engine, domain.as_bytes());
+        Self { engine, count: 0 }
+    }
+
+    fn push(&mut self, fields: &[String]) {
+        self.engine.input(&[0x01]);
+        self.engine.input(&(fields.len() as u64).to_be_bytes());
+        for field in fields {
+            put_field(&mut self.engine, field.as_bytes());
+        }
+        self.count += 1;
+    }
+
+    fn finish(self) -> RowCommitment {
+        RowCommitment {
+            count: self.count,
+            hash: sha256::Hash::from_engine(self.engine).to_string(),
+        }
+    }
+}
+
+fn put_field(engine: &mut sha256::HashEngine, bytes: &[u8]) {
+    engine.input(&(bytes.len() as u64).to_be_bytes());
+    engine.input(bytes);
+}
+
+fn valid_hash(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .as_bytes()
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+}
+
+fn validate_block_link(height: u64, block_hash: &str, previous_block_hash: &str) -> Result<()> {
+    if !valid_hash(block_hash) {
+        bail!("block hash must be exactly 64 lowercase hexadecimal characters");
+    }
+    if !valid_hash(previous_block_hash) {
+        bail!("previous block hash must be exactly 64 lowercase hexadecimal characters");
+    }
+    if height == 0 && previous_block_hash != ZERO_BLOCK_HASH {
+        bail!("height zero must use the all-zero previous block hash");
+    }
+    Ok(())
+}
+
+pub fn manifest_hash(commit: &CanonicalCommit) -> String {
+    let fields = [
+        commit.height.to_string(),
+        commit.block_hash.clone(),
+        commit.previous_block_hash.clone(),
+        commit.reorg_epoch.to_string(),
+        commit.producer_revision.clone(),
+        commit.schema_revision.clone(),
+        commit.trace_alkane.count.to_string(),
+        commit.trace_alkane.hash.clone(),
+        commit.trace_balance_utxo.count.to_string(),
+        commit.trace_balance_utxo.hash.clone(),
+        commit.active_inventory.count.to_string(),
+        commit.active_inventory.hash.clone(),
+    ];
+    let mut digest = RowDigest::new("alkanes-marketplace-canonical-manifest-v1");
+    digest.push(&fields);
+    digest.finish().hash
+}
+
+fn valid_producer_revision(value: &str) -> bool {
+    matches!(value.len(), 40 | 64)
+        && value
+            .as_bytes()
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+}
+
+fn validate_commit_record(commit: &CanonicalCommit) -> Result<()> {
+    validate_block_link(
+        commit.height,
+        &commit.block_hash,
+        &commit.previous_block_hash,
+    )?;
+    if !valid_producer_revision(&commit.producer_revision) {
+        bail!("Marketplace producer revision is not a pinned Git object id");
+    }
+    if commit.schema_revision != SCHEMA_REVISION {
+        bail!("unsupported Marketplace schema revision");
+    }
+    for (label, hash) in [
+        ("TraceAlkane row hash", &commit.trace_alkane.hash),
+        ("TraceBalanceUtxo row hash", &commit.trace_balance_utxo.hash),
+        ("active inventory root", &commit.active_inventory.hash),
+        ("manifest hash", &commit.manifest_hash),
+    ] {
+        if !valid_hash(hash) {
+            bail!("{label} is not canonical lowercase hexadecimal");
+        }
+    }
+    if manifest_hash(commit) != commit.manifest_hash {
+        bail!("Marketplace manifest hash does not bind its stored fields");
+    }
+    Ok(())
+}
+
+fn validate_commit_chain_descending(commits: &[CanonicalCommit]) -> Result<()> {
+    let Some(genesis) = commits.last() else {
+        return Ok(());
+    };
+    if genesis.height != 0 {
+        bail!("Marketplace commitment chain does not begin at height zero");
+    }
+    let mut previous: Option<&CanonicalCommit> = None;
+    for commit in commits.iter().rev() {
+        validate_commit_record(commit)?;
+        if let Some(parent) = previous {
+            if commit.height != parent.height + 1 {
+                bail!("Marketplace commitment chain contains a height gap");
+            }
+            if commit.previous_block_hash != parent.block_hash {
+                bail!("Marketplace commitment chain contains a broken hash link");
+            }
+            if commit.reorg_epoch < parent.reorg_epoch {
+                bail!("Marketplace reorg epoch moved backwards");
+            }
+        }
+        previous = Some(commit);
+    }
+    Ok(())
+}
+
+/// Pure helper used by tests and external contract verifiers. Rows are sorted lexicographically
+/// before hashing, so database execution order cannot affect the commitment.
+pub fn deterministic_rows_digest(domain: &str, mut rows: Vec<Vec<String>>) -> RowCommitment {
+    rows.sort();
+    let mut digest = RowDigest::new(domain);
+    for row in rows {
+        digest.push(&row);
+    }
+    digest.finish()
+}
+
+pub async fn ensure_schema(pool: &PgPool) -> Result<()> {
+    let mut tx = pool.begin().await?;
+    acquire_serial_lock(&mut tx).await?;
+    sqlx::query(CREATE_COMMIT_TABLES).execute(&mut *tx).await?;
+    sqlx::query(
+        r#"INSERT INTO "MarketplaceCanonicalState" (id, reorg_epoch)
+           VALUES (1, 0) ON CONFLICT (id) DO NOTHING"#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(CREATE_COMMIT_TABLE).execute(&mut *tx).await?;
+    sqlx::query(CREATE_SPEND_STAGE_TABLE)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(ADD_SPENT_HEIGHT_COLUMN)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(ADD_SPENT_HEIGHT_CONSTRAINT)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(ADD_COMMIT_REVISION_CONSTRAINTS)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query(CREATE_COMMIT_GUARD_FUNCTION)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(CREATE_STATE_GUARD_FUNCTION)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(CREATE_TRACE_ALKANE_GUARD_FUNCTION)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(CREATE_TRACE_UTXO_GUARD_FUNCTION)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(CREATE_SPEND_COMMIT_GUARD_FUNCTION)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(CREATE_PROCESSED_BLOCK_GUARD_FUNCTION)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(CREATE_POSITION_GUARD_FUNCTION)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(CREATE_COMMIT_COMPLETENESS_FUNCTION)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query(
+        r#"DROP TRIGGER IF EXISTS marketplace_commit_immutable ON "MarketplaceCanonicalCommit""#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        r#"CREATE TRIGGER marketplace_commit_immutable
+           BEFORE UPDATE OR DELETE ON "MarketplaceCanonicalCommit"
+           FOR EACH ROW EXECUTE FUNCTION marketplace_guard_commit_immutable()"#,
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(
+        r#"DROP TRIGGER IF EXISTS marketplace_canonical_state_guard
+           ON "MarketplaceCanonicalState""#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        r#"CREATE TRIGGER marketplace_canonical_state_guard
+           BEFORE INSERT OR UPDATE OR DELETE ON "MarketplaceCanonicalState"
+           FOR EACH ROW EXECUTE FUNCTION marketplace_guard_canonical_state()"#,
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(r#"DROP TRIGGER IF EXISTS marketplace_trace_alkane_immutable ON "TraceAlkane""#)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(
+        r#"CREATE TRIGGER marketplace_trace_alkane_immutable
+           BEFORE INSERT OR UPDATE OR DELETE ON "TraceAlkane"
+           FOR EACH ROW EXECUTE FUNCTION marketplace_guard_trace_alkane_committed()"#,
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(
+        r#"DROP TRIGGER IF EXISTS marketplace_trace_balance_utxo_immutable ON "TraceBalanceUtxo""#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        r#"CREATE TRIGGER marketplace_trace_balance_utxo_immutable
+           BEFORE INSERT OR UPDATE OR DELETE ON "TraceBalanceUtxo"
+           FOR EACH ROW EXECUTE FUNCTION marketplace_guard_trace_balance_utxo_committed()"#,
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(
+        r#"DROP TRIGGER IF EXISTS marketplace_spend_requires_commitment ON "TraceBalanceUtxo""#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        r#"CREATE CONSTRAINT TRIGGER marketplace_spend_requires_commitment
+           AFTER UPDATE ON "TraceBalanceUtxo"
+           DEFERRABLE INITIALLY DEFERRED
+           FOR EACH ROW EXECUTE FUNCTION marketplace_require_spend_commitment()"#,
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(
+        r#"DROP TRIGGER IF EXISTS marketplace_processed_block_immutable ON "ProcessedBlocks""#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        r#"CREATE TRIGGER marketplace_processed_block_immutable
+           BEFORE INSERT OR UPDATE OR DELETE ON "ProcessedBlocks"
+           FOR EACH ROW EXECUTE FUNCTION marketplace_guard_processed_block_committed()"#,
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query("DROP TRIGGER IF EXISTS marketplace_position_guard ON indexer_position")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(
+        r#"CREATE TRIGGER marketplace_position_guard
+           BEFORE INSERT OR UPDATE OR DELETE ON indexer_position
+           FOR EACH ROW EXECUTE FUNCTION marketplace_guard_indexer_position()"#,
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(
+        r#"DROP TRIGGER IF EXISTS marketplace_commit_atomic_progress
+           ON "MarketplaceCanonicalCommit""#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        r#"CREATE CONSTRAINT TRIGGER marketplace_commit_atomic_progress
+           AFTER INSERT ON "MarketplaceCanonicalCommit"
+           DEFERRABLE INITIALLY DEFERRED
+           FOR EACH ROW EXECUTE FUNCTION marketplace_require_atomic_progress()"#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Refuse to silently bless a legacy progress row. A canonical deployment must replay so every
+/// advertised height has a manifest and a verified predecessor.
+pub async fn verify_bootstrap_state(pool: &PgPool) -> Result<()> {
+    let mut serial_guard = pool.begin().await?;
+    acquire_serial_lock(&mut serial_guard).await?;
+    // Validate every immutable record, not only the tip: hashes, manifest binding, revision pins,
+    // chain continuity, and epoch monotonicity are all part of the startup trust boundary.
+    let commits = commits_descending(pool).await?;
+    let latest = commits.first();
+    let state_epoch: i64 =
+        sqlx::query_scalar(r#"SELECT reorg_epoch FROM "MarketplaceCanonicalState" WHERE id = 1"#)
+            .fetch_one(pool)
+            .await?;
+    if state_epoch < 0
+        || latest
+            .map(|commit| state_epoch < commit.reorg_epoch as i64)
+            .unwrap_or(false)
+    {
+        bail!("Marketplace canonical state has an invalid reorg epoch");
+    }
+
+    let committed_tip = latest
+        .map(|commit| i64::try_from(commit.height))
+        .transpose()?
+        .unwrap_or(-1);
+    let retryable_height = committed_tip
+        .checked_add(1)
+        .context("Marketplace committed tip has no representable successor")?;
+    let invalid_registry_suffix: bool = sqlx::query_scalar(
+        r#"SELECT EXISTS(
+               SELECT 1 FROM "TraceAlkane"
+               WHERE created_at_height IS NULL
+                  OR created_at_height < 0
+                  OR created_at_height > $1
+           )"#,
+    )
+    .bind(retryable_height)
+    .fetch_one(pool)
+    .await?;
+    if invalid_registry_suffix {
+        bail!("TraceAlkane contains rows outside the committed or retryable height range");
+    }
+    let invalid_inventory_suffix: bool = sqlx::query_scalar(
+        r#"SELECT EXISTS(
+               SELECT 1 FROM "TraceBalanceUtxo"
+               WHERE block_height < 0
+                  OR block_height > $1
+                  OR spent_at_height > $2
+           )"#,
+    )
+    .bind(retryable_height)
+    .bind(committed_tip)
+    .fetch_one(pool)
+    .await?;
+    if invalid_inventory_suffix {
+        bail!("TraceBalanceUtxo contains a non-retryable row or an uncommitted spend mutation");
+    }
+    let invalid_staging_suffix: bool = sqlx::query_scalar(
+        r#"SELECT EXISTS(
+               SELECT 1 FROM "MarketplaceBalanceSpendStage"
+               WHERE spend_height <> $1
+           )"#,
+    )
+    .bind(retryable_height)
+    .fetch_one(pool)
+    .await?;
+    if invalid_staging_suffix {
+        bail!("spend staging contains a row outside the single retryable height");
+    }
+
+    let progress_mismatch: bool = sqlx::query_scalar(
+        r#"SELECT EXISTS (
+               SELECT 1
+               FROM "MarketplaceCanonicalCommit" AS commit
+               FULL OUTER JOIN "ProcessedBlocks" AS processed
+                 ON processed."blockHeight"::BIGINT = commit.height
+               WHERE commit.height IS NULL
+                  OR processed."blockHeight" IS NULL
+                  OR processed."blockHash" <> commit.block_hash
+                  OR processed."isProcessing"
+           )"#,
+    )
+    .fetch_one(pool)
+    .await?;
+    if progress_mismatch {
+        bail!("ProcessedBlocks does not exactly mirror Marketplace canonical commitments");
+    }
+
+    if let Some(commit) = latest {
+        let committed_staging_row: bool = sqlx::query_scalar(
+            r#"SELECT EXISTS(
+                   SELECT 1 FROM "MarketplaceBalanceSpendStage"
+                   WHERE spend_height <= $1
+               )"#,
+        )
+        .bind(i64::try_from(commit.height)?)
+        .fetch_one(pool)
+        .await?;
+        if committed_staging_row {
+            bail!("spend staging contains a row at or below the committed tip");
+        }
+
+        let mut verify_tx = pool.begin().await?;
+        sqlx::query(r#"LOCK TABLE "TraceAlkane", "TraceBalanceUtxo" IN SHARE MODE"#)
+            .execute(&mut *verify_tx)
+            .await?;
+        let height = i64::try_from(commit.height)?;
+        let trace_alkane = trace_alkane_commitment(&mut verify_tx, height).await?;
+        let trace_balance = trace_balance_utxo_commitment(
+            &mut verify_tx,
+            Some(height),
+            height,
+            "alkanes-marketplace-trace-balance-utxo-height-v1",
+        )
+        .await?;
+        let active_inventory = trace_balance_utxo_commitment(
+            &mut verify_tx,
+            None,
+            height,
+            "alkanes-marketplace-active-inventory-v1",
+        )
+        .await?;
+        if trace_alkane != commit.trace_alkane
+            || trace_balance != commit.trace_balance_utxo
+            || active_inventory != commit.active_inventory
+        {
+            bail!("latest Marketplace commitment does not match authoritative rows");
+        }
+        verify_tx.commit().await?;
+    }
+
+    let position: Option<(i64, String)> =
+        sqlx::query_as("SELECT height, block_hash FROM indexer_position WHERE id = 1")
+            .fetch_optional(pool)
+            .await?;
+    let result: Result<()> = match (position, latest) {
+        (None, None) => Ok(()),
+        (Some((height, hash)), Some(commit))
+            if height >= 0 && commit.height == height as u64 && commit.block_hash == hash =>
+        {
+            Ok(())
+        }
+        (None, Some(_)) => bail!("canonical commitment exists without indexer_position"),
+        (Some(_), None) => bail!(
+            "legacy indexer_position has no Marketplace canonical commitment; full replay is required"
+        ),
+        (Some(_), Some(_)) => bail!(
+            "indexer_position does not exactly match the latest Marketplace canonical commitment"
+        ),
+    };
+    result?;
+    serial_guard.commit().await?;
+    Ok(())
+}
+
+pub async fn acquire_serial_lock(tx: &mut Transaction<'_, Postgres>) -> Result<()> {
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(SERIAL_ADVISORY_LOCK_KEY)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+/// Stage Bitcoin inputs without changing consumer-visible inventory. The matching UTXO rows are
+/// marked spent only inside `publish_height`, alongside the commitment and progress records.
+pub async fn stage_spent_outpoints(
+    pool: &PgPool,
+    height: u64,
+    outpoints: &[(String, i32)],
+) -> Result<()> {
+    if outpoints.is_empty() {
+        return Ok(());
+    }
+    let db_height = i32::try_from(height).context("spend height exceeds PostgreSQL INTEGER")?;
+    let mut seen = HashSet::with_capacity(outpoints.len());
+    let mut txids = Vec::with_capacity(outpoints.len());
+    let mut vouts = Vec::with_capacity(outpoints.len());
+    for (txid, vout) in outpoints {
+        if !valid_hash(txid) {
+            bail!("spent outpoint txid is not canonical lowercase hexadecimal");
+        }
+        if *vout < 0 {
+            bail!("spent outpoint vout cannot be negative");
+        }
+        if !seen.insert((txid.as_str(), *vout)) {
+            bail!("a block cannot spend the same outpoint twice");
+        }
+        txids.push(txid.clone());
+        vouts.push(*vout);
+    }
+
+    let mut tx = pool.begin().await?;
+    sqlx::query(r#"LOCK TABLE "MarketplaceBalanceSpendStage" IN ROW EXCLUSIVE MODE"#)
+        .execute(&mut *tx)
+        .await?;
+    let committed: bool = sqlx::query_scalar(
+        r#"SELECT EXISTS(
+               SELECT 1 FROM "MarketplaceCanonicalCommit" WHERE height >= $1
+           )"#,
+    )
+    .bind(i64::from(db_height))
+    .fetch_one(&mut *tx)
+    .await?;
+    if committed {
+        bail!("cannot stage spends at or below a committed Marketplace height");
+    }
+    sqlx::query(
+        r#"INSERT INTO "MarketplaceBalanceSpendStage"
+              (spend_height, outpoint_txid, outpoint_vout)
+           SELECT $1, staged.txid, staged.vout
+           FROM UNNEST($2::TEXT[], $3::INTEGER[]) AS staged(txid, vout)"#,
+    )
+    .bind(db_height)
+    .bind(txids)
+    .bind(vouts)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+pub async fn latest_commit(pool: &PgPool) -> Result<Option<CanonicalCommit>> {
+    let row = sqlx::query(
+        r#"SELECT height, block_hash, previous_block_hash, reorg_epoch,
+                  producer_revision, schema_revision,
+                  trace_alkane_row_count, trace_alkane_row_hash,
+                  trace_balance_utxo_row_count, trace_balance_utxo_row_hash,
+                  active_inventory_count, active_inventory_root, manifest_hash
+           FROM "MarketplaceCanonicalCommit" ORDER BY height DESC LIMIT 1"#,
+    )
+    .fetch_optional(pool)
+    .await?;
+    row.map(commit_from_row).transpose()
+}
+
+pub async fn commit_at_height(pool: &PgPool, height: u64) -> Result<Option<CanonicalCommit>> {
+    let row = sqlx::query(
+        r#"SELECT height, block_hash, previous_block_hash, reorg_epoch,
+                  producer_revision, schema_revision,
+                  trace_alkane_row_count, trace_alkane_row_hash,
+                  trace_balance_utxo_row_count, trace_balance_utxo_row_hash,
+                  active_inventory_count, active_inventory_root, manifest_hash
+           FROM "MarketplaceCanonicalCommit" WHERE height = $1"#,
+    )
+    .bind(i64::try_from(height).context("height exceeds PostgreSQL BIGINT")?)
+    .fetch_optional(pool)
+    .await?;
+    row.map(commit_from_row).transpose()
+}
+
+pub async fn commits_descending(pool: &PgPool) -> Result<Vec<CanonicalCommit>> {
+    let rows = sqlx::query(
+        r#"SELECT height, block_hash, previous_block_hash, reorg_epoch,
+                  producer_revision, schema_revision,
+                  trace_alkane_row_count, trace_alkane_row_hash,
+                  trace_balance_utxo_row_count, trace_balance_utxo_row_hash,
+                  active_inventory_count, active_inventory_root, manifest_hash
+           FROM "MarketplaceCanonicalCommit" ORDER BY height DESC"#,
+    )
+    .fetch_all(pool)
+    .await?;
+    let commits: Vec<_> = rows
+        .into_iter()
+        .map(commit_from_row)
+        .collect::<Result<_>>()?;
+    validate_commit_chain_descending(&commits)?;
+    Ok(commits)
+}
+
+fn commit_from_row(row: sqlx::postgres::PgRow) -> Result<CanonicalCommit> {
+    let height: i64 = row.try_get("height")?;
+    let epoch: i64 = row.try_get("reorg_epoch")?;
+    let alkane_count: i64 = row.try_get("trace_alkane_row_count")?;
+    let utxo_count: i64 = row.try_get("trace_balance_utxo_row_count")?;
+    let inventory_count: i64 = row.try_get("active_inventory_count")?;
+    if height < 0 || epoch < 0 || alkane_count < 0 || utxo_count < 0 || inventory_count < 0 {
+        bail!("negative value in Marketplace canonical commitment");
+    }
+    let commit = CanonicalCommit {
+        height: height as u64,
+        block_hash: row.try_get("block_hash")?,
+        previous_block_hash: row.try_get("previous_block_hash")?,
+        reorg_epoch: epoch as u64,
+        producer_revision: row.try_get("producer_revision")?,
+        schema_revision: row.try_get("schema_revision")?,
+        trace_alkane: RowCommitment {
+            count: alkane_count as u64,
+            hash: row.try_get("trace_alkane_row_hash")?,
+        },
+        trace_balance_utxo: RowCommitment {
+            count: utxo_count as u64,
+            hash: row.try_get("trace_balance_utxo_row_hash")?,
+        },
+        active_inventory: RowCommitment {
+            count: inventory_count as u64,
+            hash: row.try_get("active_inventory_root")?,
+        },
+        manifest_hash: row.try_get("manifest_hash")?,
+    };
+    validate_commit_record(&commit)?;
+    Ok(commit)
+}
+
+pub async fn prepare_height(
+    pool: &PgPool,
+    height: u64,
+    block_hash: &str,
+    previous_block_hash: &str,
+) -> Result<PrepareOutcome> {
+    validate_block_link(height, block_hash, previous_block_hash)?;
+    let latest = latest_commit(pool).await?;
+    if let Some(existing) = commit_at_height(pool, height).await? {
+        if existing.block_hash == block_hash && existing.previous_block_hash == previous_block_hash
+        {
+            if latest.as_ref().map(|commit| commit.height) == Some(height) {
+                return Ok(PrepareOutcome::AlreadyCommitted);
+            }
+            bail!("refusing to reprocess immutable committed height below the canonical tip");
+        }
+        bail!("canonical commitment conflict at height {height}; reconcile the fork first");
+    }
+
+    match (height, latest.as_ref()) {
+        (0, None) => {}
+        (0, Some(_)) => bail!("height zero cannot be appended to a non-empty commitment chain"),
+        (_, Some(parent))
+            if parent.height + 1 == height && parent.block_hash == previous_block_hash => {}
+        (_, Some(parent)) if parent.height + 1 != height => bail!(
+            "non-contiguous canonical append: latest height is {}, requested height is {height}",
+            parent.height
+        ),
+        (_, Some(_)) => bail!("previous block hash does not match the committed parent"),
+        (_, None) => bail!("first Marketplace canonical commitment must be height zero"),
+    }
+
+    reset_uncommitted_height(pool, height).await?;
+    Ok(PrepareOutcome::Ready)
+}
+
+async fn rebuild_balance_aggregates(tx: &mut Transaction<'_, Postgres>) -> Result<()> {
+    for table in [
+        r#"TraceAlkaneBalance"#,
+        r#"TraceBalanceAggregate"#,
+        r#"TraceHolder"#,
+        r#"TraceHolderCount"#,
+    ] {
+        let statement = format!(r#"DELETE FROM "{table}""#);
+        sqlx::query(&statement).execute(&mut **tx).await?;
+    }
+
+    sqlx::query(
+        r#"INSERT INTO "TraceAlkaneBalance"
+              (address, alkane_block, alkane_tx, balance, last_updated_block,
+               last_updated_tx, last_updated_timestamp)
+           SELECT address, alkane_block, alkane_tx, SUM(amount), MAX(block_height),
+                  MAX(outpoint_txid), transaction_timestamp()
+           FROM "TraceBalanceUtxo" WHERE NOT spent
+           GROUP BY address, alkane_block, alkane_tx"#,
+    )
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query(
+        r#"INSERT INTO "TraceBalanceAggregate"
+              (address, alkane_block, alkane_tx, total_amount, updated_at)
+           SELECT address, alkane_block, alkane_tx, SUM(amount), transaction_timestamp()
+           FROM "TraceBalanceUtxo" WHERE NOT spent
+           GROUP BY address, alkane_block, alkane_tx"#,
+    )
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query(
+        r#"INSERT INTO "TraceHolder"
+              (alkane_block, alkane_tx, address, total_amount, updated_at)
+           SELECT alkane_block, alkane_tx, address, SUM(amount), transaction_timestamp()
+           FROM "TraceBalanceUtxo" WHERE NOT spent
+           GROUP BY alkane_block, alkane_tx, address
+           HAVING SUM(amount) > 0"#,
+    )
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query(
+        r#"INSERT INTO "TraceHolderCount" (alkane_block, alkane_tx, count, updated_at)
+           SELECT alkane_block, alkane_tx, COUNT(*), transaction_timestamp()
+           FROM "TraceHolder" GROUP BY alkane_block, alkane_tx"#,
+    )
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn reset_uncommitted_height(pool: &PgPool, height: u64) -> Result<()> {
+    let height = i64::try_from(height).context("height exceeds PostgreSQL BIGINT")?;
+    let mut tx = pool.begin().await?;
+    sqlx::query(
+        r#"LOCK TABLE "MarketplaceBalanceSpendStage", "TraceAlkane", "TraceBalanceUtxo"
+           IN SHARE ROW EXCLUSIVE MODE"#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    let committed: bool = sqlx::query_scalar(
+        r#"SELECT EXISTS(SELECT 1 FROM "MarketplaceCanonicalCommit" WHERE height >= $1)"#,
+    )
+    .bind(height)
+    .fetch_one(&mut *tx)
+    .await?;
+    if committed {
+        bail!("cannot reset rows at or below a committed height");
+    }
+    sqlx::query(r#"DELETE FROM "MarketplaceBalanceSpendStage" WHERE spend_height = $1"#)
+        .bind(height)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(r#"DELETE FROM "TraceBalanceUtxo" WHERE block_height = $1"#)
+        .bind(height)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(r#"DELETE FROM "TraceAlkane" WHERE created_at_height = $1"#)
+        .bind(height)
+        .execute(&mut *tx)
+        .await?;
+    rebuild_balance_aggregates(&mut tx).await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+async fn trace_alkane_commitment(
+    tx: &mut Transaction<'_, Postgres>,
+    height: i64,
+) -> Result<RowCommitment> {
+    let rows = sqlx::query(
+        r#"SELECT alkane_block::TEXT AS alkane_block, alkane_tx::TEXT AS alkane_tx,
+                  created_at_block::TEXT AS created_at_block, created_at_tx,
+                  created_at_height::TEXT AS created_at_height
+           FROM "TraceAlkane" WHERE created_at_height = $1
+           ORDER BY alkane_block, alkane_tx, created_at_tx"#,
+    )
+    .bind(height)
+    .fetch_all(&mut **tx)
+    .await?;
+    let mut digest = RowDigest::new("alkanes-marketplace-trace-alkane-height-v1");
+    for row in rows {
+        digest.push(&[
+            row.try_get("alkane_block")?,
+            row.try_get("alkane_tx")?,
+            row.try_get("created_at_block")?,
+            row.try_get("created_at_tx")?,
+            row.try_get("created_at_height")?,
+        ]);
+    }
+    Ok(digest.finish())
+}
+
+async fn trace_balance_utxo_commitment(
+    tx: &mut Transaction<'_, Postgres>,
+    height: Option<i64>,
+    as_of_height: i64,
+    domain: &str,
+) -> Result<RowCommitment> {
+    let (statement, filter_height) = match height {
+        Some(height) => (
+            r#"SELECT event_kind, outpoint_txid, outpoint_vout, address, alkane_block,
+                      alkane_tx, amount, block_height, spent, spent_at_height
+               FROM (
+                   SELECT 'create'::TEXT AS event_kind, outpoint_txid,
+                          outpoint_vout::TEXT AS outpoint_vout, address,
+                          alkane_block::TEXT AS alkane_block, alkane_tx::TEXT AS alkane_tx,
+                          amount::TEXT AS amount, block_height::TEXT AS block_height,
+                          'false'::TEXT AS spent, ''::TEXT AS spent_at_height
+                   FROM "TraceBalanceUtxo" WHERE block_height = $1
+                   UNION ALL
+                   SELECT 'spend'::TEXT AS event_kind, outpoint_txid,
+                          outpoint_vout::TEXT AS outpoint_vout, address,
+                          alkane_block::TEXT AS alkane_block, alkane_tx::TEXT AS alkane_tx,
+                          amount::TEXT AS amount, block_height::TEXT AS block_height,
+                          'true'::TEXT AS spent, spent_at_height::TEXT AS spent_at_height
+                   FROM "TraceBalanceUtxo" WHERE spent_at_height = $1
+               ) AS events
+               ORDER BY event_kind, outpoint_txid, outpoint_vout, alkane_block, alkane_tx"#,
+            height,
+        ),
+        None => (
+            r#"SELECT 'active'::TEXT AS event_kind, outpoint_txid,
+                      outpoint_vout::TEXT AS outpoint_vout, address,
+                      alkane_block::TEXT AS alkane_block, alkane_tx::TEXT AS alkane_tx,
+                      amount::TEXT AS amount, block_height::TEXT AS block_height,
+                      'false'::TEXT AS spent, ''::TEXT AS spent_at_height
+               FROM "TraceBalanceUtxo"
+               WHERE block_height <= $1
+                 AND (spent_at_height IS NULL OR spent_at_height > $1)
+               ORDER BY outpoint_txid, outpoint_vout, alkane_block, alkane_tx"#,
+            as_of_height,
+        ),
+    };
+    let rows = sqlx::query(statement)
+        .bind(filter_height)
+        .fetch_all(&mut **tx)
+        .await?;
+    let mut digest = RowDigest::new(domain);
+    for row in rows {
+        digest.push(&[
+            row.try_get("event_kind")?,
+            row.try_get("outpoint_txid")?,
+            row.try_get("outpoint_vout")?,
+            row.try_get("address")?,
+            row.try_get("alkane_block")?,
+            row.try_get("alkane_tx")?,
+            row.try_get("amount")?,
+            row.try_get("block_height")?,
+            row.try_get("spent")?,
+            row.try_get("spent_at_height")?,
+        ]);
+    }
+    Ok(digest.finish())
+}
+
+pub async fn publish_height(
+    pool: &PgPool,
+    height: u64,
+    block_hash: &str,
+    previous_block_hash: &str,
+    block_timestamp: DateTime<Utc>,
+) -> Result<PublishOutcome> {
+    validate_block_link(height, block_hash, previous_block_hash)?;
+    let db_height = i64::try_from(height).context("height exceeds PostgreSQL BIGINT")?;
+    let db_height_i32 = i32::try_from(height).context("height exceeds PostgreSQL INTEGER")?;
+    let mut tx = pool.begin().await?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(r#"LOCK TABLE "MarketplaceBalanceSpendStage" IN SHARE ROW EXCLUSIVE MODE"#)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(r#"LOCK TABLE "TraceAlkane", "TraceBalanceUtxo" IN SHARE MODE"#)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(
+        r#"LOCK TABLE "MarketplaceCanonicalCommit", "MarketplaceCanonicalState",
+                  "ProcessedBlocks", indexer_position
+           IN SHARE ROW EXCLUSIVE MODE"#,
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    let existing = sqlx::query(
+        r#"SELECT manifest_hash, block_hash, previous_block_hash
+           FROM "MarketplaceCanonicalCommit" WHERE height = $1"#,
+    )
+    .bind(db_height)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let parent: Option<(i64, String)> = sqlx::query_as(
+        r#"SELECT height, block_hash FROM "MarketplaceCanonicalCommit"
+           ORDER BY height DESC LIMIT 1"#,
+    )
+    .fetch_optional(&mut *tx)
+    .await?;
+    match (existing.as_ref(), height, parent.as_ref()) {
+        (Some(_), _, Some((tip_height, tip_hash)))
+            if *tip_height == db_height && tip_hash == block_hash => {}
+        (Some(_), _, _) => bail!("existing Marketplace commitment is not the canonical tip"),
+        (None, 0, None) => {}
+        (None, 0, Some(_)) => bail!("cannot publish height zero to a non-empty chain"),
+        (None, _, Some((parent_height, parent_hash)))
+            if *parent_height == db_height - 1 && parent_hash == previous_block_hash => {}
+        (None, _, Some(_)) => bail!("canonical parent changed before publication"),
+        (None, _, None) => bail!("first Marketplace canonical commitment must be height zero"),
+    }
+
+    let epoch: i64 = sqlx::query_scalar(
+        r#"SELECT reorg_epoch FROM "MarketplaceCanonicalState" WHERE id = 1 FOR UPDATE"#,
+    )
+    .fetch_one(&mut *tx)
+    .await?;
+    if epoch < 0 {
+        bail!("negative Marketplace reorg epoch");
+    }
+    let staged_spends: bool = sqlx::query_scalar(
+        r#"SELECT EXISTS(
+               SELECT 1 FROM "MarketplaceBalanceSpendStage" WHERE spend_height = $1
+           )"#,
+    )
+    .bind(db_height_i32)
+    .fetch_one(&mut *tx)
+    .await?;
+    if existing.is_some() && staged_spends {
+        bail!("an already committed height cannot retain staged spends");
+    }
+    if existing.is_none() && staged_spends {
+        let already_spent: bool = sqlx::query_scalar(
+            r#"SELECT EXISTS (
+                   SELECT 1
+                   FROM "MarketplaceBalanceSpendStage" AS staged
+                   JOIN "TraceBalanceUtxo" AS inventory
+                     ON inventory.outpoint_txid = staged.outpoint_txid
+                    AND inventory.outpoint_vout = staged.outpoint_vout
+                   WHERE staged.spend_height = $1 AND inventory.spent
+               )"#,
+        )
+        .bind(db_height_i32)
+        .fetch_one(&mut *tx)
+        .await?;
+        if already_spent {
+            bail!("canonical block attempts to spend an already-spent Marketplace outpoint");
+        }
+        sqlx::query_scalar::<_, String>(
+            "SELECT set_config('alkanes.marketplace_publish_height', $1, true)",
+        )
+        .bind(db_height_i32.to_string())
+        .fetch_one(&mut *tx)
+        .await?;
+        let updated = sqlx::query(
+            r#"UPDATE "TraceBalanceUtxo" AS inventory
+               SET spent = TRUE, spent_at_height = $1
+               FROM "MarketplaceBalanceSpendStage" AS staged
+               WHERE staged.spend_height = $1
+                 AND inventory.outpoint_txid = staged.outpoint_txid
+                 AND inventory.outpoint_vout = staged.outpoint_vout
+                 AND NOT inventory.spent"#,
+        )
+        .bind(db_height_i32)
+        .execute(&mut *tx)
+        .await?;
+        if updated.rows_affected() > 0 {
+            rebuild_balance_aggregates(&mut tx).await?;
+        }
+    }
+    let trace_alkane = trace_alkane_commitment(&mut tx, db_height).await?;
+    let trace_balance_utxo = trace_balance_utxo_commitment(
+        &mut tx,
+        Some(db_height),
+        db_height,
+        "alkanes-marketplace-trace-balance-utxo-height-v1",
+    )
+    .await?;
+    let active_inventory = trace_balance_utxo_commitment(
+        &mut tx,
+        None,
+        db_height,
+        "alkanes-marketplace-active-inventory-v1",
+    )
+    .await?;
+    let mut candidate = CanonicalCommit {
+        height,
+        block_hash: block_hash.to_owned(),
+        previous_block_hash: previous_block_hash.to_owned(),
+        reorg_epoch: epoch as u64,
+        producer_revision: PRODUCER_REVISION.to_owned(),
+        schema_revision: SCHEMA_REVISION.to_owned(),
+        trace_alkane,
+        trace_balance_utxo,
+        active_inventory,
+        manifest_hash: String::new(),
+    };
+    candidate.manifest_hash = manifest_hash(&candidate);
+
+    if let Some(row) = existing {
+        let existing_manifest: String = row.try_get("manifest_hash")?;
+        let existing_hash: String = row.try_get("block_hash")?;
+        let existing_previous: String = row.try_get("previous_block_hash")?;
+        if existing_manifest == candidate.manifest_hash
+            && existing_hash == candidate.block_hash
+            && existing_previous == candidate.previous_block_hash
+        {
+            tx.commit().await?;
+            return Ok(PublishOutcome::AlreadyCommitted);
+        }
+        bail!("conflicting immutable Marketplace commitment at height {height}");
+    }
+
+    let position: Option<(i64, String)> =
+        sqlx::query_as("SELECT height, block_hash FROM indexer_position WHERE id = 1 FOR UPDATE")
+            .fetch_optional(&mut *tx)
+            .await?;
+    match (height, position) {
+        (0, None) => {}
+        (_, Some((position_height, position_hash)))
+            if position_height == db_height - 1 && position_hash == previous_block_hash => {}
+        _ => bail!("indexer_position is not the exact parent of the height being published"),
+    }
+
+    sqlx::query(
+        r#"INSERT INTO "MarketplaceCanonicalCommit"
+              (height, block_hash, previous_block_hash, reorg_epoch,
+               producer_revision, schema_revision,
+               trace_alkane_row_count, trace_alkane_row_hash,
+               trace_balance_utxo_row_count, trace_balance_utxo_row_hash,
+               active_inventory_count, active_inventory_root, manifest_hash)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)"#,
+    )
+    .bind(db_height)
+    .bind(&candidate.block_hash)
+    .bind(&candidate.previous_block_hash)
+    .bind(epoch)
+    .bind(&candidate.producer_revision)
+    .bind(&candidate.schema_revision)
+    .bind(i64::try_from(candidate.trace_alkane.count)?)
+    .bind(&candidate.trace_alkane.hash)
+    .bind(i64::try_from(candidate.trace_balance_utxo.count)?)
+    .bind(&candidate.trace_balance_utxo.hash)
+    .bind(i64::try_from(candidate.active_inventory.count)?)
+    .bind(&candidate.active_inventory.hash)
+    .bind(&candidate.manifest_hash)
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(
+        r#"INSERT INTO "ProcessedBlocks"
+              ("blockHeight", "blockHash", "timestamp", "isProcessing")
+           VALUES ($1, $2, $3, false)"#,
+    )
+    .bind(db_height_i32)
+    .bind(block_hash)
+    .bind(block_timestamp)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        "INSERT INTO indexer_position (id, height, block_hash) VALUES (1, $1, $2)\n         ON CONFLICT (id) DO UPDATE SET height = EXCLUDED.height, block_hash = EXCLUDED.block_hash",
+    )
+    .bind(db_height)
+    .bind(block_hash)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(r#"DELETE FROM "MarketplaceBalanceSpendStage" WHERE spend_height = $1"#)
+        .bind(db_height_i32)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(PublishOutcome::Published)
+}
+
+/// Delete a committed suffix only after the caller has independently matched the ancestor hash
+/// against Bitcoin Core. The row immutability triggers accept deletion only in this transaction.
+pub async fn rollback_to_common_ancestor(
+    pool: &PgPool,
+    ancestor: Option<(u64, String)>,
+) -> Result<u64> {
+    if let Some((_, ref hash)) = ancestor {
+        if !valid_hash(hash) {
+            bail!("common-ancestor hash is not canonical lowercase hexadecimal");
+        }
+    }
+    let mut tx = pool.begin().await?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("SET LOCAL alkanes.marketplace_rollback = 'on'")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(
+        r#"LOCK TABLE "MarketplaceBalanceSpendStage", "TraceAlkane", "TraceBalanceUtxo",
+                  "MarketplaceCanonicalCommit", "MarketplaceCanonicalState",
+                  "ProcessedBlocks", indexer_position
+           IN ACCESS EXCLUSIVE MODE"#,
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    let ancestor_height = match ancestor {
+        Some((height, expected_hash)) => {
+            let actual: Option<String> = sqlx::query_scalar(
+                r#"SELECT block_hash FROM "MarketplaceCanonicalCommit" WHERE height = $1"#,
+            )
+            .bind(i64::try_from(height)?)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if actual.as_deref() != Some(expected_hash.as_str()) {
+                bail!("hash-verified common ancestor changed before rollback");
+            }
+            i64::try_from(height)?
+        }
+        None => -1,
+    };
+
+    let next_epoch: i64 = sqlx::query_scalar(
+        r#"UPDATE "MarketplaceCanonicalState" SET reorg_epoch = reorg_epoch + 1
+           WHERE id = 1 RETURNING reorg_epoch"#,
+    )
+    .fetch_one(&mut *tx)
+    .await?;
+    sqlx::query(r#"DELETE FROM "TraceBalanceUtxo" WHERE block_height > $1"#)
+        .bind(ancestor_height)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(
+        r#"UPDATE "TraceBalanceUtxo"
+           SET spent = FALSE, spent_at_height = NULL
+           WHERE spent_at_height > $1"#,
+    )
+    .bind(ancestor_height)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(r#"DELETE FROM "MarketplaceBalanceSpendStage" WHERE spend_height > $1"#)
+        .bind(ancestor_height)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(r#"DELETE FROM "TraceAlkane" WHERE created_at_height > $1"#)
+        .bind(ancestor_height)
+        .execute(&mut *tx)
+        .await?;
+    rebuild_balance_aggregates(&mut tx).await?;
+    sqlx::query(r#"DELETE FROM "ProcessedBlocks" WHERE "blockHeight" > $1"#)
+        .bind(ancestor_height)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(r#"DELETE FROM "MarketplaceCanonicalCommit" WHERE height > $1"#)
+        .bind(ancestor_height)
+        .execute(&mut *tx)
+        .await?;
+
+    if ancestor_height >= 0 {
+        let ancestor_commit = commit_from_row(
+            sqlx::query(
+                r#"SELECT height, block_hash, previous_block_hash, reorg_epoch,
+                          producer_revision, schema_revision,
+                          trace_alkane_row_count, trace_alkane_row_hash,
+                          trace_balance_utxo_row_count, trace_balance_utxo_row_hash,
+                          active_inventory_count, active_inventory_root, manifest_hash
+                   FROM "MarketplaceCanonicalCommit" WHERE height = $1"#,
+            )
+            .bind(ancestor_height)
+            .fetch_one(&mut *tx)
+            .await?,
+        )?;
+        let trace_alkane = trace_alkane_commitment(&mut tx, ancestor_height).await?;
+        let trace_balance = trace_balance_utxo_commitment(
+            &mut tx,
+            Some(ancestor_height),
+            ancestor_height,
+            "alkanes-marketplace-trace-balance-utxo-height-v1",
+        )
+        .await?;
+        let active_inventory = trace_balance_utxo_commitment(
+            &mut tx,
+            None,
+            ancestor_height,
+            "alkanes-marketplace-active-inventory-v1",
+        )
+        .await?;
+        if trace_alkane != ancestor_commit.trace_alkane
+            || trace_balance != ancestor_commit.trace_balance_utxo
+            || active_inventory != ancestor_commit.active_inventory
+        {
+            bail!("rollback result does not match the hash-committed ancestor state");
+        }
+        sqlx::query(
+            "INSERT INTO indexer_position (id, height, block_hash) VALUES (1, $1, $2)\n             ON CONFLICT (id) DO UPDATE SET height = EXCLUDED.height, block_hash = EXCLUDED.block_hash",
+        )
+        .bind(ancestor_height)
+        .bind(ancestor_commit.block_hash)
+        .execute(&mut *tx)
+        .await?;
+    } else {
+        let authority_rows: i64 = sqlx::query_scalar(
+            r#"SELECT
+                   (SELECT COUNT(*) FROM "TraceAlkane") +
+                   (SELECT COUNT(*) FROM "TraceBalanceUtxo")"#,
+        )
+        .fetch_one(&mut *tx)
+        .await?;
+        if authority_rows != 0 {
+            bail!("full rollback left Marketplace authority rows behind");
+        }
+        sqlx::query("DELETE FROM indexer_position WHERE id = 1")
+            .execute(&mut *tx)
+            .await?;
+    }
+    tx.commit().await?;
+    u64::try_from(next_epoch).map_err(|_| anyhow!("negative reorg epoch after rollback"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(byte: char) -> String {
+        std::iter::repeat(byte).take(64).collect()
+    }
+
+    fn candidate(height: u64, block: char, previous: char) -> CanonicalCommit {
+        let rows = deterministic_rows_digest(
+            "alkanes-marketplace-test-v1",
+            vec![vec!["b".into(), "2".into()], vec!["a".into(), "1".into()]],
+        );
+        let mut commit = CanonicalCommit {
+            height,
+            block_hash: hash(block),
+            previous_block_hash: if height == 0 {
+                ZERO_BLOCK_HASH.into()
+            } else {
+                hash(previous)
+            },
+            reorg_epoch: 0,
+            producer_revision: std::iter::repeat('1').take(40).collect(),
+            schema_revision: SCHEMA_REVISION.into(),
+            trace_alkane: rows.clone(),
+            trace_balance_utxo: rows.clone(),
+            active_inventory: rows,
+            manifest_hash: String::new(),
+        };
+        commit.manifest_hash = manifest_hash(&commit);
+        commit
+    }
+
+    #[test]
+    fn ordered_digest_is_deterministic_and_field_bound() {
+        let forward = vec![
+            vec!["outpoint-b".into(), "2".into()],
+            vec!["outpoint-a".into(), "11".into()],
+        ];
+        let mut reverse = forward.clone();
+        reverse.reverse();
+        assert_eq!(
+            deterministic_rows_digest("domain", forward),
+            deterministic_rows_digest("domain", reverse)
+        );
+        assert_ne!(
+            deterministic_rows_digest("domain", vec![vec!["ab".into(), "c".into()]]),
+            deterministic_rows_digest("domain", vec![vec!["a".into(), "bc".into()]])
+        );
+        assert_eq!(
+            deterministic_rows_digest(
+                "domain",
+                vec![vec!["b".into(), "2".into()], vec!["a".into(), "1".into()],],
+            )
+            .hash,
+            "abc7d197a4f756fbd71d96257424da42d666904f82088e8629847910966fcc3b"
+        );
+    }
+
+    #[test]
+    fn utxo_digest_binds_spend_status_and_height() {
+        let active = deterministic_rows_digest(
+            "alkanes-marketplace-trace-balance-utxo-height-v1",
+            vec![vec!["tx".into(), "0".into(), "false".into(), "".into()]],
+        );
+        let spent = deterministic_rows_digest(
+            "alkanes-marketplace-trace-balance-utxo-height-v1",
+            vec![vec!["tx".into(), "0".into(), "true".into(), "101".into()]],
+        );
+        let spent_later = deterministic_rows_digest(
+            "alkanes-marketplace-trace-balance-utxo-height-v1",
+            vec![vec!["tx".into(), "0".into(), "true".into(), "102".into()]],
+        );
+        assert_ne!(active.hash, spent.hash);
+        assert_ne!(spent.hash, spent_later.hash);
+    }
+
+    #[test]
+    fn manifest_changes_for_every_consensus_field() {
+        let base = candidate(1, 'b', 'a');
+        let mut changed = base.clone();
+        changed.active_inventory.count += 1;
+        assert_ne!(manifest_hash(&base), manifest_hash(&changed));
+        changed = base.clone();
+        changed.reorg_epoch += 1;
+        assert_ne!(manifest_hash(&base), manifest_hash(&changed));
+        changed = base.clone();
+        changed.producer_revision.push('x');
+        assert_ne!(manifest_hash(&base), manifest_hash(&changed));
+    }
+
+    #[test]
+    fn invalid_hashes_and_genesis_link_fail_closed() {
+        assert!(validate_block_link(1, &hash('a'), &hash('b')).is_ok());
+        assert!(validate_block_link(1, &hash('A'), &hash('b')).is_err());
+        assert!(validate_block_link(0, &hash('a'), &hash('b')).is_err());
+        assert!(validate_block_link(0, &hash('a'), ZERO_BLOCK_HASH).is_ok());
+    }
+
+    #[test]
+    fn exact_retry_is_idempotent_but_conflict_changes_manifest() {
+        let first = candidate(1, 'b', 'a');
+        let retry = candidate(1, 'b', 'a');
+        assert_eq!(first.manifest_hash, retry.manifest_hash);
+        let conflict = candidate(1, 'c', 'a');
+        assert_ne!(first.manifest_hash, conflict.manifest_hash);
+    }
+
+    #[test]
+    fn chain_validation_rejects_gap_broken_link_and_epoch_regression() {
+        let genesis = candidate(0, 'a', '0');
+        let one = candidate(1, 'b', 'a');
+        let two = candidate(2, 'c', 'b');
+        assert!(
+            validate_commit_chain_descending(&[two.clone(), one.clone(), genesis.clone(),]).is_ok()
+        );
+
+        assert!(validate_commit_chain_descending(&[two.clone(), genesis.clone()]).is_err());
+        let mut broken = two.clone();
+        broken.previous_block_hash = hash('d');
+        broken.manifest_hash = manifest_hash(&broken);
+        assert!(validate_commit_chain_descending(&[broken, one.clone(), genesis.clone()]).is_err());
+        let mut parent_epoch = one.clone();
+        parent_epoch.reorg_epoch = 2;
+        parent_epoch.manifest_hash = manifest_hash(&parent_epoch);
+        assert!(validate_commit_chain_descending(&[two, parent_epoch, genesis]).is_err());
+    }
+
+    #[test]
+    fn chain_validation_rejects_invalid_non_tip_revision_and_manifest() {
+        let tip = candidate(1, 'b', 'a');
+        let mut genesis = candidate(0, 'a', '0');
+        genesis.producer_revision = "unpinned".into();
+        genesis.manifest_hash = manifest_hash(&genesis);
+        assert!(validate_commit_chain_descending(&[tip.clone(), genesis]).is_err());
+
+        let mut genesis = candidate(0, 'a', '0');
+        genesis.trace_alkane.count += 1;
+        assert!(validate_commit_chain_descending(&[tip, genesis]).is_err());
+    }
+
+    #[test]
+    fn transform_failure_has_no_publish_outcome() {
+        fn stage(fail_after: Option<usize>) -> Result<CanonicalCommit> {
+            let mut rows = Vec::new();
+            for index in 0..3 {
+                if fail_after == Some(index) {
+                    bail!("injected transform failure");
+                }
+                rows.push(vec![index.to_string()]);
+            }
+            let mut commit = candidate(1, 'b', 'a');
+            commit.trace_balance_utxo = deterministic_rows_digest("stage", rows);
+            commit.manifest_hash = manifest_hash(&commit);
+            Ok(commit)
+        }
+        assert!(stage(Some(1)).is_err());
+        assert_eq!(stage(None).unwrap().trace_balance_utxo.count, 3);
+    }
+
+    #[test]
+    fn same_height_and_deep_forks_choose_only_hash_verified_ancestor() {
+        let chain = [
+            candidate(0, 'a', '0'),
+            candidate(1, 'b', 'a'),
+            candidate(2, 'c', 'b'),
+        ];
+        let same_height_fork = [(0, hash('a')), (1, hash('b')), (2, hash('d'))];
+        let same_ancestor = chain
+            .iter()
+            .rev()
+            .find(|commit| {
+                same_height_fork
+                    .iter()
+                    .any(|(height, block)| *height == commit.height && block == &commit.block_hash)
+            })
+            .unwrap();
+        assert_eq!(same_ancestor.height, 1);
+
+        let deep_fork = [(0, hash('a')), (1, hash('e')), (2, hash('f'))];
+        let deep_ancestor = chain
+            .iter()
+            .rev()
+            .find(|commit| {
+                deep_fork
+                    .iter()
+                    .any(|(height, block)| *height == commit.height && block == &commit.block_hash)
+            })
+            .unwrap();
+        assert_eq!(deep_ancestor.height, 0);
+    }
+
+    #[test]
+    fn schema_guards_commits_and_authoritative_rows_against_late_mutation() {
+        assert!(CREATE_COMMIT_GUARD_FUNCTION.contains("immutable"));
+        assert!(CREATE_STATE_GUARD_FUNCTION.contains("advance by one"));
+        assert!(CREATE_TRACE_ALKANE_GUARD_FUNCTION.contains("MarketplaceCanonicalCommit"));
+        assert!(CREATE_TRACE_UTXO_GUARD_FUNCTION.contains("MarketplaceCanonicalCommit"));
+        assert!(CREATE_COMMIT_TABLE.contains("previous_block_hash"));
+        assert!(CREATE_COMMIT_TABLE.contains("active_inventory_root"));
+        assert!(!CREATE_TRACE_ALKANE_GUARD_FUNCTION.contains("COALESCE(NEW, OLD)"));
+        assert!(!CREATE_TRACE_UTXO_GUARD_FUNCTION.contains("COALESCE(NEW, OLD)"));
+        assert!(CREATE_PROCESSED_BLOCK_GUARD_FUNCTION.contains("immutable"));
+        assert!(CREATE_POSITION_GUARD_FUNCTION.contains("advance by one"));
+        assert!(CREATE_COMMIT_COMPLETENESS_FUNCTION.contains("matching state and progress"));
+        assert!(CREATE_SPEND_STAGE_TABLE.contains("MarketplaceBalanceSpendStage"));
+        assert!(ADD_SPENT_HEIGHT_CONSTRAINT.contains("spent_at_height >= block_height"));
+        assert!(CREATE_SPEND_COMMIT_GUARD_FUNCTION.contains("requires its canonical commitment"));
+    }
+}

--- a/crates/alkanes-contract-indexer/src/coordinator.rs
+++ b/crates/alkanes-contract-indexer/src/coordinator.rs
@@ -1,24 +1,63 @@
+use alkanes_cli_common::traits::{
+    BitcoinRpcProvider, DeezelProvider, EsploraProvider, JsonRpcProvider, MetashrewRpcProvider,
+};
 use anyhow::Result;
-use alkanes_cli_common::traits::{MetashrewRpcProvider, BitcoinRpcProvider, EsploraProvider, JsonRpcProvider, DeezelProvider};
-use tracing::{info, error};
+use tracing::{error, info};
 
-use crate::{pipeline::{BlockContext, Pipeline}, progress::ProgressStore, helpers::block::canonical_tip_height};
+use crate::{
+    helpers::block::canonical_tip_height,
+    pipeline::{BlockContext, Pipeline},
+    progress::ProgressStore,
+};
 
-pub struct CatchUpCoordinator<P: MetashrewRpcProvider + BitcoinRpcProvider + EsploraProvider + JsonRpcProvider + DeezelProvider + Send + Sync> {
+pub struct CatchUpCoordinator<
+    P: MetashrewRpcProvider
+        + BitcoinRpcProvider
+        + EsploraProvider
+        + JsonRpcProvider
+        + DeezelProvider
+        + Send
+        + Sync,
+> {
     provider: P,
     pipeline: Pipeline,
     progress: ProgressStore,
     start_height: Option<u64>,
 }
 
-impl<P: MetashrewRpcProvider + BitcoinRpcProvider + EsploraProvider + JsonRpcProvider + DeezelProvider + Send + Sync> CatchUpCoordinator<P> {
-    pub fn new(provider: P, pipeline: Pipeline, progress: ProgressStore, start_height: Option<u64>) -> Self {
-        Self { provider, pipeline, progress, start_height }
+impl<
+    P: MetashrewRpcProvider
+        + BitcoinRpcProvider
+        + EsploraProvider
+        + JsonRpcProvider
+        + DeezelProvider
+        + Send
+        + Sync,
+> CatchUpCoordinator<P>
+{
+    pub fn new(
+        provider: P,
+        pipeline: Pipeline,
+        progress: ProgressStore,
+        start_height: Option<u64>,
+    ) -> Self {
+        Self {
+            provider,
+            pipeline,
+            progress,
+            start_height,
+        }
     }
 
     /// Run a single pass: check our current position and process the next block
     /// This is deterministic - we always check our position first before fetching the next block
     pub async fn run_once(&self) -> Result<()> {
+        if let Some(epoch) = self.pipeline.reconcile_canonical(&self.provider).await? {
+            info!(
+                reorg_epoch = epoch,
+                "catch-up: rolled back to a hash-verified common ancestor"
+            );
+        }
         // First, check our current position
         let position = self.progress.get_position().await?;
 
@@ -42,7 +81,17 @@ impl<P: MetashrewRpcProvider + BitcoinRpcProvider + EsploraProvider + JsonRpcPro
             info!(height = h, "catch-up: processing block sequentially");
 
             // Process the block - position is updated atomically inside
-            match self.pipeline.process_block_sequential(&self.provider, BlockContext { height: h, emit_publish: false }).await {
+            match self
+                .pipeline
+                .process_block_sequential(
+                    &self.provider,
+                    BlockContext {
+                        height: h,
+                        emit_publish: false,
+                    },
+                )
+                .await
+            {
                 Ok(block_hash) => {
                     info!(height = h, %block_hash, "catch-up: block processed");
                 }
@@ -56,5 +105,3 @@ impl<P: MetashrewRpcProvider + BitcoinRpcProvider + EsploraProvider + JsonRpcPro
         Ok(())
     }
 }
-
-

--- a/crates/alkanes-contract-indexer/src/helpers/block.rs
+++ b/crates/alkanes-contract-indexer/src/helpers/block.rs
@@ -1,53 +1,112 @@
-use anyhow::Result;
-use alkanes_cli_common::traits::{BitcoinRpcProvider, JsonRpcProvider, DeezelProvider, MetashrewRpcProvider};
+use crate::helpers::rpc::{resilient_call, resilient_provider_call};
+use alkanes_cli_common::traits::{
+    BitcoinRpcProvider, DeezelProvider, JsonRpcProvider, MetashrewRpcProvider,
+};
+use anyhow::{Context, Result, bail};
 use serde_json::Value as JsonValue;
 use serde_json::json;
 use std::env;
-use crate::helpers::rpc::{resilient_call, resilient_provider_call};
 use tracing::warn;
 
 // Resolve block hash by height via Bitcoin RPC provider
 pub async fn get_block_hash<P>(provider: &P, height: u64) -> Result<String>
 where
-	P: BitcoinRpcProvider + DeezelProvider + Send + Sync,
+    P: BitcoinRpcProvider + DeezelProvider + Send + Sync,
 {
-	let hash = <P as BitcoinRpcProvider>::get_block_hash(provider, height).await?;
-	Ok(hash)
+    let hash = <P as BitcoinRpcProvider>::get_block_hash(provider, height).await?;
+    Ok(hash)
 }
 
-// Get txids for a block via JSON-RPC method `esplora_block::txids`
+fn canonical_hash(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .as_bytes()
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+}
+
+fn parse_block_txids(block: &JsonValue, expected_hash: &str) -> Result<Vec<String>> {
+    let returned_hash = block
+        .get("hash")
+        .and_then(JsonValue::as_str)
+        .context("Bitcoin Core block response is missing hash")?;
+    if returned_hash != expected_hash || !canonical_hash(returned_hash) {
+        bail!("Bitcoin Core block response does not match the requested canonical hash");
+    }
+    let encoded = block
+        .get("tx")
+        .and_then(JsonValue::as_array)
+        .context("Bitcoin Core block response tx must be an array")?;
+    if encoded.is_empty() {
+        bail!("Bitcoin Core block response cannot have an empty transaction list");
+    }
+
+    let mut txids = Vec::with_capacity(encoded.len());
+    let mut seen = std::collections::HashSet::with_capacity(encoded.len());
+    for (index, value) in encoded.iter().enumerate() {
+        let txid = value
+            .as_str()
+            .with_context(|| format!("Bitcoin Core block tx {index} is not a txid string"))?;
+        if !canonical_hash(txid) {
+            bail!("Bitcoin Core block tx {index} is not canonical lowercase hexadecimal");
+        }
+        if !seen.insert(txid) {
+            bail!("Bitcoin Core block response contains duplicate transaction {txid}");
+        }
+        txids.push(txid.to_owned());
+    }
+    if let Some(declared) = block.get("nTx") {
+        let declared = declared
+            .as_u64()
+            .context("Bitcoin Core block response nTx must be a non-negative integer")?;
+        if declared != txids.len() as u64 {
+            bail!("Bitcoin Core block response nTx does not match its transaction array");
+        }
+    }
+    Ok(txids)
+}
+
+// Get the authoritative transaction list directly from Bitcoin Core.
 pub async fn get_block_txids<P>(provider: &P, block_hash: &str) -> Result<Vec<String>>
 where
-	P: JsonRpcProvider + DeezelProvider + Send + Sync,
+    P: BitcoinRpcProvider + Send + Sync,
 {
-	let url = env::var("SANDSHREW_RPC_URL")
-		.ok()
-		.or_else(|| provider.get_bitcoin_rpc_url())
-		.unwrap_or_else(|| "http://localhost:18888".to_string());
-    let txids_val = resilient_call(provider, &url, "esplora_block::txids", json!([block_hash]), 1).await?;
-	let txids: Vec<String> = txids_val
-		.as_array()
-		.map(|arr| arr.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect())
-		.unwrap_or_default();
-	Ok(txids)
+    if !canonical_hash(block_hash) {
+        bail!("requested block hash is not canonical lowercase hexadecimal");
+    }
+    let block = resilient_provider_call("get_block", || provider.get_block(block_hash, false))
+        .await?;
+    parse_block_txids(&block, block_hash)
 }
 
 // Fetch tx infos for a list of txids concurrently (batch size controls max in-flight)
-pub async fn get_transactions_info<P>(provider: &P, txids: &[String], batch_size: usize) -> Result<Vec<JsonValue>>
+pub async fn get_transactions_info<P>(
+    provider: &P,
+    txids: &[String],
+    batch_size: usize,
+) -> Result<Vec<JsonValue>>
 where
-	P: JsonRpcProvider + DeezelProvider + Send + Sync,
+    P: JsonRpcProvider + DeezelProvider + Send + Sync,
 {
-	use futures::stream::{self, StreamExt};
-	let url = env::var("SANDSHREW_RPC_URL")
-		.ok()
-		.or_else(|| provider.get_bitcoin_rpc_url())
-		.unwrap_or_else(|| "http://localhost:18888".to_string());
+    use futures::stream::{self, StreamExt};
+    let url = env::var("SANDSHREW_RPC_URL")
+        .ok()
+        .or_else(|| provider.get_bitcoin_rpc_url())
+        .unwrap_or_else(|| "http://localhost:18888".to_string());
     let results: Vec<(String, Option<JsonValue>)> = stream::iter(txids.iter().cloned())
         .map(|txid| {
             let url_inner = url.clone();
             let provider_ref = provider;
             async move {
-                let res = match resilient_call(provider_ref, &url_inner, "esplora_tx", json!([txid.clone()]), 1).await {
+                let res = match resilient_call(
+                    provider_ref,
+                    &url_inner,
+                    "esplora_tx",
+                    json!([txid.clone()]),
+                    1,
+                )
+                .await
+                {
                     Ok(v) => Some(v),
                     Err(e) => {
                         warn!(%txid, error = %e, "esplora_tx failed after retries");
@@ -57,7 +116,7 @@ where
                 (txid, res)
             }
         })
-        .buffer_unordered(batch_size)
+        .buffered(batch_size)
         .collect()
         .await;
 
@@ -83,28 +142,65 @@ where
 
 // Determine if a transaction JSON has any OP_RETURN outputs
 pub fn tx_has_op_return(tx_json: &JsonValue) -> bool {
-	let Some(vout) = tx_json.get("vout").and_then(|v| v.as_array()) else { return false };
-	for o in vout {
-		if let Some(t) = o.get("scriptpubkey_type").and_then(|v| v.as_str()) {
-			if t.eq_ignore_ascii_case("op_return") { return true; }
-		}
-		if let Some(asm) = o.get("scriptpubkey_asm").and_then(|v| v.as_str()) {
-			if asm.starts_with("OP_RETURN") { return true; }
-		}
-		if let Some(spk) = o.get("scriptpubkey").and_then(|v| v.as_str()) {
-			if spk.starts_with("6a") { return true; }
-		}
-	}
-	false
+    let Some(vout) = tx_json.get("vout").and_then(|v| v.as_array()) else {
+        return false;
+    };
+    for o in vout {
+        if let Some(t) = o.get("scriptpubkey_type").and_then(|v| v.as_str()) {
+            if t.eq_ignore_ascii_case("op_return") {
+                return true;
+            }
+        }
+        if let Some(asm) = o.get("scriptpubkey_asm").and_then(|v| v.as_str()) {
+            if asm.starts_with("OP_RETURN") {
+                return true;
+            }
+        }
+        if let Some(spk) = o.get("scriptpubkey").and_then(|v| v.as_str()) {
+            if spk.starts_with("6a") {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 // Returns the canonical chain tip height  from Metashrew's reported height,
 pub async fn canonical_tip_height<P: MetashrewRpcProvider>(provider: &P) -> Result<u64> {
-    let h = resilient_provider_call("get_metashrew_height", || provider.get_metashrew_height()).await?;
-	if h == 0 {
-		return Err(anyhow::anyhow!("unexpected metashrew height 0"));
-	}
-	Ok(h)
+    let h =
+        resilient_provider_call("get_metashrew_height", || provider.get_metashrew_height()).await?;
+    if h == 0 {
+        return Err(anyhow::anyhow!("unexpected metashrew height 0"));
+    }
+    Ok(h)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
 
+    fn hash(byte: char) -> String {
+        std::iter::repeat(byte).take(64).collect()
+    }
+
+    #[test]
+    fn core_block_transaction_list_is_strict_and_complete() {
+        let block_hash = hash('a');
+        let valid = json!({
+            "hash": block_hash,
+            "nTx": 2,
+            "tx": [hash('b'), hash('c')]
+        });
+        assert_eq!(parse_block_txids(&valid, &hash('a')).unwrap().len(), 2);
+
+        let malformed = [
+            json!({"hash": hash('a'), "nTx": 2, "tx": [hash('b'), 1]}),
+            json!({"hash": hash('a'), "nTx": 2, "tx": [hash('b')]}),
+            json!({"hash": hash('a'), "tx": [hash('b'), hash('b')]}),
+            json!({"hash": hash('d'), "tx": [hash('b')]}),
+        ];
+        for block in malformed {
+            assert!(parse_block_txids(&block, &hash('a')).is_err());
+        }
+    }
+}

--- a/crates/alkanes-contract-indexer/src/helpers/protostone.rs
+++ b/crates/alkanes-contract-indexer/src/helpers/protostone.rs
@@ -1,33 +1,21 @@
-use anyhow::{Context, Result};
-use bitcoin::consensus::encode::deserialize;
-use bitcoin::Transaction;
-use alkanes_cli_common::runestone_enhanced::format_runestone_with_decoded_messages;
-use alkanes_cli_common::traits::{DeezelProvider, JsonRpcProvider, BitcoinRpcProvider, EsploraProvider, AlkanesProvider};
 use alkanes_cli_common::proto::alkanes as alkanes_pb;
-use serde_json::{json, Value as JsonValue};
+use alkanes_cli_common::runestone_enhanced::format_runestone_with_decoded_messages;
+use alkanes_cli_common::traits::{
+    AlkanesProvider, BitcoinRpcProvider, DeezelProvider, EsploraProvider, JsonRpcProvider,
+};
+use anyhow::{Context, Result, bail};
+use bitcoin::Transaction;
+use bitcoin::consensus::encode::deserialize;
+use futures::stream::{self, StreamExt};
+use serde_json::{Value as JsonValue, json};
+use std::collections::HashMap;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tokio::time::{sleep, timeout, Duration};
-use futures::stream::{self, StreamExt};
+use tokio::time::{Duration, sleep, timeout};
 use tracing::{debug, error, info, warn};
-use crate::helpers::rpc::{resilient_call, resilient_call_with_last_error};
-use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use crate::helpers::block::tx_has_op_return;
-
-// Hardcoded list of txids to skip during trace/decode. These are big-endian txid strings.
-// If a txid appears here, it will be excluded from processing to avoid blocking a whole block.
-static IGNORED_TRACE_TXIDS: &[&str] = &[
-    "a807e8d4e91a6fa957c3f9929d267f6795971e41e6da61c44886deaa45797830",
-    "33c5a9f2d415b2b826a2ea1230d1849be0a74dc73857460c9c7674fe76147830",
-    "79c202e94c425320c91d6176108b93c033fb5a627fc2750453e97c6c434e7830",
-    "12a6c6f41a722e75d48caf57ed7a22feb56686c2ba51e226e6b6033ef3357830",
-    "6ee9eda5df0814af442f75db1d553f951f04699b854b9e0cff6d1395c2bdf075",
-    "c4c00e467ec76aa228a737156488b74dc27a998cf3056655612dbd3eeb5e6fb0",
-    "9d258d9e805ca9252101d5839aee46d63fbda8786e3f80988f5b10ce35aa060e",
-    "83d0deb1d223c932e0ff4306c0f408d17dbd520bd1dfb9e8d5823b711be77830",
-    "b19dd4c02942b0c2f19c5f11e9e4b1211051a779ff4bb8e84b02f37a2f415f6d"
-];
 
 #[derive(Debug, Clone)]
 struct TraceJob {
@@ -52,187 +40,213 @@ fn uint128_to_u128(u: &alkanes_pb::Uint128) -> u128 {
     ((u.hi as u128) << 64) | (u.lo as u128)
 }
 
-/// Helper to convert AlkaneId to (block_str, tx_str)
-fn alkane_id_to_strings(id: &alkanes_pb::AlkaneId) -> (String, String) {
-    let block = id.block.as_ref().map(|b| uint128_to_u128(b).to_string()).unwrap_or_default();
-    let tx = id.tx.as_ref().map(|t| uint128_to_u128(t).to_string()).unwrap_or_default();
-    (block, tx)
+/// Helper to convert AlkaneId to (block_str, tx_str) without normalizing malformed protobufs.
+fn alkane_id_to_strings(id: &alkanes_pb::AlkaneId, label: &str) -> Result<(String, String)> {
+    let block = id
+        .block
+        .as_ref()
+        .with_context(|| format!("{label}.block is missing"))?;
+    let tx = id
+        .tx
+        .as_ref()
+        .with_context(|| format!("{label}.tx is missing"))?;
+    Ok((
+        uint128_to_u128(block).to_string(),
+        uint128_to_u128(tx).to_string(),
+    ))
+}
+
+fn alkane_transfer_to_json(
+    transfer: &alkanes_pb::AlkaneTransfer,
+    label: &str,
+) -> Result<JsonValue> {
+    let id = transfer
+        .id
+        .as_ref()
+        .with_context(|| format!("{label}.id is missing"))?;
+    let value = transfer
+        .value
+        .as_ref()
+        .with_context(|| format!("{label}.value is missing"))?;
+    let (block, tx) = alkane_id_to_strings(id, &format!("{label}.id"))?;
+    Ok(json!({
+        "id": {
+            "block": block,
+            "tx": tx,
+        },
+        "value": uint128_to_u128(value).to_string(),
+    }))
 }
 
 /// Convert AlkanesTrace events to JSON format compatible with existing indexers
-fn convert_trace_to_events(trace: &alkanes_pb::AlkanesTrace, vout: i32) -> Vec<JsonValue> {
+fn convert_trace_to_events(trace: &alkanes_pb::AlkanesTrace, vout: i32) -> Result<Vec<JsonValue>> {
     let mut events = Vec::new();
-    
-    for event in &trace.events {
-        if let Some(ref ev) = event.event {
-            match ev {
-                alkanes_pb::alkanes_trace_event::Event::EnterContext(enter) => {
-                    let call_type = match enter.call_type {
-                        0 => "none",
-                        1 => "call",
-                        2 => "delegatecall",
-                        3 => "staticcall",
-                        _ => "unknown",
-                    };
-                    
-                    let mut data = json!({
-                        "type": call_type,
-                    });
-                    
-                    if let Some(ref ctx) = enter.context {
-                        if let Some(ref inner) = ctx.inner {
-                            // Extract context fields
-                            let (myself_block, myself_tx) = inner.myself.as_ref()
-                                .map(|m| alkane_id_to_strings(m))
-                                .unwrap_or_default();
-                            
-                            // Convert inputs (Uint128) to hex strings
-                            let inputs: Vec<String> = inner.inputs.iter()
-                                .map(|i| format!("0x{:x}", uint128_to_u128(i)))
-                                .collect();
-                            
-                            // Convert incoming alkanes
-                            let incoming_alkanes: Vec<JsonValue> = inner.incoming_alkanes.iter()
-                                .map(|a| {
-                                    let (block, tx) = a.id.as_ref()
-                                        .map(|id| alkane_id_to_strings(id))
-                                        .unwrap_or_default();
-                                    let value = a.value.as_ref().map(|v| uint128_to_u128(v)).unwrap_or(0);
-                                    json!({
-                                        "id": {
-                                            "block": block,
-                                            "tx": tx,
-                                        },
-                                        "value": value.to_string(),
-                                    })
-                                })
-                                .collect();
-                            
-                            data["context"] = json!({
-                                "myself": {
-                                    "block": myself_block,
-                                    "tx": myself_tx,
-                                },
-                                "inputs": inputs,
-                                "incomingAlkanes": incoming_alkanes,
-                                "fuel": ctx.fuel,
-                            });
-                        }
-                    }
-                    
-                    events.push(json!({
-                        "event": "invoke",
-                        "vout": vout,
-                        "data": data,
-                    }));
-                }
-                alkanes_pb::alkanes_trace_event::Event::ExitContext(exit) => {
-                    let status = match exit.status {
-                        0 => "success",
-                        1 => "failure",
-                        _ => "unknown",
-                    };
-                    
-                    let mut response_data = json!({});
-                    if let Some(ref resp) = exit.response {
-                        // Convert response alkanes
-                        let alkanes: Vec<JsonValue> = resp.alkanes.iter()
-                            .map(|a| {
-                                let (block, tx) = a.id.as_ref()
-                                    .map(|id| alkane_id_to_strings(id))
-                                    .unwrap_or_default();
-                                let value = a.value.as_ref().map(|v| uint128_to_u128(v)).unwrap_or(0);
-                                json!({
-                                    "id": {
-                                        "block": block,
-                                        "tx": tx,
-                                    },
-                                    "value": value.to_string(),
-                                })
-                            })
-                            .collect();
-                        response_data["alkanes"] = json!(alkanes);
-                    }
-                    
-                    events.push(json!({
-                        "event": "return",
-                        "vout": vout,
-                        "data": {
-                            "status": status,
-                            "response": response_data,
-                        },
-                    }));
-                }
-                alkanes_pb::alkanes_trace_event::Event::CreateAlkane(create) => {
-                    let (block, tx) = create.new_alkane.as_ref()
-                        .map(|id| alkane_id_to_strings(id))
-                        .unwrap_or_default();
-                    events.push(json!({
-                        "event": "create",
-                        "vout": vout,
-                        "data": {
-                            "newAlkane": {
-                                "block": block,
-                                "tx": tx,
-                            },
-                        },
-                    }));
-                }
-                alkanes_pb::alkanes_trace_event::Event::ReceiveIntent(receive_intent) => {
-                    let incoming_alkanes: Vec<JsonValue> = receive_intent.incoming_alkanes.iter()
-                        .map(|a| {
-                            let (block, tx) = a.id.as_ref()
-                                .map(|id| alkane_id_to_strings(id))
-                                .unwrap_or_default();
-                            let value = a.value.as_ref().map(|v| uint128_to_u128(v)).unwrap_or(0);
-                            json!({
-                                "id": {
-                                    "block": block,
-                                    "tx": tx,
-                                },
-                                "value": value.to_string(),
-                            })
-                        })
-                        .collect();
-                    events.push(json!({
-                        "event": "receive_intent",
-                        "vout": vout,
-                        "data": {
-                            "incomingAlkanes": incoming_alkanes,
-                        },
-                    }));
-                }
-                alkanes_pb::alkanes_trace_event::Event::ValueTransfer(value_transfer) => {
-                    let transfers: Vec<JsonValue> = value_transfer.transfers.iter()
-                        .map(|t| {
-                            let (block, tx) = t.id.as_ref()
-                                .map(|id| alkane_id_to_strings(id))
-                                .unwrap_or_default();
-                            let value = t.value.as_ref().map(|v| uint128_to_u128(v)).unwrap_or(0);
-                            json!({
-                                "id": {
-                                    "block": block,
-                                    "tx": tx,
-                                },
-                                "value": value.to_string(),
-                            })
-                        })
-                        .collect();
 
-                    events.push(json!({
-                        "event": "value_transfer",
-                        "vout": vout,
-                        "data": {
-                            "transfers": transfers,
-                            "redirect_to": value_transfer.redirect_to,
+    for (event_index, event) in trace.events.iter().enumerate() {
+        let ev = event
+            .event
+            .as_ref()
+            .with_context(|| format!("trace event {event_index} has no event payload"))?;
+        match ev {
+            alkanes_pb::alkanes_trace_event::Event::EnterContext(enter) => {
+                let call_type = match enter.call_type {
+                    0 => "none",
+                    1 => "call",
+                    2 => "delegatecall",
+                    3 => "staticcall",
+                    value => bail!("trace event {event_index} has unknown call type {value}"),
+                };
+                let ctx = enter.context.as_ref().with_context(|| {
+                    format!("trace event {event_index} enter context is missing")
+                })?;
+                let inner = ctx.inner.as_ref().with_context(|| {
+                    format!("trace event {event_index} inner context is missing")
+                })?;
+                let myself = inner.myself.as_ref().with_context(|| {
+                    format!("trace event {event_index} context.myself is missing")
+                })?;
+                let (myself_block, myself_tx) = alkane_id_to_strings(
+                    myself,
+                    &format!("trace event {event_index} context.myself"),
+                )?;
+
+                let inputs: Vec<String> = inner
+                    .inputs
+                    .iter()
+                    .map(|i| format!("0x{:x}", uint128_to_u128(i)))
+                    .collect();
+                let incoming_alkanes: Vec<JsonValue> = inner
+                    .incoming_alkanes
+                    .iter()
+                    .enumerate()
+                    .map(|(transfer_index, transfer)| {
+                        alkane_transfer_to_json(
+                            transfer,
+                            &format!("trace event {event_index} incoming alkane {transfer_index}"),
+                        )
+                    })
+                    .collect::<Result<_>>()?;
+
+                let data = json!({
+                    "type": call_type,
+                    "context": {
+                        "myself": {
+                            "block": myself_block,
+                            "tx": myself_tx,
                         },
-                    }));
+                        "inputs": inputs,
+                        "incomingAlkanes": incoming_alkanes,
+                        "fuel": ctx.fuel,
+                    },
+                });
+
+                events.push(json!({
+                    "event": "invoke",
+                    "vout": vout,
+                    "data": data,
+                }));
+            }
+            alkanes_pb::alkanes_trace_event::Event::ExitContext(exit) => {
+                let status = match exit.status {
+                    0 => "success",
+                    1 => "failure",
+                    value => bail!("trace event {event_index} has unknown exit status {value}"),
+                };
+
+                let mut response_data = json!({});
+                if let Some(ref resp) = exit.response {
+                    // Convert response alkanes
+                    let alkanes: Vec<JsonValue> = resp
+                        .alkanes
+                        .iter()
+                        .enumerate()
+                        .map(|(transfer_index, transfer)| {
+                            alkane_transfer_to_json(
+                                transfer,
+                                &format!(
+                                    "trace event {event_index} response alkane {transfer_index}"
+                                ),
+                            )
+                        })
+                        .collect::<Result<_>>()?;
+                    response_data["alkanes"] = json!(alkanes);
                 }
+
+                events.push(json!({
+                    "event": "return",
+                    "vout": vout,
+                    "data": {
+                        "status": status,
+                        "response": response_data,
+                    },
+                }));
+            }
+            alkanes_pb::alkanes_trace_event::Event::CreateAlkane(create) => {
+                let new_alkane = create
+                    .new_alkane
+                    .as_ref()
+                    .with_context(|| format!("trace event {event_index} new alkane is missing"))?;
+                let (block, tx) = alkane_id_to_strings(
+                    new_alkane,
+                    &format!("trace event {event_index} new alkane"),
+                )?;
+                events.push(json!({
+                    "event": "create",
+                    "vout": vout,
+                    "data": {
+                        "newAlkane": {
+                            "block": block,
+                            "tx": tx,
+                        },
+                    },
+                }));
+            }
+            alkanes_pb::alkanes_trace_event::Event::ReceiveIntent(receive_intent) => {
+                let incoming_alkanes: Vec<JsonValue> = receive_intent
+                    .incoming_alkanes
+                    .iter()
+                    .enumerate()
+                    .map(|(transfer_index, transfer)| {
+                        alkane_transfer_to_json(
+                            transfer,
+                            &format!("trace event {event_index} receive alkane {transfer_index}"),
+                        )
+                    })
+                    .collect::<Result<_>>()?;
+                events.push(json!({
+                    "event": "receive_intent",
+                    "vout": vout,
+                    "data": {
+                        "incomingAlkanes": incoming_alkanes,
+                    },
+                }));
+            }
+            alkanes_pb::alkanes_trace_event::Event::ValueTransfer(value_transfer) => {
+                let transfers: Vec<JsonValue> = value_transfer
+                    .transfers
+                    .iter()
+                    .enumerate()
+                    .map(|(transfer_index, transfer)| {
+                        alkane_transfer_to_json(
+                            transfer,
+                            &format!("trace event {event_index} value transfer {transfer_index}"),
+                        )
+                    })
+                    .collect::<Result<_>>()?;
+
+                events.push(json!({
+                    "event": "value_transfer",
+                    "vout": vout,
+                    "data": {
+                        "transfers": transfers,
+                        "redirect_to": value_transfer.redirect_to,
+                    },
+                }));
             }
         }
     }
-    
-    events
+
+    Ok(events)
 }
 
 async fn trace_call<P: AlkanesProvider + DeezelProvider + JsonRpcProvider + Send + Sync>(
@@ -247,22 +261,26 @@ async fn trace_call<P: AlkanesProvider + DeezelProvider + JsonRpcProvider + Send
         hex::encode(bytes)
     };
     let outpoint_str = format!("{}:{}", txid_be, job.vout);
-    
+
     // Use AlkanesProvider::trace() which properly decodes the protobuf response
-    let trace_pb = provider.trace(&outpoint_str).await
+    let trace_pb = provider
+        .trace(&outpoint_str)
+        .await
         .context("AlkanesProvider::trace call failed")?;
-    
+
     // Convert to JSON events
-    let events = if let Some(ref alkanes_trace) = trace_pb.trace {
-        convert_trace_to_events(alkanes_trace, job.vout as i32)
-    } else {
-        Vec::new()
-    };
-    
+    let alkanes_trace = trace_pb
+        .trace
+        .as_ref()
+        .context("AlkanesProvider::trace response is missing trace payload")?;
+    let events = convert_trace_to_events(alkanes_trace, job.vout as i32)?;
+
     Ok(events)
 }
 
-async fn tx_from_json_or_fetch_hex<P: DeezelProvider + JsonRpcProvider + BitcoinRpcProvider + EsploraProvider + Send + Sync>(
+async fn tx_from_json_or_fetch_hex<
+    P: DeezelProvider + JsonRpcProvider + BitcoinRpcProvider + EsploraProvider + Send + Sync,
+>(
     provider: &P,
     tx_json: &JsonValue,
 ) -> Result<Transaction> {
@@ -296,11 +314,15 @@ async fn tx_from_json_or_fetch_hex<P: DeezelProvider + JsonRpcProvider + Bitcoin
                     warn!(%txid, attempt, "get_tx_hex timed out; will retry or fall back");
                 }
             }
-            if attempt >= 2 { break String::new(); }
+            if attempt >= 2 {
+                break String::new();
+            }
             sleep(Duration::from_millis(200 * attempt as u64)).await;
         }
     };
-    let hex_str = if !hex_str.is_empty() { hex_str } else {
+    let hex_str = if !hex_str.is_empty() {
+        hex_str
+    } else {
         info!(%txid, "falling back to BitcoinRpcProvider::get_transaction_hex");
         let mut attempt = 0;
         loop {
@@ -318,7 +340,10 @@ async fn tx_from_json_or_fetch_hex<P: DeezelProvider + JsonRpcProvider + Bitcoin
                 }
             }
             if attempt >= 3 {
-                return Err(_last_err.unwrap_or_else(|| anyhow::anyhow!("get_transaction_hex failed"))).context("get_transaction_hex call failed");
+                return Err(
+                    _last_err.unwrap_or_else(|| anyhow::anyhow!("get_transaction_hex failed"))
+                )
+                .context("get_transaction_hex call failed");
             }
             sleep(Duration::from_millis(200 * attempt as u64)).await;
         }
@@ -370,25 +395,30 @@ pub async fn decode_and_trace_for_block<P>(
     _max_trace_concurrency: usize,
 ) -> Result<Vec<TxDecodeTraceResult>>
 where
-    P: AlkanesProvider + DeezelProvider + JsonRpcProvider + BitcoinRpcProvider + EsploraProvider + Send + Sync,
+    P: AlkanesProvider
+        + DeezelProvider
+        + JsonRpcProvider
+        + BitcoinRpcProvider
+        + EsploraProvider
+        + Send
+        + Sync,
 {
     let url = resolve_sandshrew_url(provider);
-    info!(txs = txs.len(), "decode_and_trace_for_block: start (batched parallel)");
+    info!(
+        txs = txs.len(),
+        "decode_and_trace_for_block: start (batched parallel)"
+    );
     // Only OP_RETURN txs
-    let op_return_txs: Vec<JsonValue> = txs.iter().filter(|t| tx_has_op_return(t)).cloned().collect();
-    // Skip txids explicitly ignored
-    let op_return_txs: Vec<JsonValue> = op_return_txs
-        .into_iter()
-        .filter(|t| {
-            let id = t.get("txid").and_then(|v| v.as_str()).unwrap_or("");
-            let skip = IGNORED_TRACE_TXIDS.contains(&id);
-            if skip { info!(%id, "skipping txid from ignore list"); }
-            !skip
-        })
+    let op_return_txs: Vec<JsonValue> = txs
+        .iter()
+        .filter(|t| tx_has_op_return(t))
+        .cloned()
         .collect();
     let total = op_return_txs.len();
     info!(op_return_txs = total, "filtered OP_RETURN transactions");
-    if total == 0 { return Ok(Vec::new()); }
+    if total == 0 {
+        return Ok(Vec::new());
+    }
 
     // Split into up to 10 batches and process each batch concurrently.
     let num_batches = usize::min(10, total);
@@ -429,7 +459,16 @@ where
                         let txid_be = formatted.get("transaction_id").and_then(|v| v.as_str()).map(|s| s.to_string()).unwrap_or_else(|| tx.compute_txid().to_string());
                         let txid_le = to_little_endian_hex(&txid_be);
                         let start = (tx.output.len() as u32) + 1;
-                        let protos = formatted.get("protostones").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+                        let Some(protos) = formatted
+                            .get("protostones")
+                            .and_then(|value| value.as_array())
+                            .cloned()
+                        else {
+                            *fatal_err.lock().await = Some(format!(
+                                "protostone decode result is missing its array for {txid_be}"
+                            ));
+                            return;
+                        };
                         info!(batch = batch_idx, %txid_be, protostones = protos.len(), start_vout = start, "decoded runestone");
                         let mut decoded_items: Vec<DecodedProtostoneItem> = Vec::with_capacity(protos.len());
                         let mut trace_events: Vec<TraceEventItem> = Vec::new();
@@ -439,6 +478,12 @@ where
                         for (i, p) in protos.iter().enumerate() {
                             let vout = start + i as u32;
                             info!(batch = batch_idx, %txid_be, protostone_idx = i, vout, "calling trace");
+                            if p.get("message_decoded").is_none_or(JsonValue::is_null) {
+                                *fatal_err.lock().await = Some(format!(
+                                    "protostone message decode is incomplete for {txid_be} vout {vout}"
+                                ));
+                                return;
+                            }
                             let job = TraceJob { txid_le_hex: txid_le.clone(), vout, protostone_idx: i };
                             debug!(batch = batch_idx, %txid_be, protostone_idx = i, "dispatching trace job");
                             decoded_items.push(DecodedProtostoneItem { vout: vout as i32, protostone_index: i as i32, decoded: p.clone() });
@@ -451,8 +496,21 @@ where
                                     
                                     // Process events - they are already in the correct format from convert_trace_to_events
                                     for ev in &events {
-                                        let event_type = ev.get("event").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
-                                        let data = ev.get("data").cloned().unwrap_or_else(|| serde_json::json!({}));
+                                        let Some(event_type) = ev.get("event").and_then(|v| v.as_str()) else {
+                                            *fatal_err.lock().await = Some(format!(
+                                                "trace event is missing event type for {} vout {}",
+                                                txid_be, vout
+                                            ));
+                                            return;
+                                        };
+                                        let Some(data) = ev.get("data").cloned() else {
+                                            *fatal_err.lock().await = Some(format!(
+                                                "trace event is missing data for {} vout {}",
+                                                txid_be, vout
+                                            ));
+                                            return;
+                                        };
+                                        let event_type = event_type.to_string();
                                         
                                         // Check for success status in return events
                                         if event_type == "return" {
@@ -462,9 +520,23 @@ where
                                         
                                         // Extract alkane address from invoke context
                                         let (blk_str, tx_str) = if event_type == "invoke" {
-                                            let blk = data.get("context").and_then(|c| c.get("myself")).and_then(|m| m.get("block")).and_then(|v| v.as_str()).unwrap_or("").to_string();
-                                            let tx = data.get("context").and_then(|c| c.get("myself")).and_then(|m| m.get("tx")).and_then(|v| v.as_str()).unwrap_or("").to_string();
-                                            (blk, tx)
+                                            let myself = data.get("context")
+                                                .and_then(|c| c.get("myself"));
+                                            let Some(blk) = myself.and_then(|m| m.get("block")).and_then(|v| v.as_str()) else {
+                                                *fatal_err.lock().await = Some(format!(
+                                                    "invoke trace is missing context.myself.block for {} vout {}",
+                                                    txid_be, vout
+                                                ));
+                                                return;
+                                            };
+                                            let Some(tx) = myself.and_then(|m| m.get("tx")).and_then(|v| v.as_str()) else {
+                                                *fatal_err.lock().await = Some(format!(
+                                                    "invoke trace is missing context.myself.tx for {} vout {}",
+                                                    txid_be, vout
+                                                ));
+                                                return;
+                                            };
+                                            (blk.to_string(), tx.to_string())
                                         } else { (String::new(), String::new()) };
                                         
                                         trace_events.push(TraceEventItem {
@@ -484,15 +556,6 @@ where
                                         combined.push_str(" | ");
                                         combined.push_str(&cause.to_string());
                                     }
-                                    let lc = combined.to_ascii_lowercase();
-                                    // Known upstream non-deterministic client error from alkanes base-rpc addHexPrefix
-                                    // Example contains: "non-standard error object received" and "cannot read properties of undefined (reading 'substr')"
-                                    let is_known_upstream_typeerror = lc.contains("non-standard error object received") && lc.contains("cannot read properties of undefined");
-                                    if is_known_upstream_typeerror {
-                                        warn!(batch = batch_idx, %txid_be, protostone_idx = i, vout, error = %combined, "trace returned upstream TypeError; skipping this protostone");
-                                        // Do not set has_trace; continue with next protostone/tx
-                                        continue;
-                                    }
                                     error!(batch = batch_idx, %txid_be, protostone_idx = i, vout, error = ?e, "trace failed; aborting block batch");
                                     // Record fatal error to fail the block rather than proceeding with partial results
                                     *fatal_err.lock().await = Some(format!("trace failed for {} vout {}: {}", txid_be, vout, combined));
@@ -510,7 +573,11 @@ where
                         };
                         results.lock().await.push(result);
                     }
-                    Ok(Err(e)) => { warn!(batch = batch_idx, %txid_str, error = %e, "protostone decode failed; skipping tx"); }
+                    Ok(Err(e)) => {
+                        error!(batch = batch_idx, %txid_str, error = %e, "protostone decode failed; aborting block batch");
+                        *fatal_err.lock().await = Some(format!("protostone decode failed for {}: {}", txid_str, e));
+                        return;
+                    }
                     Err(panic) => {
                         let panic_msg: &str = if let Some(s) = panic.downcast_ref::<&str>() {
                             s
@@ -519,7 +586,9 @@ where
                         } else {
                             "panic"
                         };
-                        error!(batch = batch_idx, %txid_str, message = %panic_msg, "protostone decode panicked; skipping tx");
+                        error!(batch = batch_idx, %txid_str, message = %panic_msg, "protostone decode panicked; aborting block batch");
+                        *fatal_err.lock().await = Some(format!("protostone decode panicked for {}: {}", txid_str, panic_msg));
+                        return;
                     }
                 }
             }
@@ -534,8 +603,97 @@ where
         return Err(anyhow::anyhow!(err));
     }
 
-    let out = results.lock().await.clone();
-    Ok(out)
+    let mut by_txid = HashMap::with_capacity(total);
+    for result in results.lock().await.clone() {
+        let result_txid = result.transaction_id.clone();
+        if by_txid.insert(result_txid.clone(), result).is_some() {
+            return Err(anyhow::anyhow!("duplicate trace result for {result_txid}"));
+        }
+    }
+    let mut ordered = Vec::with_capacity(total);
+    for tx in &op_return_txs {
+        let txid = tx
+            .get("txid")
+            .and_then(|value| value.as_str())
+            .context("OP_RETURN transaction is missing txid")?;
+        ordered.push(by_txid.remove(txid).with_context(|| {
+            format!("trace pipeline produced no result for OP_RETURN transaction {txid}")
+        })?);
+    }
+    if !by_txid.is_empty() {
+        return Err(anyhow::anyhow!(
+            "trace pipeline returned transactions outside the source block"
+        ));
+    }
+    Ok(ordered)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alkanes_pb::alkanes_trace_event::Event;
 
+    fn uint128(value: u64) -> alkanes_pb::Uint128 {
+        alkanes_pb::Uint128 { lo: value, hi: 0 }
+    }
+
+    #[test]
+    fn trace_event_without_payload_fails_closed() {
+        let trace = alkanes_pb::AlkanesTrace {
+            events: vec![alkanes_pb::AlkanesTraceEvent { event: None }],
+        };
+
+        assert!(convert_trace_to_events(&trace, 1).is_err());
+    }
+
+    #[test]
+    fn transfer_without_id_or_value_fails_closed() {
+        let missing_id = alkanes_pb::AlkaneTransfer {
+            id: None,
+            value: Some(uint128(1)),
+        };
+        let missing_value = alkanes_pb::AlkaneTransfer {
+            id: Some(alkanes_pb::AlkaneId {
+                block: Some(uint128(4)),
+                tx: Some(uint128(10)),
+            }),
+            value: None,
+        };
+
+        for transfer in [missing_id, missing_value] {
+            let trace = alkanes_pb::AlkanesTrace {
+                events: vec![alkanes_pb::AlkanesTraceEvent {
+                    event: Some(Event::ValueTransfer(alkanes_pb::AlkanesValueTransfer {
+                        transfers: vec![transfer],
+                        redirect_to: 0,
+                    })),
+                }],
+            };
+            assert!(convert_trace_to_events(&trace, 1).is_err());
+        }
+    }
+
+    #[test]
+    fn transfer_conversion_preserves_full_u128_value() {
+        let trace = alkanes_pb::AlkanesTrace {
+            events: vec![alkanes_pb::AlkanesTraceEvent {
+                event: Some(Event::ValueTransfer(alkanes_pb::AlkanesValueTransfer {
+                    transfers: vec![alkanes_pb::AlkaneTransfer {
+                        id: Some(alkanes_pb::AlkaneId {
+                            block: Some(uint128(4)),
+                            tx: Some(uint128(10)),
+                        }),
+                        value: Some(alkanes_pb::Uint128 { lo: 7, hi: 1 }),
+                    }],
+                    redirect_to: 0,
+                })),
+            }],
+        };
+
+        let events = convert_trace_to_events(&trace, 1).unwrap();
+        assert_eq!(
+            events[0]["data"]["transfers"][0]["value"],
+            JsonValue::String(((1_u128 << 64) + 7).to_string())
+        );
+    }
+}

--- a/crates/alkanes-contract-indexer/src/lib.rs
+++ b/crates/alkanes-contract-indexer/src/lib.rs
@@ -1,13 +1,12 @@
+pub mod canonical_commit;
 pub mod config;
+pub mod coordinator;
 pub mod db;
 pub mod helpers;
 pub mod inferred_transfers;
-pub mod schema;
-pub mod progress;
-pub mod coordinator;
 pub mod pipeline;
 pub mod poller;
+pub mod progress;
 pub mod provider;
+pub mod schema;
 pub mod transform_integration;
-
-

--- a/crates/alkanes-contract-indexer/src/main.rs
+++ b/crates/alkanes-contract-indexer/src/main.rs
@@ -1,18 +1,19 @@
 use anyhow::Result;
 use dotenvy::dotenv;
-use tracing::info;
-use tracing_subscriber::{fmt, EnvFilter};
 use tokio::sync::oneshot;
+use tracing::info;
+use tracing_subscriber::{EnvFilter, fmt};
 
+mod canonical_commit;
 mod config;
-mod db;
-mod progress;
 mod coordinator;
-mod pipeline;
-mod poller;
-mod provider;
+mod db;
 mod helpers;
 mod inferred_transfers;
+mod pipeline;
+mod poller;
+mod progress;
+mod provider;
 mod transform_integration;
 use crate::db::blocks::ensure_processed_blocks_table;
 
@@ -35,14 +36,24 @@ async fn main() -> Result<()> {
 
     // Ensure ProcessedBlocks exists (defensive)
     ensure_processed_blocks_table(&pool).await?;
-    
+
     // Apply trace transform schema
     info!("Applying trace transform schema...");
     let mut transform_service = transform_integration::TraceTransformService::new(pool.clone());
     transform_service.apply_schema().await?;
     // Load existing pools from database
     transform_service.load_existing_pools().await?;
-    info!("Trace transform schema applied and {} pools loaded", transform_service.known_pools.len());
+    info!(
+        "Trace transform schema applied and {} pools loaded",
+        transform_service.known_pools.len()
+    );
+
+    // Canonical publication is the only Marketplace visibility boundary. Legacy progress without
+    // a matching commitment is refused so deployments cannot silently bless partial history.
+    progress::ensure_position_table(&pool).await?;
+    progress::migrate_from_kv_store(&pool).await?;
+    canonical_commit::ensure_schema(&pool).await?;
+    canonical_commit::verify_bootstrap_state(&pool).await?;
 
     // Provider
     let provider = provider::build_provider(
@@ -54,11 +65,6 @@ async fn main() -> Result<()> {
     .await?;
 
     // Pipeline and poller
-    // Bootstrap position table used for progress tracking
-    progress::ensure_position_table(&pool).await?;
-    // Migrate from old kv_store if needed
-    progress::migrate_from_kv_store(&pool).await?;
-
     let pipeline = pipeline::Pipeline::new(
         pool.clone(),
         cfg.factory_block_id.clone(),
@@ -99,7 +105,12 @@ async fn main() -> Result<()> {
         cfg.network_provider.clone(),
     )
     .await?;
-    let coordinator = coordinator::CatchUpCoordinator::new(coord_provider, pipeline, progress_store, cfg.start_height);
+    let coordinator = coordinator::CatchUpCoordinator::new(
+        coord_provider,
+        pipeline,
+        progress_store,
+        cfg.start_height,
+    );
     let coordinator_fut = async move {
         // Wait for initial pools refresh + height init before starting catch-up
         let _ = poller_init_rx.await;

--- a/crates/alkanes-contract-indexer/src/pipeline.rs
+++ b/crates/alkanes-contract-indexer/src/pipeline.rs
@@ -1,420 +1,969 @@
-use anyhow::Result;
-use alkanes_cli_sys::SystemAlkanes as ConcreteProvider;
-use alkanes_cli_common::traits::{DeezelProvider, JsonRpcProvider, BitcoinRpcProvider};
-use sqlx::PgPool;
-use tracing::{info, warn};
-use crate::helpers::pools::{fetch_and_upsert_pools_for_tip};
+use crate::canonical_commit::{self, PrepareOutcome};
+use crate::db::transactions::replace_pool_creations;
+use crate::db::transactions::{
+    replace_decoded_protostones, replace_trace_events, upsert_alkane_transactions,
+};
+use crate::helpers::block::{
+    canonical_tip_height, get_block_hash as helper_get_block_hash,
+    get_block_txids as helper_get_block_txids,
+    get_transactions_info as helper_get_transactions_info, tx_has_op_return,
+};
 use crate::helpers::notify::{notify_pools_processed, publish_block_processed};
-use crate::helpers::block::{get_block_hash as helper_get_block_hash, get_block_txids as helper_get_block_txids, get_transactions_info as helper_get_transactions_info, tx_has_op_return};
-use crate::helpers::protostone::decode_and_trace_for_block;
-use crate::helpers::protostone::TxDecodeTraceResult;
-use crate::db::transactions::{upsert_alkane_transactions, replace_trace_events, replace_decoded_protostones};
-use crate::helpers::poolswap::index_pool_swaps_for_block;
+use crate::helpers::poolburn::index_pool_burns_for_block;
 use crate::helpers::poolcreate::index_pool_creations_for_block;
 use crate::helpers::poolmint::index_pool_mints_for_block;
-use crate::helpers::poolburn::index_pool_burns_for_block;
-use crate::helpers::subfrost::{index_subfrost_wraps_for_block, index_subfrost_unwraps_for_block};
-use crate::db::transactions::replace_pool_creations;
-use chrono::{TimeZone, Utc};
-use chrono::DateTime;
-use std::time::Instant;
-use crate::transform_integration::{TraceTransformService, convert_trace_event, convert_transaction_context};
+use crate::helpers::pools::fetch_and_upsert_pools_for_tip;
+use crate::helpers::poolswap::index_pool_swaps_for_block;
+use crate::helpers::protostone::TxDecodeTraceResult;
+use crate::helpers::protostone::decode_and_trace_for_block;
+use crate::helpers::subfrost::{index_subfrost_unwraps_for_block, index_subfrost_wraps_for_block};
+use crate::transform_integration::{
+    TraceTransformService, convert_trace_event, convert_transaction_context,
+};
+use alkanes_cli_common::traits::{
+    BitcoinRpcProvider, DeezelProvider, JsonRpcProvider, MetashrewRpcProvider,
+};
+use alkanes_cli_sys::SystemAlkanes as ConcreteProvider;
 use alkanes_trace_transform::types::VoutInfo;
+use anyhow::{Context, Result, anyhow};
+use chrono::DateTime;
+use chrono::{TimeZone, Utc};
+use sqlx::PgPool;
+use std::collections::HashSet;
+use std::time::Instant;
+use tracing::{info, warn};
 
 #[derive(Clone, Debug)]
 pub struct BlockContext {
-	pub height: u64,
-	pub emit_publish: bool,
+    pub height: u64,
+    pub emit_publish: bool,
+}
+
+fn spent_outpoints_from_transactions(txs: &[serde_json::Value]) -> Result<Vec<(String, i32)>> {
+    let mut outpoints = Vec::new();
+    for tx in txs {
+        let txid = tx
+            .get("txid")
+            .and_then(|value| value.as_str())
+            .unwrap_or("<unknown>");
+        let inputs = tx
+            .get("vin")
+            .and_then(|value| value.as_array())
+            .with_context(|| format!("transaction {txid} vin must be an array"))?;
+        for input in inputs {
+            let is_coinbase = input
+                .get("is_coinbase")
+                .map(|value| value.as_bool().context("vin.is_coinbase must be boolean"))
+                .transpose()?
+                .unwrap_or(false);
+            if is_coinbase {
+                continue;
+            }
+            let previous_txid = input
+                .get("txid")
+                .and_then(|value| value.as_str())
+                .context("non-coinbase vin is missing txid")?;
+            if previous_txid.len() != 64
+                || !previous_txid
+                    .as_bytes()
+                    .iter()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+            {
+                return Err(anyhow!(
+                    "non-coinbase vin txid is not canonical lowercase hexadecimal"
+                ));
+            }
+            let previous_vout = input
+                .get("vout")
+                .and_then(|value| value.as_u64())
+                .context("non-coinbase vin is missing a non-negative vout")?;
+            outpoints.push((
+                previous_txid.to_owned(),
+                i32::try_from(previous_vout).context("vin.vout exceeds PostgreSQL INTEGER")?,
+            ));
+        }
+    }
+    Ok(outpoints)
+}
+
+fn canonical_hash(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .as_bytes()
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+}
+
+fn verify_source_transactions(
+    txids: &[String],
+    txs: &[serde_json::Value],
+    expected_height: u64,
+    expected_block_hash: &str,
+) -> Result<DateTime<Utc>> {
+    if txids.len() != txs.len() {
+        return Err(anyhow!(
+            "source block declared {} transactions but {} bodies were returned",
+            txids.len(),
+            txs.len()
+        ));
+    }
+    let expected: HashSet<&str> = txids.iter().map(String::as_str).collect();
+    if expected.len() != txids.len() {
+        return Err(anyhow!("source block transaction list contains duplicates"));
+    }
+    if !canonical_hash(expected_block_hash) || txids.iter().any(|txid| !canonical_hash(txid)) {
+        return Err(anyhow!(
+            "source block or transaction hash is not canonical lowercase hexadecimal"
+        ));
+    }
+    let mut observed = HashSet::with_capacity(txs.len());
+    let mut block_timestamp = None;
+    for (tx_index, tx) in txs.iter().enumerate() {
+        let txid = tx
+            .get("txid")
+            .and_then(|value| value.as_str())
+            .context("source transaction body is missing txid")?;
+        if !canonical_hash(txid) {
+            return Err(anyhow!(
+                "source transaction body contains a non-canonical txid"
+            ));
+        }
+        if !observed.insert(txid) {
+            return Err(anyhow!(
+                "source transaction bodies contain duplicate txid {txid}"
+            ));
+        }
+
+        let vin = tx
+            .get("vin")
+            .and_then(serde_json::Value::as_array)
+            .with_context(|| format!("source transaction {txid} vin must be an array"))?;
+        if vin.is_empty() {
+            return Err(anyhow!("source transaction {txid} cannot have an empty vin"));
+        }
+        let vout = tx
+            .get("vout")
+            .and_then(serde_json::Value::as_array)
+            .with_context(|| format!("source transaction {txid} vout must be an array"))?;
+        if vout.is_empty() {
+            return Err(anyhow!("source transaction {txid} cannot have an empty vout"));
+        }
+        for (vout_index, output) in vout.iter().enumerate() {
+            let script = output
+                .get("scriptpubkey")
+                .and_then(serde_json::Value::as_str)
+                .with_context(|| {
+                    format!("source transaction {txid} vout {vout_index} is missing scriptpubkey")
+                })?;
+            if script.len() % 2 != 0
+                || !script
+                    .as_bytes()
+                    .iter()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+            {
+                return Err(anyhow!(
+                    "source transaction {txid} vout {vout_index} has non-canonical scriptpubkey"
+                ));
+            }
+            output
+                .get("value")
+                .and_then(serde_json::Value::as_u64)
+                .with_context(|| {
+                    format!(
+                        "source transaction {txid} vout {vout_index} value must be a non-negative u64"
+                    )
+                })?;
+        }
+
+        let status = tx
+            .get("status")
+            .context("source transaction is missing confirmation status")?;
+        if status.get("confirmed").and_then(serde_json::Value::as_bool) != Some(true) {
+            return Err(anyhow!("source transaction {txid} is not confirmed"));
+        }
+        if status
+            .get("block_height")
+            .and_then(serde_json::Value::as_u64)
+            != Some(expected_height)
+        {
+            return Err(anyhow!(
+                "source transaction {txid} does not belong to the requested block height"
+            ));
+        }
+        if status
+            .get("block_hash")
+            .and_then(serde_json::Value::as_str)
+            != Some(expected_block_hash)
+        {
+            return Err(anyhow!(
+                "source transaction {txid} does not belong to the requested block hash"
+            ));
+        }
+        let timestamp_seconds = status
+            .get("block_time")
+            .and_then(serde_json::Value::as_i64)
+            .with_context(|| format!("source transaction {txid} is missing status.block_time"))?;
+        let timestamp = Utc
+            .timestamp_opt(timestamp_seconds, 0)
+            .single()
+            .with_context(|| format!("source transaction {txid} has invalid status.block_time"))?;
+        if block_timestamp
+            .replace(timestamp)
+            .is_some_and(|previous| previous != timestamp)
+        {
+            return Err(anyhow!(
+                "source transaction {tx_index} reports a different block timestamp"
+            ));
+        }
+    }
+    if observed != expected {
+        return Err(anyhow!(
+            "source transaction bodies do not exactly match the block txid set"
+        ));
+    }
+    block_timestamp.context("source block contains no transaction timestamp")
 }
 
 #[derive(Clone, Debug)]
 pub struct Pipeline {
-	pool: PgPool,
-	factory_block_id: String,
-	factory_tx_id: String,
+    pool: PgPool,
+    factory_block_id: String,
+    factory_tx_id: String,
 }
 
 impl Pipeline {
-	pub fn new(pool: PgPool, factory_block_id: String, factory_tx_id: String) -> Self {
-		Self { pool, factory_block_id, factory_tx_id }
-	}
+    pub fn new(pool: PgPool, factory_block_id: String, factory_tx_id: String) -> Self {
+        Self {
+            pool,
+            factory_block_id,
+            factory_tx_id,
+        }
+    }
 
-	// Runs on every new tip height (even during catch-up)
-	pub async fn fetch_pools_for_tip(&self, provider: &ConcreteProvider, tip_height: u64) -> Result<()> {
-		let res = fetch_and_upsert_pools_for_tip(
-			provider,
-			&self.pool,
-			&self.factory_block_id,
-			&self.factory_tx_id,
-			tip_height,
-		).await;
-		if res.is_ok() {
-			notify_pools_processed(tip_height).await;
-		}
-		res
-	}
+    /// Compare the last published commitment with Bitcoin Core and atomically remove a forked
+    /// suffix. This runs even when caught up, so a same-height replacement cannot go unnoticed.
+    pub async fn reconcile_canonical<P>(&self, provider: &P) -> Result<Option<u64>>
+    where
+        P: BitcoinRpcProvider + MetashrewRpcProvider + DeezelProvider + Send + Sync,
+    {
+        let mut serial_guard = self.pool.begin().await?;
+        canonical_commit::acquire_serial_lock(&mut serial_guard).await?;
+        let Some(tip) = canonical_commit::latest_commit(&self.pool).await? else {
+            serial_guard.commit().await?;
+            return Ok(None);
+        };
+        let source_tip_height = canonical_tip_height(provider).await?;
+        if tip.height <= source_tip_height
+            && helper_get_block_hash(provider, tip.height).await? == tip.block_hash
+        {
+            serial_guard.commit().await?;
+            return Ok(None);
+        }
 
-	/// Sequential per-block processing (historical and then following tip)
-	/// Returns the block hash on success for position tracking
-	pub async fn process_block_sequential<P>(&self, provider: &P, ctx: BlockContext) -> Result<String>
-	where
-		P: DeezelProvider + JsonRpcProvider + BitcoinRpcProvider + alkanes_cli_common::traits::AlkanesProvider + alkanes_cli_common::traits::EsploraProvider + Send + Sync,
-	{
-		// Resolve block hash via bitcoind and print/log it
-		let block_hash = helper_get_block_hash(provider, ctx.height).await?;
-		info!(height = ctx.height, %block_hash, "resolved block hash");
+        let commits = canonical_commit::commits_descending(&self.pool).await?;
+        let mut ancestor = None;
+        for commit in &commits {
+            if commit.height > source_tip_height {
+                continue;
+            }
+            let canonical_hash = helper_get_block_hash(provider, commit.height).await?;
+            if canonical_hash == commit.block_hash {
+                ancestor = Some((commit.height, commit.block_hash.clone()));
+                break;
+            }
+        }
+        let epoch = canonical_commit::rollback_to_common_ancestor(&self.pool, ancestor).await?;
+        serial_guard.commit().await?;
+        Ok(Some(epoch))
+    }
 
-		// Fetch txids for the block via JSON-RPC helper
-		let txids = helper_get_block_txids(provider, &block_hash).await?;
-		info!(height = ctx.height, count = txids.len(), "esplora_block::txids fetched");
+    // Runs on every new tip height (even during catch-up)
+    pub async fn fetch_pools_for_tip(
+        &self,
+        provider: &ConcreteProvider,
+        tip_height: u64,
+    ) -> Result<()> {
+        let res = fetch_and_upsert_pools_for_tip(
+            provider,
+            &self.pool,
+            &self.factory_block_id,
+            &self.factory_tx_id,
+            tip_height,
+        )
+        .await;
+        if res.is_ok() {
+            notify_pools_processed(tip_height).await;
+        }
+        res
+    }
 
-		// Fetch tx infos concurrently using helper and maintain order
-		let txs = helper_get_transactions_info(provider, &txids, 25).await?;
-		info!(height = ctx.height, txs = txs.len(), "esplora_tx fetched");
+    /// Sequential per-block processing (historical and then following tip)
+    /// Returns the block hash on success for position tracking
+    pub async fn process_block_sequential<P>(
+        &self,
+        provider: &P,
+        ctx: BlockContext,
+    ) -> Result<String>
+    where
+        P: DeezelProvider
+            + JsonRpcProvider
+            + BitcoinRpcProvider
+            + alkanes_cli_common::traits::AlkanesProvider
+            + alkanes_cli_common::traits::EsploraProvider
+            + Send
+            + Sync,
+    {
+        // The poller and catch-up coordinator run concurrently. A transaction-scoped advisory lock
+        // serializes the complete staging/publish interval, including failed attempts.
+        let mut serial_guard = self.pool.begin().await?;
+        canonical_commit::acquire_serial_lock(&mut serial_guard).await?;
+        let transform_height =
+            i32::try_from(ctx.height).map_err(|_| anyhow!("block height exceeds transform i32"))?;
 
-		// Filter for OP_RETURN outputs
-		let opret_count: usize = txs.iter().filter(|tx| tx_has_op_return(tx)).count();
-		info!(height = ctx.height, op_return_txs = opret_count, "OP_RETURN transactions in block");
+        // Resolve block hash via bitcoind and print/log it
+        let block_hash = helper_get_block_hash(provider, ctx.height).await?;
+        let previous_block_hash = if ctx.height == 0 {
+            canonical_commit::ZERO_BLOCK_HASH.to_owned()
+        } else {
+            helper_get_block_hash(provider, ctx.height - 1).await?
+        };
+        match canonical_commit::prepare_height(
+            &self.pool,
+            ctx.height,
+            &block_hash,
+            &previous_block_hash,
+        )
+        .await?
+        {
+            PrepareOutcome::AlreadyCommitted => {
+                serial_guard.commit().await?;
+                return Ok(block_hash);
+            }
+            PrepareOutcome::Ready => {}
+        }
+        info!(height = ctx.height, %block_hash, "resolved block hash");
 
-		// Build filtered list of OP_RETURN transactions only
-		let op_return_txs: Vec<_> = txs.iter().filter(|tx| tx_has_op_return(tx)).cloned().collect();
+        // Fetch txids for the block via JSON-RPC helper
+        let txids = helper_get_block_txids(provider, &block_hash).await?;
+        info!(
+            height = ctx.height,
+            count = txids.len(),
+            "esplora_block::txids fetched"
+        );
 
-		// Decode+trace protostones for this block (only OP_RETURN txs) with timing
-		if !op_return_txs.is_empty() {
-			let count = op_return_txs.len();
-			let t0 = Instant::now();
-			info!(height = ctx.height, op_return_txs = count, "decode_and_trace_for_block: start");
-			let results: Vec<TxDecodeTraceResult> = decode_and_trace_for_block(provider, &op_return_txs, 32, 16).await?;
+        // Fetch tx infos concurrently using helper and maintain order
+        let txs = helper_get_transactions_info(provider, &txids, 25).await?;
+        let block_ts = verify_source_transactions(&txids, &txs, ctx.height, &block_hash)?;
+        info!(height = ctx.height, txs = txs.len(), "esplora_tx fetched");
+        let spent_outpoints = spent_outpoints_from_transactions(&txs)?;
+        canonical_commit::stage_spent_outpoints(&self.pool, ctx.height, &spent_outpoints).await?;
+        info!(
+            height = ctx.height,
+            spends = spent_outpoints.len(),
+            "Bitcoin inputs staged for canonical inventory publication"
+        );
 
-			// Prepare batch payloads
-			let mut tx_rows: Vec<(i32, String, i32, bool, bool, serde_json::Value)> = Vec::with_capacity(results.len());
-			let mut all_txids: Vec<String> = Vec::with_capacity(results.len());
+        // Filter for OP_RETURN outputs
+        let opret_count: usize = txs.iter().filter(|tx| tx_has_op_return(tx)).count();
+        info!(
+            height = ctx.height,
+            op_return_txs = opret_count,
+            "OP_RETURN transactions in block"
+        );
+
+        // Build filtered list of OP_RETURN transactions only
+        let op_return_txs: Vec<_> = txs
+            .iter()
+            .filter(|tx| tx_has_op_return(tx))
+            .cloned()
+            .collect();
+
+        // Decode+trace protostones for this block (only OP_RETURN txs) with timing
+        if !op_return_txs.is_empty() {
+            let count = op_return_txs.len();
+            let t0 = Instant::now();
+            info!(
+                height = ctx.height,
+                op_return_txs = count,
+                "decode_and_trace_for_block: start"
+            );
+            let results: Vec<TxDecodeTraceResult> =
+                decode_and_trace_for_block(provider, &op_return_txs, 32, 16).await?;
+
+            // Prepare batch payloads
+            let mut tx_rows: Vec<(i32, String, i32, bool, bool, serde_json::Value)> =
+                Vec::with_capacity(results.len());
+            let mut all_txids: Vec<String> = Vec::with_capacity(results.len());
             let mut protostone_rows: Vec<(String, i32, i32, i32, serde_json::Value)> = Vec::new();
-            let mut event_rows: Vec<(String, i32, i32, String, serde_json::Value, String, String)> = Vec::new();
+            let mut event_rows: Vec<(String, i32, i32, String, serde_json::Value, String, String)> =
+                Vec::new();
 
-			for (tx_index, r) in results.iter().enumerate() {
-				let txid = r.transaction_id.clone();
-				all_txids.push(txid.clone());
-				tx_rows.push((
-					ctx.height as i32,
-					txid.clone(),
-					tx_index as i32,
-					r.has_trace,
-					r.trace_succeed,
-					r.transaction_json.clone(),
-				));
+            for (tx_index, r) in results.iter().enumerate() {
+                let txid = r.transaction_id.clone();
+                all_txids.push(txid.clone());
+                tx_rows.push((
+                    transform_height,
+                    txid.clone(),
+                    tx_index as i32,
+                    r.has_trace,
+                    r.trace_succeed,
+                    r.transaction_json.clone(),
+                ));
                 for d in &r.decoded_protostones {
-                    protostone_rows.push((txid.clone(), d.vout, d.protostone_index, ctx.height as i32, d.decoded.clone()));
-				}
-				for e in &r.trace_events {
-					event_rows.push((
-						txid.clone(),
-                        ctx.height as i32,
-						e.vout,
-						e.event_type.clone(),
-						e.data.clone(),
-						e.alkane_address_block.clone(),
-						e.alkane_address_tx.clone(),
-					));
-				}
-			}
+                    protostone_rows.push((
+                        txid.clone(),
+                        d.vout,
+                        d.protostone_index,
+                        transform_height,
+                        d.decoded.clone(),
+                    ));
+                }
+                for e in &r.trace_events {
+                    event_rows.push((
+                        txid.clone(),
+                        transform_height,
+                        e.vout,
+                        e.event_type.clone(),
+                        e.data.clone(),
+                        e.alkane_address_block.clone(),
+                        e.alkane_address_tx.clone(),
+                    ));
+                }
+            }
 
-			// Write in a single transaction
-			let mut dbtx = self.pool.begin().await?;
-			upsert_alkane_transactions(&mut dbtx, &tx_rows).await?;
-			replace_decoded_protostones(&mut dbtx, &all_txids, &protostone_rows).await?;
-			replace_trace_events(&mut dbtx, &all_txids, &event_rows).await?;
-			dbtx.commit().await?;
+            // Write in a single transaction
+            let mut dbtx = self.pool.begin().await?;
+            upsert_alkane_transactions(&mut dbtx, &tx_rows).await?;
+            replace_decoded_protostones(&mut dbtx, &all_txids, &protostone_rows).await?;
+            replace_trace_events(&mut dbtx, &all_txids, &event_rows).await?;
+            dbtx.commit().await?;
 
-			let elapsed_ms = t0.elapsed().as_millis() as u64;
-			info!(height = ctx.height, op_return_txs = count, elapsed_ms, "decode_and_trace_for_block: done");
+            let elapsed_ms = t0.elapsed().as_millis() as u64;
+            info!(
+                height = ctx.height,
+                op_return_txs = count,
+                elapsed_ms,
+                "decode_and_trace_for_block: done"
+            );
 
-			// Process traces through transform pipeline
-			let transform_t0 = std::time::Instant::now();
-			let mut transform_service = TraceTransformService::new(self.pool.clone());
-			// Load known pools at start of each block processing
-			if let Err(e) = transform_service.load_existing_pools().await {
-				warn!("Failed to load existing pools: {:?}", e);
-			}
-			info!("Transform pipeline: processing {} transactions from block {}", results.len(), ctx.height);
-			for r in &results {
-				info!("Transform pipeline: tx {} has {} trace_events", r.transaction_id, r.trace_events.len());
-				if !r.trace_events.is_empty() {
-					// Convert transaction info to context
-					let tx_info = txs.iter().find(|tx| {
-						tx.get("txid").and_then(|v| v.as_str()).unwrap_or("") == r.transaction_id
-					});
-					
-					if let Some(tx) = tx_info {
-						let timestamp = tx.get("status")
-							.and_then(|s| s.get("block_time"))
-							.and_then(|bt| bt.as_i64())
-							.and_then(|bt| Utc.timestamp_opt(bt, 0).single())
-							.unwrap_or_else(|| Utc::now());
-						
-						let vouts: Vec<VoutInfo> = tx.get("vout")
-							.and_then(|v| v.as_array())
-							.map(|arr| {
-								arr.iter().enumerate().map(|(i, v)| {
-									VoutInfo {
-										index: i as i32,
-										address: v.get("scriptpubkey_address").and_then(|a| a.as_str()).map(|s| s.to_string()),
-										script_pubkey: v.get("scriptpubkey").and_then(|s| s.as_str()).unwrap_or("").to_string(),
-										value: v.get("value").and_then(|val| val.as_u64()).unwrap_or(0),
-									}
-								}).collect()
-							})
-							.unwrap_or_default();
-						
-						let context = convert_transaction_context(
-							r.transaction_id.clone(),
-							ctx.height as i32,
-							timestamp,
-							vouts,
-						);
-						
-						let traces: Vec<alkanes_trace_transform::types::TraceEvent> = r.trace_events.iter().map(|e| {
-							convert_trace_event(
-								e.event_type.clone(),
-								e.vout,
-								e.alkane_address_block.clone(),
-								e.alkane_address_tx.clone(),
-								e.data.clone(),
-							)
-						}).collect();
-						
-						if let Err(e) = transform_service.process_transaction(context, traces).await {
-							warn!(txid = %r.transaction_id, error = ?e, "transform processing failed");
-						}
-					}
-				}
-			}
-			let transform_elapsed_ms = transform_t0.elapsed().as_millis() as u64;
-			info!(height = ctx.height, elapsed_ms = transform_elapsed_ms, "trace transform processing: done");
+            // Process traces through transform pipeline
+            let transform_t0 = std::time::Instant::now();
+            let mut transform_service = TraceTransformService::new(self.pool.clone());
+            // Load known pools at start of each block processing
+            transform_service.load_existing_pools().await?;
+            info!(
+                "Transform pipeline: processing {} transactions from block {}",
+                results.len(),
+                ctx.height
+            );
+            for r in &results {
+                info!(
+                    "Transform pipeline: tx {} has {} trace_events",
+                    r.transaction_id,
+                    r.trace_events.len()
+                );
+                if !r.trace_events.is_empty() {
+                    // Convert transaction info to context
+                    let tx_info = txs.iter().find(|tx| {
+                        tx.get("txid").and_then(|v| v.as_str()).unwrap_or("") == r.transaction_id
+                    });
 
-			// Extract and index balances from trace events
-			let balance_t0 = std::time::Instant::now();
-			let mut all_outpoint_balances = Vec::new();
-			for r in &results {
-				if !r.trace_events.is_empty() {
-					match crate::helpers::balance_tracker::extract_balance_changes(
-						&r.transaction_json,
-						&r.trace_events
-					) {
-						Ok(balances) => all_outpoint_balances.extend(balances),
-						Err(e) => warn!(txid = %r.transaction_id, error = ?e, "balance extraction failed"),
-					}
-				}
-			}
+                    let tx = tx_info.with_context(|| {
+                        format!(
+                            "traced transaction {} is missing from its source block",
+                            r.transaction_id
+                        )
+                    })?;
+                    let timestamp_seconds = tx
+                        .get("status")
+                        .and_then(|status| status.get("block_time"))
+                        .and_then(|value| value.as_i64())
+                        .context("confirmed transaction is missing status.block_time")?;
+                    let timestamp = Utc
+                        .timestamp_opt(timestamp_seconds, 0)
+                        .single()
+                        .context("confirmed transaction has an invalid status.block_time")?;
+                    let source_vouts = tx
+                        .get("vout")
+                        .and_then(|value| value.as_array())
+                        .context("confirmed transaction vout must be an array")?;
+                    let vouts: Vec<VoutInfo> = source_vouts
+                        .iter()
+                        .enumerate()
+                        .map(|(index, value)| {
+                            Ok(VoutInfo {
+                                index: i32::try_from(index)
+                                    .context("transaction has too many outputs")?,
+                                address: value
+                                    .get("scriptpubkey_address")
+                                    .map(|address| {
+                                        address
+                                            .as_str()
+                                            .context("scriptpubkey_address must be text")
+                                            .map(str::to_owned)
+                                    })
+                                    .transpose()?,
+                                script_pubkey: value
+                                    .get("scriptpubkey")
+                                    .and_then(|script| script.as_str())
+                                    .context("vout.scriptpubkey must be text")?
+                                    .to_owned(),
+                                value: value
+                                    .get("value")
+                                    .and_then(|amount| amount.as_u64())
+                                    .context("vout.value must be a non-negative u64")?,
+                            })
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+                    let context = convert_transaction_context(
+                        r.transaction_id.clone(),
+                        transform_height,
+                        timestamp,
+                        vouts,
+                    );
+                    let traces: Vec<alkanes_trace_transform::types::TraceEvent> = r
+                        .trace_events
+                        .iter()
+                        .map(|e| {
+                            convert_trace_event(
+                                e.event_type.clone(),
+                                e.vout,
+                                e.alkane_address_block.clone(),
+                                e.alkane_address_tx.clone(),
+                                e.data.clone(),
+                            )
+                        })
+                        .collect();
+                    transform_service
+                        .process_transaction(context, traces)
+                        .await?;
+                }
+            }
+            let transform_elapsed_ms = transform_t0.elapsed().as_millis() as u64;
+            info!(
+                height = ctx.height,
+                elapsed_ms = transform_elapsed_ms,
+                "trace transform processing: done"
+            );
 
-			if !all_outpoint_balances.is_empty() {
-				crate::helpers::balance_tracker::upsert_utxo_balances(
-					&self.pool,
-					ctx.height as i32,
-					&all_outpoint_balances
-				).await?;
-				crate::helpers::balance_tracker::update_address_balances(
-					&self.pool,
-					&all_outpoint_balances
-				).await?;
-				crate::helpers::balance_tracker::refresh_holders_for_block(
-					&self.pool,
-					&all_outpoint_balances
-				).await?;
-			}
-			let balance_elapsed_ms = balance_t0.elapsed().as_millis() as u64;
-			info!(height = ctx.height, balance_updates = all_outpoint_balances.len(), elapsed_ms = balance_elapsed_ms, "balance indexing: done");
+            // Extract and index balances from trace events
+            let balance_t0 = std::time::Instant::now();
+            let mut all_outpoint_balances = Vec::new();
+            for r in &results {
+                if !r.trace_events.is_empty() {
+                    let balances = crate::helpers::balance_tracker::extract_balance_changes(
+                        &r.transaction_json,
+                        &r.trace_events,
+                    )?;
+                    all_outpoint_balances.extend(balances);
+                }
+            }
 
-			// Extract and index storage changes from trace events
-			let storage_t0 = std::time::Instant::now();
-			let mut all_storage_changes = Vec::new();
-			for r in &results {
-				if !r.trace_events.is_empty() {
-					match crate::helpers::storage_tracker::extract_storage_changes(
-						&r.transaction_json,
-						&r.trace_events
-					) {
-						Ok(changes) => all_storage_changes.extend(changes),
-						Err(e) => warn!(txid = %r.transaction_id, error = ?e, "storage extraction failed"),
-					}
-				}
-			}
+            if !all_outpoint_balances.is_empty() {
+                crate::helpers::balance_tracker::upsert_utxo_balances(
+                    &self.pool,
+                    transform_height,
+                    &all_outpoint_balances,
+                )
+                .await?;
+                crate::helpers::balance_tracker::update_address_balances(
+                    &self.pool,
+                    &all_outpoint_balances,
+                )
+                .await?;
+                crate::helpers::balance_tracker::refresh_holders_for_block(
+                    &self.pool,
+                    &all_outpoint_balances,
+                )
+                .await?;
+            }
+            let balance_elapsed_ms = balance_t0.elapsed().as_millis() as u64;
+            info!(
+                height = ctx.height,
+                balance_updates = all_outpoint_balances.len(),
+                elapsed_ms = balance_elapsed_ms,
+                "balance indexing: done"
+            );
 
-			if !all_storage_changes.is_empty() {
-				crate::helpers::storage_tracker::upsert_storage_changes(
-					&self.pool,
-					ctx.height as i32,
-					&all_storage_changes
-				).await?;
-			}
-			let storage_elapsed_ms = storage_t0.elapsed().as_millis() as u64;
-			info!(height = ctx.height, storage_updates = all_storage_changes.len(), elapsed_ms = storage_elapsed_ms, "storage indexing: done");
+            // Extract and index storage changes from trace events
+            let storage_t0 = std::time::Instant::now();
+            let mut all_storage_changes = Vec::new();
+            for r in &results {
+                if !r.trace_events.is_empty() {
+                    match crate::helpers::storage_tracker::extract_storage_changes(
+                        &r.transaction_json,
+                        &r.trace_events,
+                    ) {
+                        Ok(changes) => all_storage_changes.extend(changes),
+                        Err(e) => {
+                            warn!(txid = %r.transaction_id, error = ?e, "storage extraction failed")
+                        }
+                    }
+                }
+            }
 
-			// Extract and index AMM trade events
-			let amm_t0 = std::time::Instant::now();
-			let mut all_trades = Vec::new();
-			for r in &results {
-				if !r.trace_events.is_empty() {
-					let ts_opt = r.transaction_json.get("status")
-						.and_then(|s| s.get("block_time"))
-						.and_then(|v| v.as_i64());
-					let ts = ts_opt
-						.and_then(|secs| chrono::Utc.timestamp_opt(secs, 0).single())
-						.unwrap_or_else(|| chrono::Utc.timestamp_opt(0, 0).single().unwrap());
-					
-					match crate::helpers::amm_tracker::extract_trade_events(
-						&r.transaction_json,
-						&r.trace_events,
-						ts,
-						ctx.height as i32
-					) {
-						Ok(trades) => all_trades.extend(trades),
-						Err(e) => warn!(txid = %r.transaction_id, error = ?e, "trade extraction failed"),
-					}
-				}
-			}
+            if !all_storage_changes.is_empty() {
+                crate::helpers::storage_tracker::upsert_storage_changes(
+                    &self.pool,
+                    transform_height,
+                    &all_storage_changes,
+                )
+                .await?;
+            }
+            let storage_elapsed_ms = storage_t0.elapsed().as_millis() as u64;
+            info!(
+                height = ctx.height,
+                storage_updates = all_storage_changes.len(),
+                elapsed_ms = storage_elapsed_ms,
+                "storage indexing: done"
+            );
 
-			if !all_trades.is_empty() {
-				crate::helpers::amm_tracker::insert_trade_events(&self.pool, &all_trades).await?;
-			}
-			
-			// Extract reserve snapshots from storage changes
-			if !all_storage_changes.is_empty() {
-				let ts_opt = results.first()
-					.and_then(|r| r.transaction_json.get("status"))
-					.and_then(|s| s.get("block_time"))
-					.and_then(|v| v.as_i64());
-				let ts = ts_opt
-					.and_then(|secs| chrono::Utc.timestamp_opt(secs, 0).single())
-					.unwrap_or_else(|| chrono::Utc.timestamp_opt(0, 0).single().unwrap());
-				
-				let reserves = crate::helpers::amm_tracker::extract_reserves_from_storage(
-					&all_storage_changes,
-					ts,
-					ctx.height as i32
-				);
-				
-				if !reserves.is_empty() {
-					crate::helpers::amm_tracker::insert_reserve_snapshots(&self.pool, &reserves).await?;
-				}
-			}
-			
-			let amm_elapsed_ms = amm_t0.elapsed().as_millis() as u64;
-			info!(height = ctx.height, trade_events = all_trades.len(), elapsed_ms = amm_elapsed_ms, "AMM indexing: done");
+            // Extract and index AMM trade events
+            let amm_t0 = std::time::Instant::now();
+            let mut all_trades = Vec::new();
+            for r in &results {
+                if !r.trace_events.is_empty() {
+                    let ts_opt = r
+                        .transaction_json
+                        .get("status")
+                        .and_then(|s| s.get("block_time"))
+                        .and_then(|v| v.as_i64());
+                    let ts = ts_opt
+                        .and_then(|secs| chrono::Utc.timestamp_opt(secs, 0).single())
+                        .unwrap_or_else(|| chrono::Utc.timestamp_opt(0, 0).single().unwrap());
 
-			// Aggregate candles periodically (every 10 blocks)
-			if ctx.height % 10 == 0 && !all_trades.is_empty() {
-				let candle_t0 = std::time::Instant::now();
-				let start_time = chrono::Utc.timestamp_opt((ctx.height as i64 - 600) * 600, 0).single()
-					.unwrap_or_else(|| chrono::Utc::now());
-				let end_time = chrono::Utc::now();
-				
-				if let Err(e) = crate::helpers::amm_tracker::aggregate_candles(&self.pool, start_time, end_time).await {
-					warn!(height = ctx.height, error = ?e, "candle aggregation failed");
-				} else {
-					let candle_elapsed_ms = candle_t0.elapsed().as_millis() as u64;
-					info!(height = ctx.height, elapsed_ms = candle_elapsed_ms, "candle aggregation: done");
-				}
-			}
+                    match crate::helpers::amm_tracker::extract_trade_events(
+                        &r.transaction_json,
+                        &r.trace_events,
+                        ts,
+                        transform_height,
+                    ) {
+                        Ok(trades) => all_trades.extend(trades),
+                        Err(e) => {
+                            warn!(txid = %r.transaction_id, error = ?e, "trade extraction failed")
+                        }
+                    }
+                }
+            }
+
+            if !all_trades.is_empty() {
+                crate::helpers::amm_tracker::insert_trade_events(&self.pool, &all_trades).await?;
+            }
+
+            // Extract reserve snapshots from storage changes
+            if !all_storage_changes.is_empty() {
+                let ts_opt = results
+                    .first()
+                    .and_then(|r| r.transaction_json.get("status"))
+                    .and_then(|s| s.get("block_time"))
+                    .and_then(|v| v.as_i64());
+                let ts = ts_opt
+                    .and_then(|secs| chrono::Utc.timestamp_opt(secs, 0).single())
+                    .unwrap_or_else(|| chrono::Utc.timestamp_opt(0, 0).single().unwrap());
+
+                let reserves = crate::helpers::amm_tracker::extract_reserves_from_storage(
+                    &all_storage_changes,
+                    ts,
+                    transform_height,
+                );
+
+                if !reserves.is_empty() {
+                    crate::helpers::amm_tracker::insert_reserve_snapshots(&self.pool, &reserves)
+                        .await?;
+                }
+            }
+
+            let amm_elapsed_ms = amm_t0.elapsed().as_millis() as u64;
+            info!(
+                height = ctx.height,
+                trade_events = all_trades.len(),
+                elapsed_ms = amm_elapsed_ms,
+                "AMM indexing: done"
+            );
+
+            // Aggregate candles periodically (every 10 blocks)
+            if ctx.height % 10 == 0 && !all_trades.is_empty() {
+                let candle_t0 = std::time::Instant::now();
+                let start_time = chrono::Utc
+                    .timestamp_opt((ctx.height as i64 - 600) * 600, 0)
+                    .single()
+                    .unwrap_or_else(|| chrono::Utc::now());
+                let end_time = chrono::Utc::now();
+
+                if let Err(e) =
+                    crate::helpers::amm_tracker::aggregate_candles(&self.pool, start_time, end_time)
+                        .await
+                {
+                    warn!(height = ctx.height, error = ?e, "candle aggregation failed");
+                } else {
+                    let candle_elapsed_ms = candle_t0.elapsed().as_millis() as u64;
+                    info!(
+                        height = ctx.height,
+                        elapsed_ms = candle_elapsed_ms,
+                        "candle aggregation: done"
+                    );
+                }
+            }
 
             // Build inputs for PoolSwap / PoolCreation / PoolMint / PoolBurn indexers and run them
-			let mut swap_inputs: Vec<(String, i32, chrono::DateTime<Utc>, serde_json::Value, Vec<serde_json::Value>)> = Vec::new();
-			let mut creation_inputs: Vec<(String, i32, chrono::DateTime<Utc>, serde_json::Value, Vec<serde_json::Value>)> = Vec::new();
-            let mut mint_inputs: Vec<(String, i32, chrono::DateTime<Utc>, serde_json::Value, Vec<serde_json::Value>)> = Vec::new();
-            let mut burn_inputs: Vec<(String, i32, chrono::DateTime<Utc>, serde_json::Value, Vec<serde_json::Value>)> = Vec::new();
-            let mut subfrost_inputs: Vec<(String, i32, chrono::DateTime<Utc>, serde_json::Value, Vec<serde_json::Value>)> = Vec::new();
-			for (tx_index, r) in results.iter().enumerate() {
-				let ts_opt = r.transaction_json
-					.get("status").and_then(|s| s.get("block_time")).and_then(|v| v.as_i64());
-				let ts = ts_opt
-					.and_then(|secs| Utc.timestamp_opt(secs, 0).single())
-					.unwrap_or_else(|| Utc.timestamp_opt(0, 0).single().unwrap());
-				let trace_events_json: Vec<serde_json::Value> = r.trace_events.iter().map(|e| {
-					serde_json::json!({
-						"vout": e.vout,
-						"eventType": e.event_type,
-						"data": e.data,
-						"alkaneAddressBlock": e.alkane_address_block,
-						"alkaneAddressTx": e.alkane_address_tx,
-					})
-				}).collect();
-                swap_inputs.push((r.transaction_id.clone(), tx_index as i32, ts, r.transaction_json.clone(), trace_events_json.clone()));
-                creation_inputs.push((r.transaction_id.clone(), tx_index as i32, ts, r.transaction_json.clone(), trace_events_json.clone()));
-                mint_inputs.push((r.transaction_id.clone(), tx_index as i32, ts, r.transaction_json.clone(), trace_events_json.clone()));
-                burn_inputs.push((r.transaction_id.clone(), tx_index as i32, ts, r.transaction_json.clone(), trace_events_json.clone()));
-                subfrost_inputs.push((r.transaction_id.clone(), tx_index as i32, ts, r.transaction_json.clone(), trace_events_json));
-			}
-			index_pool_swaps_for_block(&self.pool, ctx.height as i32, &swap_inputs).await?;
+            let mut swap_inputs: Vec<(
+                String,
+                i32,
+                chrono::DateTime<Utc>,
+                serde_json::Value,
+                Vec<serde_json::Value>,
+            )> = Vec::new();
+            let mut creation_inputs: Vec<(
+                String,
+                i32,
+                chrono::DateTime<Utc>,
+                serde_json::Value,
+                Vec<serde_json::Value>,
+            )> = Vec::new();
+            let mut mint_inputs: Vec<(
+                String,
+                i32,
+                chrono::DateTime<Utc>,
+                serde_json::Value,
+                Vec<serde_json::Value>,
+            )> = Vec::new();
+            let mut burn_inputs: Vec<(
+                String,
+                i32,
+                chrono::DateTime<Utc>,
+                serde_json::Value,
+                Vec<serde_json::Value>,
+            )> = Vec::new();
+            let mut subfrost_inputs: Vec<(
+                String,
+                i32,
+                chrono::DateTime<Utc>,
+                serde_json::Value,
+                Vec<serde_json::Value>,
+            )> = Vec::new();
+            for (tx_index, r) in results.iter().enumerate() {
+                // All source transactions were proven to belong to this block and to carry this
+                // exact timestamp before any transforms ran. Do not reparse with an epoch fallback.
+                let ts = block_ts;
+                let trace_events_json: Vec<serde_json::Value> = r
+                    .trace_events
+                    .iter()
+                    .map(|e| {
+                        serde_json::json!({
+                            "vout": e.vout,
+                            "eventType": e.event_type,
+                            "data": e.data,
+                            "alkaneAddressBlock": e.alkane_address_block,
+                            "alkaneAddressTx": e.alkane_address_tx,
+                        })
+                    })
+                    .collect();
+                swap_inputs.push((
+                    r.transaction_id.clone(),
+                    tx_index as i32,
+                    ts,
+                    r.transaction_json.clone(),
+                    trace_events_json.clone(),
+                ));
+                creation_inputs.push((
+                    r.transaction_id.clone(),
+                    tx_index as i32,
+                    ts,
+                    r.transaction_json.clone(),
+                    trace_events_json.clone(),
+                ));
+                mint_inputs.push((
+                    r.transaction_id.clone(),
+                    tx_index as i32,
+                    ts,
+                    r.transaction_json.clone(),
+                    trace_events_json.clone(),
+                ));
+                burn_inputs.push((
+                    r.transaction_id.clone(),
+                    tx_index as i32,
+                    ts,
+                    r.transaction_json.clone(),
+                    trace_events_json.clone(),
+                ));
+                subfrost_inputs.push((
+                    r.transaction_id.clone(),
+                    tx_index as i32,
+                    ts,
+                    r.transaction_json.clone(),
+                    trace_events_json,
+                ));
+            }
+            index_pool_swaps_for_block(&self.pool, transform_height, &swap_inputs).await?;
 
-			let creations = index_pool_creations_for_block(&self.pool, ctx.height as i32, &creation_inputs).await?;
-			if !creations.is_empty() {
-				let mut dbtx = self.pool.begin().await?;
-				replace_pool_creations(&mut dbtx, &all_txids, &creations).await?;
-				dbtx.commit().await?;
-			}
+            let creations =
+                index_pool_creations_for_block(&self.pool, transform_height, &creation_inputs)
+                    .await?;
+            if !creations.is_empty() {
+                let mut dbtx = self.pool.begin().await?;
+                replace_pool_creations(&mut dbtx, &all_txids, &creations).await?;
+                dbtx.commit().await?;
+            }
 
             // Index pool mints
-            index_pool_mints_for_block(&self.pool, ctx.height as i32, &mint_inputs).await?;
+            index_pool_mints_for_block(&self.pool, transform_height, &mint_inputs).await?;
 
             // Index pool burns
-            index_pool_burns_for_block(&self.pool, ctx.height as i32, &burn_inputs).await?;
+            index_pool_burns_for_block(&self.pool, transform_height, &burn_inputs).await?;
 
             // Index Subfrost wraps and unwraps
-            index_subfrost_wraps_for_block(&self.pool, ctx.height as i32, &subfrost_inputs).await?;
-            index_subfrost_unwraps_for_block(&self.pool, ctx.height as i32, &subfrost_inputs).await?;
-		}
+            index_subfrost_wraps_for_block(&self.pool, transform_height, &subfrost_inputs).await?;
+            index_subfrost_unwraps_for_block(&self.pool, transform_height, &subfrost_inputs)
+                .await?;
+        }
 
-		// Determine block timestamp: use first tx's block_time if present, else now()
-		let block_ts: DateTime<Utc> = txs.iter()
-			.filter_map(|tx| tx.get("status").and_then(|s| s.get("block_time")).and_then(|v| v.as_i64()))
-			.next()
-			.and_then(|secs| Utc.timestamp_opt(secs, 0).single())
-			.unwrap_or_else(|| Utc::now());
+        // Do not publish a block that ceased to be canonical while its transforms were running.
+        if helper_get_block_hash(provider, ctx.height).await? != block_hash
+            || (ctx.height > 0
+                && helper_get_block_hash(provider, ctx.height - 1).await? != previous_block_hash)
+        {
+            return Err(anyhow!(
+                "Bitcoin Core canonical hash changed before Marketplace publication"
+            ));
+        }
 
+        canonical_commit::publish_height(
+            &self.pool,
+            ctx.height,
+            &block_hash,
+            &previous_block_hash,
+            block_ts,
+        )
+        .await?;
+        serial_guard.commit().await?;
+        info!(height = ctx.height, %block_hash, "published canonical commitment, ProcessedBlocks, and position atomically");
 
-		// ATOMIC: Record both ProcessedBlocks and indexer_position in a single transaction
-		// This ensures we never have a gap between indexed data and position tracking
-		let mut final_tx = self.pool.begin().await?;
+        // Notify downstream services via Redis pub-sub only for realtime blocks (not during catch-up)
+        if ctx.emit_publish {
+            publish_block_processed(ctx.height).await;
+        }
 
-		// Upsert ProcessedBlocks entry
-		sqlx::query(
-			r#"
-			insert into "ProcessedBlocks" ("blockHeight", "blockHash", "timestamp", "isProcessing")
-			values ($1, $2, $3, false)
-			on conflict ("blockHeight") do update set
-				"blockHash" = excluded."blockHash",
-				"timestamp" = excluded."timestamp",
-				"isProcessing" = false
-			"#,
-		)
-		.bind(ctx.height as i32)
-		.bind(&block_hash)
-		.bind(block_ts)
-		.execute(&mut *final_tx)
-		.await?;
-
-		// Upsert indexer_position (the single-row progress tracker)
-		sqlx::query(
-			"INSERT INTO indexer_position (id, height, block_hash)
-			 VALUES (1, $1, $2)
-			 ON CONFLICT (id) DO UPDATE SET height = $1, block_hash = $2"
-		)
-		.bind(ctx.height as i64)
-		.bind(&block_hash)
-		.execute(&mut *final_tx)
-		.await?;
-
-		final_tx.commit().await?;
-		info!(height = ctx.height, %block_hash, "recorded ProcessedBlocks and position atomically");
-
-		// Notify downstream services via Redis pub-sub only for realtime blocks (not during catch-up)
-		if ctx.emit_publish {
-			publish_block_processed(ctx.height).await;
-		}
-
-		// Return the block hash for position tracking
-		Ok(block_hash)
-	}
+        // Return the block hash for position tracking
+        Ok(block_hash)
+    }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
 
+    fn hash(byte: char) -> String {
+        std::iter::repeat(byte).take(64).collect()
+    }
+
+    fn source_tx(txid: &str, block_hash: &str) -> serde_json::Value {
+        json!({
+            "txid": txid,
+            "vin": [{"is_coinbase": true}],
+            "vout": [{"scriptpubkey": "51", "value": 1}],
+            "status": {
+                "confirmed": true,
+                "block_height": 100,
+                "block_hash": block_hash,
+                "block_time": 1_700_000_000
+            }
+        })
+    }
+
+    #[test]
+    fn spend_staging_extracts_inputs_and_skips_coinbase() {
+        let previous = std::iter::repeat('a').take(64).collect::<String>();
+        let txs = vec![
+            json!({"txid": "coinbase", "vin": [{"is_coinbase": true}]}),
+            json!({"txid": "spend", "vin": [{
+                "is_coinbase": false,
+                "txid": previous,
+                "vout": 7
+            }]}),
+        ];
+
+        let outpoints = spent_outpoints_from_transactions(&txs).unwrap();
+        assert_eq!(
+            outpoints,
+            vec![(std::iter::repeat('a').take(64).collect(), 7)]
+        );
+    }
+
+    #[test]
+    fn malformed_spend_input_fails_closed() {
+        let malformed = vec![json!({
+            "txid": "spend",
+            "vin": [{"is_coinbase": false, "txid": "ABC", "vout": -1}]
+        })];
+        assert!(spent_outpoints_from_transactions(&malformed).is_err());
+        assert!(spent_outpoints_from_transactions(&[json!({"txid": "missing"})]).is_err());
+    }
+
+    #[test]
+    fn source_transaction_set_must_match_exactly() {
+        let block_hash = hash('d');
+        let a = hash('a');
+        let b = hash('b');
+        let c = hash('c');
+        let expected = vec![a.clone(), b.clone()];
+        assert!(
+            verify_source_transactions(
+                &expected,
+                &[source_tx(&b, &block_hash), source_tx(&a, &block_hash)],
+                100,
+                &block_hash,
+            )
+            .is_ok()
+        );
+        assert!(
+            verify_source_transactions(
+                &expected,
+                &[source_tx(&a, &block_hash), source_tx(&c, &block_hash)],
+                100,
+                &block_hash,
+            )
+            .is_err()
+        );
+        assert!(
+            verify_source_transactions(
+                &expected,
+                &[source_tx(&a, &block_hash), source_tx(&a, &block_hash)],
+                100,
+                &block_hash,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn malformed_or_wrong_block_source_transaction_fails_closed() {
+        let block_hash = hash('d');
+        let txid = hash('a');
+        let expected = vec![txid.clone()];
+
+        let mut missing_output = source_tx(&txid, &block_hash);
+        missing_output["vout"] = json!([]);
+        assert!(
+            verify_source_transactions(&expected, &[missing_output], 100, &block_hash).is_err()
+        );
+
+        let mut bad_script = source_tx(&txid, &block_hash);
+        bad_script["vout"][0]["scriptpubkey"] = json!("ABC");
+        assert!(
+            verify_source_transactions(&expected, &[bad_script], 100, &block_hash).is_err()
+        );
+
+        let mut wrong_block = source_tx(&txid, &block_hash);
+        wrong_block["status"]["block_hash"] = json!(hash('e'));
+        assert!(
+            verify_source_transactions(&expected, &[wrong_block], 100, &block_hash).is_err()
+        );
+
+        let mut missing_time = source_tx(&txid, &block_hash);
+        missing_time["status"].as_object_mut().unwrap().remove("block_time");
+        assert!(
+            verify_source_transactions(&expected, &[missing_time], 100, &block_hash).is_err()
+        );
+    }
+}

--- a/crates/alkanes-contract-indexer/src/poller.rs
+++ b/crates/alkanes-contract-indexer/src/poller.rs
@@ -1,9 +1,13 @@
 use alkanes_cli_sys::SystemAlkanes as ConcreteProvider;
 use tokio::sync::oneshot;
-use tokio::time::{sleep, Duration, Instant};
+use tokio::time::{Duration, Instant, sleep};
 use tracing::{error, info, warn};
 
-use crate::{pipeline::{BlockContext, Pipeline}, progress::ProgressStore, helpers::block::canonical_tip_height};
+use crate::{
+    helpers::block::canonical_tip_height,
+    pipeline::{BlockContext, Pipeline},
+    progress::ProgressStore,
+};
 
 pub struct BlockPoller {
     provider: ConcreteProvider,
@@ -23,7 +27,14 @@ impl BlockPoller {
         init_signal: Option<oneshot::Sender<()>>,
         start_height: Option<u64>,
     ) -> Self {
-        Self { provider, pipeline, progress, poll_interval_ms, init_signal, start_height }
+        Self {
+            provider,
+            pipeline,
+            progress,
+            poll_interval_ms,
+            init_signal,
+            start_height,
+        }
     }
 
     pub async fn run(mut self) {
@@ -32,6 +43,13 @@ impl BlockPoller {
 
         loop {
             let tick_start = Instant::now();
+
+            if let Err(e) = self.pipeline.reconcile_canonical(&self.provider).await {
+                error!(error = %e, "failed to reconcile canonical commitment chain");
+                backoff_ms = (backoff_ms.saturating_mul(2)).min(30_000);
+                sleep(Duration::from_millis(backoff_ms)).await;
+                continue;
+            }
 
             // First, check our current position from the database
             let position = match self.progress.get_position().await {
@@ -50,8 +68,15 @@ impl BlockPoller {
 
                     if !initialized {
                         // On first observation, refresh pools/state once
-                        if let Err(e) = self.pipeline.fetch_pools_for_tip(&self.provider, tip_height).await {
+                        if let Err(e) = self
+                            .pipeline
+                            .fetch_pools_for_tip(&self.provider, tip_height)
+                            .await
+                        {
                             error!(height = tip_height, error = %e, "fetch_pools_for_tip failed");
+                            backoff_ms = (backoff_ms.saturating_mul(2)).min(30_000);
+                            sleep(Duration::from_millis(backoff_ms)).await;
+                            continue;
                         }
                         info!(tip_height, "initialized metashrew height");
                         initialized = true;
@@ -88,15 +113,32 @@ impl BlockPoller {
                     // Process blocks one at a time if we're behind
                     if next_height <= tip_height {
                         // Refresh pools at new tip before processing
-                        if let Err(e) = self.pipeline.fetch_pools_for_tip(&self.provider, tip_height).await {
+                        if let Err(e) = self
+                            .pipeline
+                            .fetch_pools_for_tip(&self.provider, tip_height)
+                            .await
+                        {
                             error!(height = tip_height, error = %e, "fetch_pools_for_tip failed");
+                            backoff_ms = (backoff_ms.saturating_mul(2)).min(30_000);
+                            sleep(Duration::from_millis(backoff_ms)).await;
+                            continue;
                         }
 
                         for h in next_height..=tip_height {
                             info!(height = h, "new block detected");
 
                             // Process the block - position is updated atomically inside
-                            match self.pipeline.process_block_sequential(&self.provider, BlockContext { height: h, emit_publish: true }).await {
+                            match self
+                                .pipeline
+                                .process_block_sequential(
+                                    &self.provider,
+                                    BlockContext {
+                                        height: h,
+                                        emit_publish: true,
+                                    },
+                                )
+                                .await
+                            {
                                 Ok(block_hash) => {
                                     info!(height = h, %block_hash, "block processed");
                                 }
@@ -117,11 +159,13 @@ impl BlockPoller {
             }
 
             let elapsed = tick_start.elapsed();
-            let base = if backoff_ms == self.poll_interval_ms { self.poll_interval_ms } else { backoff_ms };
+            let base = if backoff_ms == self.poll_interval_ms {
+                self.poll_interval_ms
+            } else {
+                backoff_ms
+            };
             let sleep_ms = base.saturating_sub(elapsed.as_millis() as u64);
             sleep(Duration::from_millis(sleep_ms.max(50))).await;
         }
     }
 }
-
-

--- a/crates/alkanes-contract-indexer/src/transform_integration.rs
+++ b/crates/alkanes-contract-indexer/src/transform_integration.rs
@@ -1,5 +1,5 @@
 use alkanes_trace_transform::*;
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 use sqlx::{PgPool, Row};
 use std::collections::HashSet;
 
@@ -20,7 +20,7 @@ impl TraceTransformService {
     pub fn new(pool: PgPool) -> Self {
         let balance_processor = OptimizedBalanceProcessor::new(pool.clone());
         let amm_tracker = OptimizedAmmTracker::new(pool.clone());
-        
+
         Self {
             pool,
             balance_processor,
@@ -28,46 +28,59 @@ impl TraceTransformService {
             known_pools: HashSet::new(),
         }
     }
-    
+
     /// Initialize by loading existing pools from the Pool table
     pub async fn load_existing_pools(&mut self) -> Result<()> {
         // Query all pools from the Pool table using dynamic query
-        let pools = sqlx::query(
-            r#"SELECT DISTINCT "poolBlockId", "poolTxId" FROM "Pool""#
-        )
-        .fetch_all(&self.pool)
-        .await?;
-        
+        let pools = sqlx::query(r#"SELECT DISTINCT "poolBlockId", "poolTxId" FROM "Pool""#)
+            .fetch_all(&self.pool)
+            .await?;
+
         for row in pools {
-            let block_str: Option<String> = row.try_get("poolBlockId").ok();
-            let tx_str: Option<String> = row.try_get("poolTxId").ok();
-            
-            if let (Some(block_str), Some(tx_str)) = (block_str, tx_str) {
-                if let (Ok(block), Ok(tx)) = (block_str.parse::<i32>(), tx_str.parse::<i64>()) {
-                    let pool_id = types::AlkaneId::new(block, tx);
-                    self.known_pools.insert(pool_id);
-                    tracing::info!("Loaded existing pool: {}:{}", block, tx);
-                }
+            let block_str: String = row
+                .try_get("poolBlockId")
+                .context("Pool.poolBlockId is not canonical text")?;
+            let tx_str: String = row
+                .try_get("poolTxId")
+                .context("Pool.poolTxId is not canonical text")?;
+            let block = block_str
+                .parse::<i32>()
+                .with_context(|| format!("invalid Pool.poolBlockId {block_str:?}"))?;
+            let tx = tx_str
+                .parse::<i64>()
+                .with_context(|| format!("invalid Pool.poolTxId {tx_str:?}"))?;
+            if block <= 0 || tx < 0 {
+                bail!("Pool registry contains out-of-range alkane id {block}:{tx}");
             }
+            let pool_id = types::AlkaneId::new(block, tx);
+            self.known_pools.insert(pool_id);
+            tracing::info!("Loaded existing pool: {}:{}", block, tx);
         }
-        
-        tracing::info!("Loaded {} existing pools from database", self.known_pools.len());
+
+        tracing::info!(
+            "Loaded {} existing pools from database",
+            self.known_pools.len()
+        );
         Ok(())
     }
-    
+
     /// Apply the trace transform schema
     pub async fn apply_schema(&self) -> Result<()> {
         schema::apply_schema(&self.pool).await
     }
-    
+
     /// Process traces from a transaction
     pub async fn process_transaction(
         &mut self,
         context: types::TransactionContext,
         traces: Vec<types::TraceEvent>,
     ) -> Result<()> {
-        tracing::info!("Transform: processing tx {} with {} traces", context.txid, traces.len());
-        
+        tracing::info!(
+            "Transform: processing tx {} with {} traces",
+            context.txid,
+            traces.len()
+        );
+
         if !traces.is_empty() {
             // Count event types
             let mut event_counts = std::collections::HashMap::new();
@@ -76,56 +89,85 @@ impl TraceTransformService {
             }
             tracing::info!("Transform: event types: {:?}", event_counts);
         }
-        
+
         // First pass: Track ALL create events and factory pools
         for trace in &traces {
             if trace.event_type == "create" {
                 // Extract alkane ID from create event data
                 // For create events, the new alkane ID is in data.newAlkane
-                let alkane_id_opt = trace.data.get("newAlkane").and_then(|v| {
-                    let block = v.get("block")?.as_str()?.parse::<i32>().ok()?;
-                    let tx = v.get("tx")?.as_str()?.parse::<i64>().ok()?;
-                    Some(types::AlkaneId::new(block, tx))
+                let encoded_id = trace
+                    .data
+                    .get("newAlkane")
+                    .context("create trace is missing data.newAlkane")?;
+                let block_text = encoded_id
+                    .get("block")
+                    .and_then(|value| value.as_str())
+                    .context("create trace data.newAlkane.block must be a decimal string")?;
+                let tx_text = encoded_id
+                    .get("tx")
+                    .and_then(|value| value.as_str())
+                    .context("create trace data.newAlkane.tx must be a decimal string")?;
+                let alkane_id = types::AlkaneId::new(
+                    block_text
+                        .parse::<i32>()
+                        .context("create trace has invalid alkane block")?,
+                    tx_text
+                        .parse::<i64>()
+                        .context("create trace has invalid alkane tx")?,
+                );
+                if alkane_id.block <= 0 || alkane_id.tx < 0 {
+                    bail!("create trace has an out-of-range alkane id");
+                }
+
+                self.insert_alkane_registry(alkane_id.clone(), &context)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "failed to register alkane {}:{} in transaction {}",
+                            alkane_id.block, alkane_id.tx, context.txid
+                        )
+                    })?;
+                tracing::info!("Registered alkane: {}:{}", alkane_id.block, alkane_id.tx);
+
+                // Check if this create is from the factory
+                let factory_invoke = traces.iter().any(|t| {
+                    t.vout == trace.vout
+                        && t.event_type == "invoke"
+                        && t.alkane_address_block.parse::<i32>().ok() == Some(FACTORY_BLOCK)
+                        && t.alkane_address_tx.parse::<i64>().ok() == Some(FACTORY_TX)
                 });
-                
-                if let Some(alkane_id) = alkane_id_opt {
-                    // Insert into TraceAlkane registry
-                    if let Err(e) = self.insert_alkane_registry(alkane_id.clone(), &context).await {
-                        tracing::warn!("Failed to insert alkane {}:{} to registry: {:?}", alkane_id.block, alkane_id.tx, e);
-                    } else {
-                        tracing::info!("Registered alkane: {}:{}", alkane_id.block, alkane_id.tx);
-                    }
-                    
-                    // Check if this create is from the factory
-                    let factory_invoke = traces.iter().any(|t| {
-                        t.vout == trace.vout &&
-                        t.event_type == "invoke" &&
-                        t.alkane_address_block.parse::<i32>().ok() == Some(FACTORY_BLOCK) &&
-                        t.alkane_address_tx.parse::<i64>().ok() == Some(FACTORY_TX)
-                    });
-                    
-                    if factory_invoke {
-                        if self.known_pools.insert(alkane_id.clone()) {
-                            tracing::info!("Discovered new pool created by factory: {}:{}", alkane_id.block, alkane_id.tx);
-                        }
+
+                if factory_invoke {
+                    if self.known_pools.insert(alkane_id.clone()) {
+                        tracing::info!(
+                            "Discovered new pool created by factory: {}:{}",
+                            alkane_id.block,
+                            alkane_id.tx
+                        );
                     }
                 }
             }
         }
-        
+
         // Update extractor context for balance processing
         // The OptimizedBalanceProcessor uses ValueTransferExtractor which now handles
         // both receive_intent and value_transfer events automatically
-        self.balance_processor = OptimizedBalanceProcessor::with_context(self.pool.clone(), context.clone());
-        
+        self.balance_processor =
+            OptimizedBalanceProcessor::with_context(self.pool.clone(), context.clone());
+
         // Process each trace
         for trace in &traces {
-            // Process balance changes
-            if let Err(e) = self.balance_processor.process_trace(trace).await {
-                tracing::warn!("Transform: balance processing failed for {} at vout {}: {:?}", trace.event_type, trace.vout, e);
-            }
+            self.balance_processor
+                .process_trace(trace)
+                .await
+                .with_context(|| {
+                    format!(
+                        "balance transform failed for {} at vout {} in transaction {}",
+                        trace.event_type, trace.vout, context.txid
+                    )
+                })?;
         }
-        
+
         // Extract and process AMM trades
         let trades = extract_trades_from_traces(&context, &traces, &self.known_pools);
         let trade_count = trades.len();
@@ -134,10 +176,10 @@ impl TraceTransformService {
             self.amm_tracker.process_trades(trades).await?;
             tracing::debug!("Transform: processed {} trades", trade_count);
         }
-        
+
         Ok(())
     }
-    
+
     /// Insert alkane into registry (TraceAlkane table)
     async fn insert_alkane_registry(
         &self,
@@ -149,7 +191,6 @@ impl TraceTransformService {
             INSERT INTO "TraceAlkane" 
                 (alkane_block, alkane_tx, created_at_block, created_at_tx, created_at_height, created_at_timestamp)
             VALUES ($1, $2, $3, $4, $5, $6)
-            ON CONFLICT (alkane_block, alkane_tx) DO NOTHING
             "#
         )
         .bind(alkane_id.block as i32)
@@ -160,52 +201,66 @@ impl TraceTransformService {
         .bind(context.timestamp)
         .execute(&self.pool)
         .await?;
-        
+
         Ok(())
     }
-    
+
     /// Create UTXO balance entry from ReceiveIntent event
     async fn create_utxo_from_receive_intent(
         &self,
         trace: &types::TraceEvent,
         context: &types::TransactionContext,
     ) -> Result<()> {
-        tracing::info!("create_utxo_from_receive_intent: full data = {}", serde_json::to_string_pretty(&trace.data).unwrap_or_else(|_| "error".to_string()));
-        
+        tracing::info!(
+            "create_utxo_from_receive_intent: full data = {}",
+            serde_json::to_string_pretty(&trace.data).unwrap_or_else(|_| "error".to_string())
+        );
+
         // Parse ReceiveIntent event structure: incoming_alkanes array
-        let incoming_alkanes = trace.data.get("incoming_alkanes")
+        let incoming_alkanes = trace
+            .data
+            .get("incoming_alkanes")
             .or_else(|| trace.data.get("incomingAlkanes"))
             .and_then(|v| v.as_array())
             .ok_or_else(|| anyhow::anyhow!("No incoming_alkanes array in receive_intent"))?;
-        
+
         // Get target vout info (the vout where this event occurred)
         let vout = trace.vout;
-        let target_vout = context.vouts.get(vout as usize)
+        let target_vout = context
+            .vouts
+            .get(vout as usize)
             .ok_or_else(|| anyhow::anyhow!("vout {} out of range", vout))?;
-        
-        let address = target_vout.address.as_ref()
+
+        let address = target_vout
+            .address
+            .as_ref()
             .ok_or_else(|| anyhow::anyhow!("No address for vout {}", vout))?;
         let script_pubkey = &target_vout.script_pubkey;
-        
+
         // Process each incoming alkane
         for alkane in incoming_alkanes {
-            let alkane_id = alkane.get("id")
+            let alkane_id = alkane
+                .get("id")
                 .ok_or_else(|| anyhow::anyhow!("No id in incoming alkane"))?;
-            let alkane_block = alkane_id.get("block")
+            let alkane_block = alkane_id
+                .get("block")
                 .and_then(|v| v.as_i64())
-                .ok_or_else(|| anyhow::anyhow!("No block in alkane id"))? as i32;
-            let alkane_tx = alkane_id.get("tx")
+                .ok_or_else(|| anyhow::anyhow!("No block in alkane id"))?
+                as i32;
+            let alkane_tx = alkane_id
+                .get("tx")
                 .and_then(|v| v.as_i64())
                 .ok_or_else(|| anyhow::anyhow!("No tx in alkane id"))?;
-            
+
             // Amount is in U128 format with "lo" field
-            let amount = alkane.get("value")
+            let amount = alkane
+                .get("value")
                 .and_then(|v| v.get("lo"))
                 .and_then(|v| v.as_i64())
-                .or_else(|| alkane.get("amount")
-                    .and_then(|v| v.as_i64()))
-                .ok_or_else(|| anyhow::anyhow!("No amount in incoming alkane"))? as i64;
-            
+                .or_else(|| alkane.get("amount").and_then(|v| v.as_i64()))
+                .ok_or_else(|| anyhow::anyhow!("No amount in incoming alkane"))?
+                as i64;
+
             // Insert UTXO balance
             sqlx::query(
                 r#"
@@ -214,7 +269,7 @@ impl TraceTransformService {
                      created_block, created_tx, created_timestamp)
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
                 ON CONFLICT (tx_hash, vout, alkane_block, alkane_tx) DO NOTHING
-                "#
+                "#,
             )
             .bind(&context.txid)
             .bind(vout)
@@ -228,7 +283,7 @@ impl TraceTransformService {
             .bind(context.timestamp)
             .execute(&self.pool)
             .await?;
-            
+
             // Also update aggregate balance
             sqlx::query(
                 r#"
@@ -253,10 +308,10 @@ impl TraceTransformService {
             .execute(&self.pool)
             .await?;
         }
-        
+
         Ok(())
     }
-    
+
     /// Create UTXO balance entry from ValueTransfer event
     async fn create_utxo_balance(
         &self,
@@ -264,41 +319,55 @@ impl TraceTransformService {
         context: &types::TransactionContext,
     ) -> Result<()> {
         // Parse ValueTransfer event structure
-        let transfers = trace.data.get("transfers")
+        let transfers = trace
+            .data
+            .get("transfers")
             .and_then(|v| v.as_array())
             .ok_or_else(|| anyhow::anyhow!("No transfers array in value_transfer"))?;
-        
-        let redirect_to = trace.data.get("redirect_to")
+
+        let redirect_to = trace
+            .data
+            .get("redirect_to")
             .and_then(|v| v.as_i64())
-            .ok_or_else(|| anyhow::anyhow!("No redirect_to in value_transfer"))? as i32;
-        
+            .ok_or_else(|| anyhow::anyhow!("No redirect_to in value_transfer"))?
+            as i32;
+
         // Get target vout info
-        let target_vout = context.vouts.get(redirect_to as usize)
+        let target_vout = context
+            .vouts
+            .get(redirect_to as usize)
             .ok_or_else(|| anyhow::anyhow!("redirect_to {} out of range", redirect_to))?;
-        
-        let address = target_vout.address.as_ref()
+
+        let address = target_vout
+            .address
+            .as_ref()
             .ok_or_else(|| anyhow::anyhow!("No address for vout {}", redirect_to))?;
         let script_pubkey = &target_vout.script_pubkey;
-        
+
         // Process each transfer
         for transfer in transfers {
-            let alkane_id = transfer.get("id")
+            let alkane_id = transfer
+                .get("id")
                 .ok_or_else(|| anyhow::anyhow!("No id in transfer"))?;
-            let alkane_block = alkane_id.get("block")
+            let alkane_block = alkane_id
+                .get("block")
                 .and_then(|v| v.as_i64())
-                .ok_or_else(|| anyhow::anyhow!("No block in alkane id"))? as i32;
-            let alkane_tx = alkane_id.get("tx")
+                .ok_or_else(|| anyhow::anyhow!("No block in alkane id"))?
+                as i32;
+            let alkane_tx = alkane_id
+                .get("tx")
                 .and_then(|v| v.as_i64())
                 .ok_or_else(|| anyhow::anyhow!("No tx in alkane id"))?;
-            
+
             // Amount is in U128 format with "lo" field
-            let amount = transfer.get("value")
+            let amount = transfer
+                .get("value")
                 .and_then(|v| v.get("lo"))
                 .and_then(|v| v.as_i64())
-                .or_else(|| transfer.get("amount")
-                    .and_then(|v| v.as_i64()))
-                .ok_or_else(|| anyhow::anyhow!("No amount in transfer"))? as i64;
-            
+                .or_else(|| transfer.get("amount").and_then(|v| v.as_i64()))
+                .ok_or_else(|| anyhow::anyhow!("No amount in transfer"))?
+                as i64;
+
             // Insert UTXO balance
             sqlx::query(
                 r#"
@@ -307,7 +376,7 @@ impl TraceTransformService {
                      created_block, created_tx, created_timestamp)
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
                 ON CONFLICT (tx_hash, vout, alkane_block, alkane_tx) DO NOTHING
-                "#
+                "#,
             )
             .bind(&context.txid)
             .bind(redirect_to)
@@ -321,7 +390,7 @@ impl TraceTransformService {
             .bind(context.timestamp)
             .execute(&self.pool)
             .await?;
-            
+
             // Also update aggregate balance
             sqlx::query(
                 r#"
@@ -346,10 +415,10 @@ impl TraceTransformService {
             .execute(&self.pool)
             .await?;
         }
-        
+
         Ok(())
     }
-    
+
     /// Process balance changes from receive_intent and value_transfer events
     /// This method is being phased out in favor of using the library's ValueTransferExtractor
     /// which now handles both event types.
@@ -362,34 +431,38 @@ impl TraceTransformService {
         // receive_intent and value_transfer through ValueTransferExtractor.
         // Keeping this for backwards compatibility but it's no longer needed.
         return Ok(());
-        
+
         // Handle ValueTransfer with UTXO tracking
         if trace.event_type == "value_transfer" {
             return self.create_utxo_balance(trace, context).await;
         }
-        
+
         // Handle ReceiveIntent with UTXO tracking
         if trace.event_type == "receive_intent" {
             return self.create_utxo_from_receive_intent(trace, context).await;
         }
-        
+
         // Extract alkane ID - skip if not present or empty
         if trace.alkane_address_block.is_empty() || trace.alkane_address_tx.is_empty() {
             return Ok(());
         }
-        
+
         let alkane_block = trace.alkane_address_block.parse::<i32>()?;
         let alkane_tx = trace.alkane_address_tx.parse::<i64>()?;
-        
+
         // Extract amount and addresses based on event type
         let (address, amount_change) = match trace.event_type.as_str() {
             "receive_intent" => {
                 // Recipient receives alkanes
-                let recipient = trace.data.get("recipient")
+                let recipient = trace
+                    .data
+                    .get("recipient")
                     .and_then(|v| v.as_str())
                     .ok_or_else(|| anyhow::anyhow!("No recipient in receive_intent"))?;
-                
-                let amount = trace.data.get("amount")
+
+                let amount = trace
+                    .data
+                    .get("amount")
                     .or_else(|| trace.data.get("value"))
                     .and_then(|v| {
                         if let Some(s) = v.as_str() {
@@ -399,17 +472,21 @@ impl TraceTransformService {
                         }
                     })
                     .ok_or_else(|| anyhow::anyhow!("No amount in receive_intent"))?;
-                
+
                 (recipient.to_string(), amount)
             }
             "value_transfer" => {
                 // For value_transfer, we need both from and to
                 // For now, just track the "to" address with positive change
-                let to_addr = trace.data.get("to")
+                let to_addr = trace
+                    .data
+                    .get("to")
                     .and_then(|v| v.as_str())
                     .ok_or_else(|| anyhow::anyhow!("No to in value_transfer"))?;
-                
-                let amount = trace.data.get("value")
+
+                let amount = trace
+                    .data
+                    .get("value")
                     .or_else(|| trace.data.get("amount"))
                     .and_then(|v| {
                         if let Some(s) = v.as_str() {
@@ -419,12 +496,12 @@ impl TraceTransformService {
                         }
                     })
                     .ok_or_else(|| anyhow::anyhow!("No value in value_transfer"))?;
-                
+
                 (to_addr.to_string(), amount)
             }
             _ => return Ok(()),
         };
-        
+
         // Upsert into TraceAlkaneBalance
         sqlx::query(
             r#"
@@ -448,7 +525,7 @@ impl TraceTransformService {
         .bind(context.timestamp)
         .execute(&self.pool)
         .await?;
-        
+
         Ok(())
     }
 }
@@ -461,41 +538,60 @@ fn extract_trades_from_traces(
     known_pools: &HashSet<types::AlkaneId>,
 ) -> Vec<TradeEvent> {
     let mut trades = Vec::new();
-    
-    tracing::info!("extract_trades: processing {} traces with {} known pools", traces.len(), known_pools.len());
-    
+
+    tracing::info!(
+        "extract_trades: processing {} traces with {} known pools",
+        traces.len(),
+        known_pools.len()
+    );
+
     // Group traces by vout
-    let mut traces_by_vout: std::collections::HashMap<i32, Vec<&types::TraceEvent>> = 
+    let mut traces_by_vout: std::collections::HashMap<i32, Vec<&types::TraceEvent>> =
         std::collections::HashMap::new();
-    
+
     for trace in traces {
         traces_by_vout.entry(trace.vout).or_default().push(trace);
     }
-    
-    tracing::info!("extract_trades: grouped into {} vouts", traces_by_vout.len());
+
+    tracing::info!(
+        "extract_trades: grouped into {} vouts",
+        traces_by_vout.len()
+    );
     for (&vout, traces) in traces_by_vout.iter() {
         tracing::info!("extract_trades: vout {} has {} traces", vout, traces.len());
     }
-    
+
     // Look for receive_intent + value_transfer patterns
     for (&vout, vout_traces) in traces_by_vout.iter() {
-        tracing::info!("extract_trades: examining vout {} with {} traces", vout, vout_traces.len());
-        
-        let receive_intent = vout_traces.iter()
+        tracing::info!(
+            "extract_trades: examining vout {} with {} traces",
+            vout,
+            vout_traces.len()
+        );
+
+        let receive_intent = vout_traces
+            .iter()
             .find(|t| t.event_type == "receive_intent");
-        let value_transfers: Vec<&&types::TraceEvent> = vout_traces.iter()
+        let value_transfers: Vec<&&types::TraceEvent> = vout_traces
+            .iter()
             .filter(|t| t.event_type == "value_transfer")
             .collect();
-        
-        tracing::info!("extract_trades: vout {} has receive_intent={} value_transfers={}", 
-            vout, receive_intent.is_some(), value_transfers.len());
-        
+
+        tracing::info!(
+            "extract_trades: vout {} has receive_intent={} value_transfers={}",
+            vout,
+            receive_intent.is_some(),
+            value_transfers.len()
+        );
+
         if let Some(intent) = receive_intent {
             if !value_transfers.is_empty() {
                 // Parse pool ID from alkane address - try intent first, fall back to invoke event
                 let (pool_block, pool_tx) = if !intent.alkane_address_block.is_empty() {
-                    (intent.alkane_address_block.parse().unwrap_or(0), 
-                     intent.alkane_address_tx.parse().unwrap_or(0))
+                    (
+                        intent.alkane_address_block.parse().unwrap_or(0),
+                        intent.alkane_address_tx.parse().unwrap_or(0),
+                    )
                 } else {
                     // Find invoke event on a KNOWN POOL (created by factory)
                     // This ensures we track swaps on pools, not on the factory/router
@@ -506,30 +602,41 @@ fn extract_trades_from_traces(
                         if t.data.get("type").and_then(|v| v.as_str()) != Some("call") {
                             return false;
                         }
-                        
+
                         // Parse the alkane address
                         let block = t.alkane_address_block.parse::<i32>().unwrap_or(0);
                         let tx = t.alkane_address_tx.parse::<i64>().unwrap_or(0);
                         let addr = types::AlkaneId::new(block, tx);
-                        
+
                         // Check if this address is a known pool
                         known_pools.contains(&addr)
                     });
-                    
+
                     if let Some(inv) = pool_invoke {
-                        tracing::info!("extract_trades: found pool invoke ({}:{}) - this is a registered pool", 
-                            inv.alkane_address_block, inv.alkane_address_tx);
-                        (inv.alkane_address_block.parse().unwrap_or(0),
-                         inv.alkane_address_tx.parse().unwrap_or(0))
+                        tracing::info!(
+                            "extract_trades: found pool invoke ({}:{}) - this is a registered pool",
+                            inv.alkane_address_block,
+                            inv.alkane_address_tx
+                        );
+                        (
+                            inv.alkane_address_block.parse().unwrap_or(0),
+                            inv.alkane_address_tx.parse().unwrap_or(0),
+                        )
                     } else {
-                        tracing::info!("extract_trades: no invoke on known pools found (only factory/router invokes)");
+                        tracing::info!(
+                            "extract_trades: no invoke on known pools found (only factory/router invokes)"
+                        );
                         (0, 0)
                     }
                 };
-                
-                tracing::info!("extract_trades: potential trade at vout {}, pool {}:{}", 
-                    vout, pool_block, pool_tx);
-                
+
+                tracing::info!(
+                    "extract_trades: potential trade at vout {}, pool {}:{}",
+                    vout,
+                    pool_block,
+                    pool_tx
+                );
+
                 if let Some(trade) = parse_trade_from_intent(
                     context,
                     intent,
@@ -537,15 +644,22 @@ fn extract_trades_from_traces(
                     vout,
                     types::AlkaneId::new(pool_block, pool_tx),
                 ) {
-                    tracing::info!("extract_trades: found trade in tx {} at vout {}", context.txid, vout);
+                    tracing::info!(
+                        "extract_trades: found trade in tx {} at vout {}",
+                        context.txid,
+                        vout
+                    );
                     trades.push(trade);
                 } else {
-                    tracing::info!("extract_trades: failed to parse trade at vout {} - parse_trade_from_intent returned None", vout);
+                    tracing::info!(
+                        "extract_trades: failed to parse trade at vout {} - parse_trade_from_intent returned None",
+                        vout
+                    );
                 }
             }
         }
     }
-    
+
     trades
 }
 
@@ -562,38 +676,42 @@ fn parse_trade_from_intent(
     tracing::info!("parse_trade: intent data: {}", intent.data);
     let inputs = match intent.data.get("transfers").and_then(|v| v.as_array()) {
         Some(arr) => {
-            tracing::info!("parse_trade: found {} transfers in receive_intent", arr.len());
+            tracing::info!(
+                "parse_trade: found {} transfers in receive_intent",
+                arr.len()
+            );
             arr
-        },
+        }
         None => {
             tracing::warn!("parse_trade: no 'transfers' field in receive_intent");
             return None;
         }
     };
-    
+
     let mut token0_id: Option<types::AlkaneId> = None;
     let mut token1_id: Option<types::AlkaneId> = None;
     let mut amount0_in = 0u128;
     let mut amount1_in = 0u128;
-    
+
     for (i, input) in inputs.iter().enumerate() {
         let id_obj = input.get("id")?;
         // block and tx can be either strings or numbers
-        let block: i32 = id_obj.get("block")
-            .and_then(|v| {
-                v.as_str().and_then(|s| s.parse().ok())
-                    .or_else(|| v.as_i64().map(|n| n as i32))
-            })?;
-        let tx: i64 = id_obj.get("tx")
-            .and_then(|v| {
-                v.as_str().and_then(|s| s.parse().ok())
-                    .or_else(|| v.as_i64())
-            })?;
+        let block: i32 = id_obj.get("block").and_then(|v| {
+            v.as_str()
+                .and_then(|s| s.parse().ok())
+                .or_else(|| v.as_i64().map(|n| n as i32))
+        })?;
+        let tx: i64 = id_obj.get("tx").and_then(|v| {
+            v.as_str()
+                .and_then(|s| s.parse().ok())
+                .or_else(|| v.as_i64())
+        })?;
         // The field is "value" not "amount"
-        let amount: u128 = input.get("value")
+        let amount: u128 = input
+            .get("value")
             .and_then(|v| v.as_str())
             .and_then(|s| s.parse().ok())?;
-        
+
         if i == 0 {
             token0_id = Some(types::AlkaneId::new(block, tx));
             amount0_in = amount;
@@ -602,31 +720,32 @@ fn parse_trade_from_intent(
             amount1_in = amount;
         }
     }
-    
+
     // Extract output amounts from value_transfers
     let mut amount0_out = 0u128;
     let mut amount1_out = 0u128;
-    
+
     for transfer in transfers {
         if let Some(transfers_arr) = transfer.data.get("transfers").and_then(|v| v.as_array()) {
             for t in transfers_arr {
                 let id_obj = t.get("id")?;
                 // block and tx can be either strings or numbers
-                let block: i32 = id_obj.get("block")
-                    .and_then(|v| {
-                        v.as_str().and_then(|s| s.parse().ok())
-                            .or_else(|| v.as_i64().map(|n| n as i32))
-                    })?;
-                let tx: i64 = id_obj.get("tx")
-                    .and_then(|v| {
-                        v.as_str().and_then(|s| s.parse().ok())
-                            .or_else(|| v.as_i64())
-                    })?;
+                let block: i32 = id_obj.get("block").and_then(|v| {
+                    v.as_str()
+                        .and_then(|s| s.parse().ok())
+                        .or_else(|| v.as_i64().map(|n| n as i32))
+                })?;
+                let tx: i64 = id_obj.get("tx").and_then(|v| {
+                    v.as_str()
+                        .and_then(|s| s.parse().ok())
+                        .or_else(|| v.as_i64())
+                })?;
                 // The field is "value" not "amount"
-                let amount: u128 = t.get("value")
+                let amount: u128 = t
+                    .get("value")
                     .and_then(|v| v.as_str())
                     .and_then(|s| s.parse().ok())?;
-                
+
                 let alkane_id = types::AlkaneId::new(block, tx);
                 if Some(&alkane_id) == token0_id.as_ref() {
                     amount0_out += amount;
@@ -635,7 +754,11 @@ fn parse_trade_from_intent(
                 } else {
                     // Discover token1 from outputs (for swaps where only 1 token comes in)
                     if token1_id.is_none() {
-                        tracing::info!("parse_trade: discovered token1 from output: {}:{}", block, tx);
+                        tracing::info!(
+                            "parse_trade: discovered token1 from output: {}:{}",
+                            block,
+                            tx
+                        );
                         token1_id = Some(alkane_id);
                         amount1_out = amount;
                     }
@@ -643,11 +766,11 @@ fn parse_trade_from_intent(
             }
         }
     }
-    
+
     // Calculate reserves (simplified - would need pool state)
     let reserve0_after = amount0_in.saturating_sub(amount0_out);
     let reserve1_after = amount1_in.saturating_sub(amount1_out);
-    
+
     Some(TradeEvent {
         txid: context.txid.clone(),
         vout,

--- a/crates/alkanes-trace-transform/src/schema.rs
+++ b/crates/alkanes-trace-transform/src/schema.rs
@@ -1,5 +1,5 @@
 /// Optimized Postgres schema for trace transform with proper indexes
-/// 
+///
 /// This schema is optimized for:
 /// 1. Fast lookups by address
 /// 2. Fast lookups by alkane ID
@@ -40,8 +40,13 @@ CREATE TABLE IF NOT EXISTS "TraceBalanceUtxo" (
     amount NUMERIC NOT NULL,
     block_height INTEGER NOT NULL,
     spent BOOLEAN NOT NULL DEFAULT FALSE,
+    spent_at_height INTEGER,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (outpoint_txid, outpoint_vout, alkane_block, alkane_tx)
+    PRIMARY KEY (outpoint_txid, outpoint_vout, alkane_block, alkane_tx),
+    CONSTRAINT trace_balance_utxo_spent_height_check CHECK (
+        (NOT spent AND spent_at_height IS NULL) OR
+        (spent AND spent_at_height IS NOT NULL AND spent_at_height >= block_height)
+    )
 );
 
 CREATE INDEX IF NOT EXISTS idx_balance_utxo_address ON "TraceBalanceUtxo"(address) WHERE NOT spent;
@@ -158,29 +163,33 @@ CREATE INDEX IF NOT EXISTS idx_storage_block ON "TraceStorage"(block_height);
 pub async fn apply_schema(pool: &PgPool) -> Result<()> {
     // Execute schema statements one by one without transaction
     // This allows IF NOT EXISTS to work properly for indexes
-    
+
     // Split by semicolons and execute each statement
     for (idx, statement) in TRACE_TRANSFORM_SCHEMA.split(';').enumerate() {
         let trimmed = statement.trim();
-        
+
         // Skip empty statements
         if trimmed.is_empty() {
             continue;
         }
-        
+
         // Remove comment lines
         let cleaned: String = trimmed
             .lines()
             .filter(|line| !line.trim().starts_with("--"))
             .collect::<Vec<_>>()
             .join("\n");
-        
+
         // Skip if only comments (nothing left after removing comment lines)
         if !cleaned.trim().is_empty() {
             // Log what we're about to execute
             let preview = cleaned.lines().next().unwrap_or("").trim();
-            eprintln!("Executing statement {}: {}...", idx, &preview[..preview.len().min(60)]);
-            
+            eprintln!(
+                "Executing statement {}: {}...",
+                idx,
+                &preview[..preview.len().min(60)]
+            );
+
             match sqlx::query(&cleaned).execute(pool).await {
                 Ok(_) => eprintln!("  ✓ Success"),
                 Err(e) => {
@@ -191,25 +200,29 @@ pub async fn apply_schema(pool: &PgPool) -> Result<()> {
             }
         }
     }
-    
+
     // Apply alkane registry schema
     for (idx, statement) in ALKANE_REGISTRY_SCHEMA.split(';').enumerate() {
         let trimmed = statement.trim();
-        
+
         if trimmed.is_empty() {
             continue;
         }
-        
+
         let cleaned: String = trimmed
             .lines()
             .filter(|line| !line.trim().starts_with("--"))
             .collect::<Vec<_>>()
             .join("\n");
-        
+
         if !cleaned.trim().is_empty() {
             let preview = cleaned.lines().next().unwrap_or("").trim();
-            eprintln!("Executing alkane registry statement {}: {}...", idx, &preview[..preview.len().min(60)]);
-            
+            eprintln!(
+                "Executing alkane registry statement {}: {}...",
+                idx,
+                &preview[..preview.len().min(60)]
+            );
+
             match sqlx::query(&cleaned).execute(pool).await {
                 Ok(_) => eprintln!("  ✓ Success"),
                 Err(e) => {
@@ -219,7 +232,7 @@ pub async fn apply_schema(pool: &PgPool) -> Result<()> {
             }
         }
     }
-    
+
     Ok(())
 }
 
@@ -239,43 +252,46 @@ pub async fn drop_schema(pool: &PgPool) -> Result<()> {
         DROP TABLE IF EXISTS "TraceBalanceAggregate" CASCADE;
         DROP TABLE IF EXISTS "TraceStorage" CASCADE;
     "#;
-    
+
     sqlx::query(drop_sql).execute(pool).await?;
-    
+
     Ok(())
 }
 
 #[cfg(all(test, feature = "postgres"))]
 mod tests {
     use super::*;
-    
+
     #[tokio::test]
     #[ignore] // Requires database connection
     async fn test_apply_schema() {
         // This test requires a real Postgres connection
         // Run with: cargo test --features postgres -- --ignored
-        
+
         let database_url = std::env::var("DATABASE_URL")
             .unwrap_or_else(|_| "postgres://localhost/alkanes_test".to_string());
-        
+
         let pool = PgPool::connect(&database_url).await.unwrap();
-        
+
         // Apply schema
         apply_schema(&pool).await.unwrap();
-        
+
         // Verify tables exist
         let tables: Vec<(String,)> = sqlx::query_as(
             r#"SELECT table_name FROM information_schema.tables 
                WHERE table_schema = 'public' 
                AND table_name LIKE 'Trace%'
-               ORDER BY table_name"#
+               ORDER BY table_name"#,
         )
         .fetch_all(&pool)
         .await
         .unwrap();
-        
-        assert!(tables.len() >= 7, "Should have created trace transform tables");
-        
+
+        assert!(
+            tables.len() >= 7,
+            "Should have created trace transform tables"
+        );
+
         // Clean up
         drop_schema(&pool).await.unwrap();
     }

--- a/crates/alkanes-trace-transform/src/trackers/balance.rs
+++ b/crates/alkanes-trace-transform/src/trackers/balance.rs
@@ -1,9 +1,9 @@
 use crate::backend::StorageBackend;
 use crate::extractor::TraceExtractor;
 use crate::tracker::StateTracker;
-use crate::types::{AlkaneId, TraceEvent, TransactionContext, Result};
+use crate::types::{AlkaneId, Result, TraceEvent, TransactionContext};
+use anyhow::{bail, Context};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 /// Balance change for a specific alkane at a specific outpoint
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,71 +44,82 @@ impl ValueTransferExtractor {
     pub fn new() -> Self {
         Self { context: None }
     }
-    
+
     pub fn with_context(context: TransactionContext) -> Self {
-        Self { context: Some(context) }
-    }
-    
-    /// Extract transfers from value_transfer event data
-    fn extract_transfers(&self, data: &serde_json::Value, vout: i32) -> Vec<BalanceChange> {
-        let mut changes = Vec::new();
-        
-        // Get the redirect_to field (which vout the value transfers to)
-        let redirect_to = data.get("redirect_to")
-            .and_then(|v| v.as_i64())
-            .unwrap_or(vout as i64) as i32;
-        
-        // Get the address for the target vout from context
-        let address = self.context.as_ref()
-            .and_then(|ctx| ctx.vouts.iter().find(|v| v.index == redirect_to))
-            .and_then(|v| v.address.clone());
-        
-        if address.is_none() {
-            return changes;
+        Self {
+            context: Some(context),
         }
-        
-        let address = address.unwrap();
-        let block_height = self.context.as_ref().map(|c| c.block_height).unwrap_or(0);
-        let txid = self.context.as_ref().map(|c| c.txid.clone()).unwrap_or_default();
+    }
+
+    /// Extract transfers from value_transfer event data
+    fn extract_transfers(&self, data: &serde_json::Value, vout: i32) -> Result<Vec<BalanceChange>> {
+        let mut changes = Vec::new();
+
+        let context = self
+            .context
+            .as_ref()
+            .context("value_transfer extraction requires transaction context")?;
+
+        // Get the redirect_to field (which vout the value transfers to)
+        let redirect_to = match data.get("redirect_to") {
+            Some(value) => parse_i32(value, "value_transfer.redirect_to")?,
+            None => vout,
+        };
+        if redirect_to < 0 {
+            bail!("value_transfer.redirect_to cannot be negative");
+        }
+
+        // Get the address for the target vout from context
+        let address = context
+            .vouts
+            .iter()
+            .find(|v| v.index == redirect_to)
+            .and_then(|v| v.address.clone());
+
+        let block_height = context.block_height;
+        let txid = context.txid.clone();
         let outpoint = format!("{}:{}", txid, redirect_to);
-        
+
         // Extract transfers array
-        let transfers = data.get("transfers")
+        let transfers = data
+            .get("transfers")
             .and_then(|v| v.as_array())
-            .map(|a| a.as_slice())
-            .unwrap_or(&[]);
-        
+            .context("value_transfer.transfers must be an array")?;
+
         for transfer in transfers {
             // Parse alkane ID
-            let alkane_id = transfer.get("id")
-                .or_else(|| transfer.get("alkaneId"));
+            let alkane_id = transfer
+                .get("id")
+                .or_else(|| transfer.get("alkaneId"))
+                .context("value_transfer entry is missing id")?;
+            let block = parse_i32(
+                alkane_id
+                    .get("block")
+                    .context("value_transfer id is missing block")?,
+                "value_transfer.id.block",
+            )?;
+            let tx = parse_i64(
+                alkane_id
+                    .get("tx")
+                    .context("value_transfer id is missing tx")?,
+                "value_transfer.id.tx",
+            )?;
+            if block <= 0 || tx < 0 {
+                bail!("value_transfer alkane id must have block > 0 and tx >= 0");
+            }
 
-            if let Some(id_obj) = alkane_id {
-                // block and tx can be strings or numbers - handle both
-                let block = id_obj.get("block")
-                    .and_then(|v| {
-                        v.as_str().and_then(|s| s.parse::<i32>().ok())
-                            .or_else(|| v.as_i64().map(|n| n as i32))
-                    })
-                    .unwrap_or(0);
-                let tx = id_obj.get("tx")
-                    .and_then(|v| {
-                        v.as_str().and_then(|s| s.parse::<i64>().ok())
-                            .or_else(|| v.as_i64())
-                    })
-                    .unwrap_or(0);
-
-                // Parse amount - value can be string or number
-                let amount = transfer.get("value")
+            let amount = parse_u128(
+                transfer
+                    .get("value")
                     .or_else(|| transfer.get("amount"))
-                    .and_then(|v| {
-                        v.as_str().and_then(|s| s.parse::<u128>().ok())
-                            .or_else(|| v.as_u64().map(|n| n as u128))
-                            .or_else(|| v.as_i64().map(|n| n as u128))
-                    })
-                    .unwrap_or(0);
+                    .context("value_transfer entry is missing value/amount")?,
+                "value_transfer amount",
+            )?;
 
-                if block > 0 && amount > 0 {
+            if amount > 0 {
+                // Addressless protocol outputs are not spendable Marketplace inventory, but
+                // their payloads are still fully validated above so malformed events fail closed.
+                if let Some(address) = address.as_ref() {
                     changes.push(BalanceChange {
                         outpoint: outpoint.clone(),
                         address: address.clone(),
@@ -120,95 +131,82 @@ impl ValueTransferExtractor {
                 }
             }
         }
-        
-        changes
+
+        Ok(changes)
     }
-    
+
     /// Extract balance changes from receive_intent event with transfers array
     /// NOTE: receive_intent events show what's INCOMING to a protostone (shadow vout),
     /// but we should NOT create balance entries from them directly because:
     /// 1. The vout is a virtual protostone index, not a physical output
     /// 2. The actual destination is determined by value_transfer events
     /// We keep this for backward compatibility with tests that use incoming_alkanes format
-    fn extract_from_receive_intent(&self, data: &serde_json::Value, vout: i32) -> Vec<BalanceChange> {
+    fn extract_from_receive_intent(
+        &self,
+        data: &serde_json::Value,
+        vout: i32,
+    ) -> Result<Vec<BalanceChange>> {
         let mut changes = Vec::new();
+
+        let context = self
+            .context
+            .as_ref()
+            .context("receive_intent extraction requires transaction context")?;
 
         // Get the address for this vout from context
         // Note: For receive_intent, vout is typically a shadow vout (tx.output.len() + 1 + i)
         // which won't have an address. This is expected behavior for protocol messages.
-        let address = self.context.as_ref()
-            .and_then(|ctx| ctx.vouts.iter().find(|v| v.index == vout))
+        let address = context
+            .vouts
+            .iter()
+            .find(|v| v.index == vout)
             .and_then(|v| v.address.clone());
 
-        if address.is_none() {
-            // This is expected for receive_intent events on shadow vouts
-            // The actual balance tracking happens via value_transfer events
-            return changes;
-        }
-
-        let address = address.unwrap();
-        let block_height = self.context.as_ref().map(|c| c.block_height).unwrap_or(0);
-        let txid = self.context.as_ref().map(|c| c.txid.clone()).unwrap_or_default();
+        let block_height = context.block_height;
+        let txid = context.txid.clone();
         let outpoint = format!("{}:{}", txid, vout);
 
         // The field name varies depending on the source:
         // - From protostone.rs convert_trace_to_events: "transfers"
         // - From test data: "incoming_alkanes" or "incomingAlkanes"
-        let incoming_alkanes = data.get("transfers")
+        let incoming_alkanes = data
+            .get("transfers")
             .or_else(|| data.get("incoming_alkanes"))
             .or_else(|| data.get("incomingAlkanes"))
             .and_then(|v| v.as_array())
-            .map(|a| a.as_slice())
-            .unwrap_or(&[]);
+            .context("receive_intent transfers/incoming_alkanes must be an array")?;
 
         for alkane_entry in incoming_alkanes {
             // Parse alkane ID
-            let alkane_id = alkane_entry.get("id");
+            let alkane_id = alkane_entry
+                .get("id")
+                .context("receive_intent entry is missing id")?;
+            let block = parse_i32(
+                alkane_id
+                    .get("block")
+                    .context("receive_intent id is missing block")?,
+                "receive_intent.id.block",
+            )?;
+            let tx = parse_i64(
+                alkane_id
+                    .get("tx")
+                    .context("receive_intent id is missing tx")?,
+                "receive_intent.id.tx",
+            )?;
+            if block <= 0 || tx < 0 {
+                bail!("receive_intent alkane id must have block > 0 and tx >= 0");
+            }
+            let amount = parse_u128(
+                alkane_entry
+                    .get("value")
+                    .or_else(|| alkane_entry.get("amount"))
+                    .context("receive_intent entry is missing value/amount")?,
+                "receive_intent amount",
+            )?;
 
-            if let Some(id_obj) = alkane_id {
-                // block and tx can be strings or numbers - handle both
-                let block = id_obj.get("block")
-                    .and_then(|v| {
-                        v.as_str().and_then(|s| s.parse::<i32>().ok())
-                            .or_else(|| v.as_i64().map(|n| n as i32))
-                    })
-                    .unwrap_or(0);
-                let tx = id_obj.get("tx")
-                    .and_then(|v| {
-                        v.as_str().and_then(|s| s.parse::<i64>().ok())
-                            .or_else(|| v.as_i64())
-                    })
-                    .unwrap_or(0);
-
-                // Parse amount from value field - can be:
-                // - U128 format {lo, hi}
-                // - String representation
-                // - Direct number
-                let amount = alkane_entry.get("value")
-                    .and_then(|v| {
-                        // Check for U128 format {lo, hi}
-                        if let Some(lo) = v.get("lo") {
-                            lo.as_i64().or_else(|| lo.as_u64().map(|n| n as i64))
-                                .map(|n| n as u128)
-                        } else {
-                            // Fallback to direct value (string or number)
-                            v.as_str().and_then(|s| s.parse::<u128>().ok())
-                                .or_else(|| v.as_u64().map(|n| n as u128))
-                                .or_else(|| v.as_i64().map(|n| n as u128))
-                        }
-                    })
-                    .or_else(|| {
-                        // Fallback to amount field
-                        alkane_entry.get("amount")
-                            .and_then(|v| {
-                                v.as_str().and_then(|s| s.parse::<u128>().ok())
-                                    .or_else(|| v.as_u64().map(|n| n as u128))
-                                    .or_else(|| v.as_i64().map(|n| n as u128))
-                            })
-                    })
-                    .unwrap_or(0);
-
-                if block > 0 && amount > 0 {
+            if amount > 0 {
+                // Shadow vouts normally have no address, but their payloads must still be valid.
+                if let Some(address) = address.as_ref() {
                     changes.push(BalanceChange {
                         outpoint: outpoint.clone(),
                         address: address.clone(),
@@ -221,8 +219,68 @@ impl ValueTransferExtractor {
             }
         }
 
-        changes
+        Ok(changes)
     }
+}
+
+fn parse_i32(value: &serde_json::Value, label: &str) -> Result<i32> {
+    if let Some(text) = value.as_str() {
+        return text
+            .parse::<i32>()
+            .with_context(|| format!("{label} is not canonical i32 decimal text"));
+    }
+    if let Some(number) = value.as_i64() {
+        return i32::try_from(number).with_context(|| format!("{label} exceeds i32"));
+    }
+    bail!("{label} must be an integer or decimal string")
+}
+
+fn parse_i64(value: &serde_json::Value, label: &str) -> Result<i64> {
+    if let Some(text) = value.as_str() {
+        return text
+            .parse::<i64>()
+            .with_context(|| format!("{label} is not canonical i64 decimal text"));
+    }
+    value
+        .as_i64()
+        .with_context(|| format!("{label} must be an integer or decimal string"))
+}
+
+fn parse_u64_word(value: &serde_json::Value, label: &str) -> Result<u64> {
+    if let Some(text) = value.as_str() {
+        return text
+            .parse::<u64>()
+            .with_context(|| format!("{label} is not canonical u64 decimal text"));
+    }
+    value
+        .as_u64()
+        .with_context(|| format!("{label} must be a non-negative integer or decimal string"))
+}
+
+fn parse_u128(value: &serde_json::Value, label: &str) -> Result<u128> {
+    if let Some(text) = value.as_str() {
+        return text
+            .parse::<u128>()
+            .with_context(|| format!("{label} is not canonical u128 decimal text"));
+    }
+    if let Some(number) = value.as_u64() {
+        return Ok(number as u128);
+    }
+    if value.as_i64().is_some() {
+        bail!("{label} cannot be negative");
+    }
+    if let Some(object) = value.as_object() {
+        let lo = parse_u64_word(
+            object.get("lo").context("u128 object is missing lo")?,
+            "u128.lo",
+        )?;
+        let hi = match object.get("hi") {
+            Some(hi) => parse_u64_word(hi, "u128.hi")?,
+            None => 0,
+        };
+        return Ok(((hi as u128) << 64) | lo as u128);
+    }
+    bail!("{label} must be a non-negative integer, decimal string, or {{lo, hi}} object")
 }
 
 impl Default for ValueTransferExtractor {
@@ -233,21 +291,21 @@ impl Default for ValueTransferExtractor {
 
 impl TraceExtractor for ValueTransferExtractor {
     type Output = Vec<BalanceChange>;
-    
+
     fn extract(&self, trace: &TraceEvent) -> Result<Option<Vec<BalanceChange>>> {
         let changes = match trace.event_type.as_str() {
-            "value_transfer" => self.extract_transfers(&trace.data, trace.vout),
-            "receive_intent" => self.extract_from_receive_intent(&trace.data, trace.vout),
+            "value_transfer" => self.extract_transfers(&trace.data, trace.vout)?,
+            "receive_intent" => self.extract_from_receive_intent(&trace.data, trace.vout)?,
             _ => return Ok(None),
         };
-        
+
         if changes.is_empty() {
             Ok(None)
         } else {
             Ok(Some(changes))
         }
     }
-    
+
     fn name(&self) -> &'static str {
         "value_transfer_extractor"
     }
@@ -260,17 +318,17 @@ impl BalanceTracker {
     pub fn new() -> Self {
         Self
     }
-    
+
     /// Encode key for aggregate balance: "balance:{address}:{alkane_id}"
     fn balance_key(address: &str, alkane_id: &AlkaneId) -> Vec<u8> {
         format!("balance:{}:{}", address, alkane_id.to_string()).into_bytes()
     }
-    
+
     /// Encode key for UTXO balance: "utxo:{outpoint}:{alkane_id}"
     fn utxo_key(outpoint: &str, alkane_id: &AlkaneId) -> Vec<u8> {
         format!("utxo:{}:{}", outpoint, alkane_id.to_string()).into_bytes()
     }
-    
+
     /// Encode key for holder enumeration: "holder:{alkane_id}:{address}"
     fn holder_key(alkane_id: &AlkaneId, address: &str) -> Vec<u8> {
         format!("holder:{}:{}", alkane_id.to_string(), address).into_bytes()
@@ -285,17 +343,21 @@ impl Default for BalanceTracker {
 
 impl StateTracker for BalanceTracker {
     type Input = Vec<BalanceChange>;
-    
+
     fn name(&self) -> &'static str {
         "value_transfer_extractor"
     }
-    
-    fn update<B: StorageBackend>(&mut self, backend: &mut B, changes: Vec<BalanceChange>) -> Result<()> {
+
+    fn update<B: StorageBackend>(
+        &mut self,
+        backend: &mut B,
+        changes: Vec<BalanceChange>,
+    ) -> Result<()> {
         for change in changes {
             let balance_key = Self::balance_key(&change.address, &change.alkane_id);
             let utxo_key = Self::utxo_key(&change.outpoint, &change.alkane_id);
             let holder_key = Self::holder_key(&change.alkane_id, &change.address);
-            
+
             // Update UTXO-level balance
             let utxo_balance = UtxoBalance {
                 outpoint: change.outpoint.clone(),
@@ -305,32 +367,33 @@ impl StateTracker for BalanceTracker {
                 block_height: change.block_height,
                 spent: false,
             };
-            
+
             let utxo_bytes = serde_json::to_vec(&utxo_balance)?;
             backend.set("utxo_balances", &utxo_key, &utxo_bytes)?;
-            
+
             // Update aggregate balance
-            let current_balance = backend.get("address_balances", &balance_key)?
+            let current_balance = backend
+                .get("address_balances", &balance_key)?
                 .and_then(|bytes| serde_json::from_slice::<AddressBalance>(&bytes).ok())
                 .map(|b| b.total_amount)
                 .unwrap_or(0);
-            
+
             let new_balance = AddressBalance {
                 address: change.address.clone(),
                 alkane_id: change.alkane_id.clone(),
                 total_amount: current_balance + change.amount,
             };
-            
+
             let balance_bytes = serde_json::to_vec(&new_balance)?;
             backend.set("address_balances", &balance_key, &balance_bytes)?;
-            
+
             // Update holder enumeration
             backend.set("holders", &holder_key, &balance_bytes)?;
         }
-        
+
         Ok(())
     }
-    
+
     fn reset<B: StorageBackend>(&mut self, backend: &mut B) -> Result<()> {
         // Clear all tables
         for key in ["address_balances", "utxo_balances", "holders"] {
@@ -348,7 +411,7 @@ mod tests {
     use crate::backend::InMemoryBackend;
     use crate::types::VoutInfo;
     use serde_json::json;
-    
+
     fn create_test_context() -> TransactionContext {
         TransactionContext {
             txid: "abc123".to_string(),
@@ -370,12 +433,12 @@ mod tests {
             ],
         }
     }
-    
+
     #[test]
     fn test_value_transfer_extraction() {
         let context = create_test_context();
         let extractor = ValueTransferExtractor::with_context(context);
-        
+
         let trace = TraceEvent {
             event_type: "value_transfer".to_string(),
             vout: 0,
@@ -395,10 +458,10 @@ mod tests {
                 ]
             }),
         };
-        
+
         let result = extractor.extract(&trace).unwrap();
         assert!(result.is_some());
-        
+
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert_eq!(changes[0].address, "bc1qtest2");
@@ -407,12 +470,96 @@ mod tests {
         assert_eq!(changes[0].amount, 1000);
         assert_eq!(changes[1].amount, 2000);
     }
-    
+
+    #[test]
+    fn malformed_value_transfer_fails_closed() {
+        let extractor = ValueTransferExtractor::with_context(create_test_context());
+        let trace = TraceEvent {
+            event_type: "value_transfer".to_string(),
+            vout: 0,
+            alkane_address_block: "4".to_string(),
+            alkane_address_tx: "0".to_string(),
+            data: json!({"redirect_to": 1}),
+        };
+
+        assert!(extractor.extract(&trace).is_err());
+    }
+
+    #[test]
+    fn negative_amount_never_wraps_to_u128() {
+        let extractor = ValueTransferExtractor::with_context(create_test_context());
+        let trace = TraceEvent {
+            event_type: "value_transfer".to_string(),
+            vout: 0,
+            alkane_address_block: "4".to_string(),
+            alkane_address_tx: "0".to_string(),
+            data: json!({
+                "transfers": [{"id": {"block": 4, "tx": 10}, "amount": -1}]
+            }),
+        };
+
+        assert!(extractor.extract(&trace).is_err());
+    }
+
+    #[test]
+    fn malformed_alkane_id_fails_closed() {
+        let extractor = ValueTransferExtractor::with_context(create_test_context());
+        let trace = TraceEvent {
+            event_type: "value_transfer".to_string(),
+            vout: 0,
+            alkane_address_block: "4".to_string(),
+            alkane_address_tx: "0".to_string(),
+            data: json!({
+                "transfers": [{"id": {"block": "not-a-number", "tx": 10}, "amount": 1}]
+            }),
+        };
+
+        assert!(extractor.extract(&trace).is_err());
+    }
+
+    #[test]
+    fn full_u128_word_encoding_is_preserved() {
+        let extractor = ValueTransferExtractor::with_context(create_test_context());
+        let trace = TraceEvent {
+            event_type: "value_transfer".to_string(),
+            vout: 0,
+            alkane_address_block: "4".to_string(),
+            alkane_address_tx: "0".to_string(),
+            data: json!({
+                "transfers": [{
+                    "id": {"block": 4, "tx": 10},
+                    "amount": {"lo": 7, "hi": 1}
+                }]
+            }),
+        };
+
+        let changes = extractor.extract(&trace).unwrap().unwrap();
+        assert_eq!(changes[0].amount, (1_u128 << 64) + 7);
+    }
+
+    #[test]
+    fn addressless_events_are_still_validated() {
+        let mut context = create_test_context();
+        context.vouts[0].address = None;
+        let extractor = ValueTransferExtractor::with_context(context);
+        let trace = TraceEvent {
+            event_type: "value_transfer".to_string(),
+            vout: 0,
+            alkane_address_block: "4".to_string(),
+            alkane_address_tx: "0".to_string(),
+            data: json!({
+                "transfers": [{"id": {"block": 4, "tx": 10}, "amount": -1}]
+            }),
+        };
+
+        assert!(extractor.extract(&trace).is_err());
+    }
+
     #[test]
     fn test_balance_tracking() {
         let mut backend = InMemoryBackend::new();
         let mut tracker = BalanceTracker::new();
-        
+
         let changes = vec![
             BalanceChange {
                 outpoint: "abc123:0".to_string(),
@@ -431,60 +578,72 @@ mod tests {
                 tx_hash: "abc123".to_string(),
             },
         ];
-        
+
         tracker.update(&mut backend, changes).unwrap();
-        
+
         // Check aggregate balance
         let balance_key = BalanceTracker::balance_key("bc1qtest", &AlkaneId::new(4, 10));
-        let balance_bytes = backend.get("address_balances", &balance_key).unwrap().unwrap();
+        let balance_bytes = backend
+            .get("address_balances", &balance_key)
+            .unwrap()
+            .unwrap();
         let balance: AddressBalance = serde_json::from_slice(&balance_bytes).unwrap();
-        
+
         assert_eq!(balance.total_amount, 1500);
         assert_eq!(balance.address, "bc1qtest");
-        
+
         // Check UTXO balances
         let utxo_key = BalanceTracker::utxo_key("abc123:0", &AlkaneId::new(4, 10));
         let utxo_bytes = backend.get("utxo_balances", &utxo_key).unwrap().unwrap();
         let utxo: UtxoBalance = serde_json::from_slice(&utxo_bytes).unwrap();
-        
+
         assert_eq!(utxo.amount, 1000);
         assert!(!utxo.spent);
     }
-    
+
     #[test]
     fn test_balance_accumulation() {
         let mut backend = InMemoryBackend::new();
         let mut tracker = BalanceTracker::new();
-        
+
         // First deposit
-        tracker.update(&mut backend, vec![
-            BalanceChange {
-                outpoint: "tx1:0".to_string(),
-                address: "bc1qtest".to_string(),
-                alkane_id: AlkaneId::new(4, 10),
-                amount: 1000,
-                block_height: 100,
-                tx_hash: "tx1".to_string(),
-            },
-        ]).unwrap();
-        
+        tracker
+            .update(
+                &mut backend,
+                vec![BalanceChange {
+                    outpoint: "tx1:0".to_string(),
+                    address: "bc1qtest".to_string(),
+                    alkane_id: AlkaneId::new(4, 10),
+                    amount: 1000,
+                    block_height: 100,
+                    tx_hash: "tx1".to_string(),
+                }],
+            )
+            .unwrap();
+
         // Second deposit
-        tracker.update(&mut backend, vec![
-            BalanceChange {
-                outpoint: "tx2:0".to_string(),
-                address: "bc1qtest".to_string(),
-                alkane_id: AlkaneId::new(4, 10),
-                amount: 2000,
-                block_height: 101,
-                tx_hash: "tx2".to_string(),
-            },
-        ]).unwrap();
-        
+        tracker
+            .update(
+                &mut backend,
+                vec![BalanceChange {
+                    outpoint: "tx2:0".to_string(),
+                    address: "bc1qtest".to_string(),
+                    alkane_id: AlkaneId::new(4, 10),
+                    amount: 2000,
+                    block_height: 101,
+                    tx_hash: "tx2".to_string(),
+                }],
+            )
+            .unwrap();
+
         // Check accumulated balance
         let balance_key = BalanceTracker::balance_key("bc1qtest", &AlkaneId::new(4, 10));
-        let balance_bytes = backend.get("address_balances", &balance_key).unwrap().unwrap();
+        let balance_bytes = backend
+            .get("address_balances", &balance_key)
+            .unwrap()
+            .unwrap();
         let balance: AddressBalance = serde_json::from_slice(&balance_bytes).unwrap();
-        
+
         assert_eq!(balance.total_amount, 3000);
     }
 }

--- a/crates/alkanes-trace-transform/src/trackers/optimized_balance.rs
+++ b/crates/alkanes-trace-transform/src/trackers/optimized_balance.rs
@@ -1,8 +1,25 @@
 use crate::extractor::TraceExtractor;
-use crate::types::{AlkaneId, TraceEvent, Result};
-use crate::trackers::balance::{ValueTransferExtractor, BalanceChange};
+use crate::trackers::balance::{BalanceChange, ValueTransferExtractor};
+use crate::types::{AlkaneId, Result, TraceEvent};
+use anyhow::{bail, Context};
 use sqlx::PgPool;
 use std::collections::HashMap;
+
+fn parse_outpoint<'a>(outpoint: &'a str, label: &str) -> Result<(&'a str, i32)> {
+    let (txid, vout_text) = outpoint
+        .split_once(':')
+        .with_context(|| format!("{label} must have txid:vout form"))?;
+    if txid.is_empty() || vout_text.contains(':') {
+        bail!("{label} must have exactly one non-empty txid:vout pair");
+    }
+    let vout: i32 = vout_text
+        .parse()
+        .with_context(|| format!("{label} vout is not an i32"))?;
+    if vout < 0 {
+        bail!("{label} vout cannot be negative");
+    }
+    Ok((txid, vout))
+}
 
 /// Optimized balance tracker that writes directly to proper indexed tables
 /// instead of using the generic key-value backend
@@ -14,62 +31,69 @@ impl OptimizedBalanceTracker {
     pub fn new(pool: PgPool) -> Self {
         Self { pool }
     }
-    
+
     /// Process balance changes and update all tables
     pub async fn process_balance_changes(&self, changes: Vec<BalanceChange>) -> Result<()> {
         if changes.is_empty() {
             return Ok(());
         }
-        
+
         let mut tx = self.pool.begin().await?;
-        
+
         // Group changes by (address, alkane_id) for aggregation, keeping the latest change for metadata
         let mut aggregates: HashMap<(String, AlkaneId), (u128, i32, String)> = HashMap::new();
-        
+
         for change in &changes {
             // Insert/update UTXO-level balance
             self.upsert_utxo_balance(&mut tx, change).await?;
-            
+
             // Accumulate for aggregate update, keeping track of latest block/tx
             let key = (change.address.clone(), change.alkane_id.clone());
             let entry = aggregates.entry(key).or_insert((0, 0, String::new()));
-            entry.0 += change.amount;
+            entry.0 = entry
+                .0
+                .checked_add(change.amount)
+                .context("balance delta overflow while aggregating one transaction")?;
             // Keep the latest block height and tx
             if change.block_height >= entry.1 {
                 entry.1 = change.block_height;
                 entry.2 = change.tx_hash.clone();
             }
         }
-        
+
         // Update aggregate balances
         for ((address, alkane_id), (amount_delta, block_height, tx_hash)) in aggregates {
-            self.update_aggregate_balance(&mut tx, &address, &alkane_id, amount_delta, block_height, &tx_hash).await?;
-            self.update_holder(&mut tx, &address, &alkane_id, amount_delta).await?;
+            self.update_aggregate_balance(
+                &mut tx,
+                &address,
+                &alkane_id,
+                amount_delta,
+                block_height,
+                &tx_hash,
+            )
+            .await?;
+            self.update_holder(&mut tx, &address, &alkane_id, amount_delta)
+                .await?;
         }
-        
+
         tx.commit().await?;
-        
+
         Ok(())
     }
-    
+
     /// Insert or update UTXO balance
     async fn upsert_utxo_balance(
         &self,
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         change: &BalanceChange,
     ) -> Result<()> {
-        let parts: Vec<&str> = change.outpoint.split(':').collect();
-        let txid = parts.get(0).unwrap_or(&"");
-        let vout: i32 = parts.get(1).and_then(|v| v.parse().ok()).unwrap_or(0);
-        
+        let (txid, vout) = parse_outpoint(&change.outpoint, "balance outpoint")?;
+
         sqlx::query(
             r#"INSERT INTO "TraceBalanceUtxo"
                (outpoint_txid, outpoint_vout, address, alkane_block, alkane_tx, amount, block_height, spent)
                VALUES ($1, $2, $3, $4, $5, $6::numeric, $7, $8)
-               ON CONFLICT (outpoint_txid, outpoint_vout, alkane_block, alkane_tx)
-               DO UPDATE SET
-                   amount = EXCLUDED.amount,
-                   spent = EXCLUDED.spent"#
+               "#
         )
         .bind(txid)
         .bind(vout)
@@ -81,10 +105,10 @@ impl OptimizedBalanceTracker {
         .bind(false) // not spent when created
         .execute(&mut **tx)
         .await?;
-        
+
         Ok(())
     }
-    
+
     /// Update aggregate balance (writes to TraceAlkaneBalance for API compatibility)
     async fn update_aggregate_balance(
         &self,
@@ -98,18 +122,26 @@ impl OptimizedBalanceTracker {
         // Get current balance from TraceAlkaneBalance (used by API)
         let current: Option<String> = sqlx::query_scalar(
             r#"SELECT balance::TEXT FROM "TraceAlkaneBalance"
-               WHERE address = $1 AND alkane_block = $2 AND alkane_tx = $3"#
+               WHERE address = $1 AND alkane_block = $2 AND alkane_tx = $3"#,
         )
         .bind(address)
         .bind(alkane_id.block)
         .bind(alkane_id.tx)
         .fetch_optional(&mut **tx)
         .await?;
-        
-        let new_total = current
-            .and_then(|s| s.parse::<u128>().ok())
-            .unwrap_or(0) + amount_delta;
-        
+
+        let current_total = current
+            .map(|value| {
+                value
+                    .parse::<u128>()
+                    .with_context(|| format!("invalid existing TraceAlkaneBalance value {value:?}"))
+            })
+            .transpose()?
+            .unwrap_or(0);
+        let new_total = current_total
+            .checked_add(amount_delta)
+            .context("TraceAlkaneBalance overflow")?;
+
         sqlx::query(
             r#"INSERT INTO "TraceAlkaneBalance"
                (address, alkane_block, alkane_tx, balance, last_updated_block, last_updated_tx, last_updated_timestamp)
@@ -129,10 +161,10 @@ impl OptimizedBalanceTracker {
         .bind(tx_hash)
         .execute(&mut **tx)
         .await?;
-        
+
         Ok(())
     }
-    
+
     /// Update holder enumeration
     async fn update_holder(
         &self,
@@ -144,19 +176,27 @@ impl OptimizedBalanceTracker {
         // Get current holder amount
         let current: Option<String> = sqlx::query_scalar(
             r#"SELECT total_amount::TEXT FROM "TraceHolder"
-               WHERE alkane_block = $1 AND alkane_tx = $2 AND address = $3"#
+               WHERE alkane_block = $1 AND alkane_tx = $2 AND address = $3"#,
         )
         .bind(alkane_id.block)
         .bind(alkane_id.tx)
         .bind(address)
         .fetch_optional(&mut **tx)
         .await?;
-        
+
         let was_zero = current.is_none();
-        let new_total = current
-            .and_then(|s| s.parse::<u128>().ok())
-            .unwrap_or(0) + amount_delta;
-        
+        let current_total = current
+            .map(|value| {
+                value
+                    .parse::<u128>()
+                    .with_context(|| format!("invalid existing TraceHolder value {value:?}"))
+            })
+            .transpose()?
+            .unwrap_or(0);
+        let new_total = current_total
+            .checked_add(amount_delta)
+            .context("TraceHolder balance overflow")?;
+
         sqlx::query(
             r#"INSERT INTO "TraceHolder"
                (alkane_block, alkane_tx, address, total_amount, updated_at)
@@ -164,7 +204,7 @@ impl OptimizedBalanceTracker {
                ON CONFLICT (alkane_block, alkane_tx, address)
                DO UPDATE SET
                    total_amount = EXCLUDED.total_amount,
-                   updated_at = NOW()"#
+                   updated_at = NOW()"#,
         )
         .bind(alkane_id.block)
         .bind(alkane_id.tx)
@@ -172,7 +212,7 @@ impl OptimizedBalanceTracker {
         .bind(new_total.to_string())
         .execute(&mut **tx)
         .await?;
-        
+
         // Update holder count if this is a new holder
         if was_zero && new_total > 0 {
             sqlx::query(
@@ -182,43 +222,42 @@ impl OptimizedBalanceTracker {
                    ON CONFLICT (alkane_block, alkane_tx)
                    DO UPDATE SET
                        count = "TraceHolderCount".count + 1,
-                       updated_at = NOW()"#
+                       updated_at = NOW()"#,
             )
             .bind(alkane_id.block)
             .bind(alkane_id.tx)
             .execute(&mut **tx)
             .await?;
         }
-        
+
         Ok(())
     }
-    
+
     /// Mark UTXOs as spent
-    pub async fn mark_utxos_spent(&self, outpoints: Vec<String>, _block_height: i32) -> Result<()> {
+    pub async fn mark_utxos_spent(&self, outpoints: Vec<String>, block_height: i32) -> Result<()> {
         if outpoints.is_empty() {
             return Ok(());
         }
-        
+
         let mut tx = self.pool.begin().await?;
-        
+
         for outpoint in outpoints {
-            let parts: Vec<&str> = outpoint.split(':').collect();
-            let txid = parts.get(0).unwrap_or(&"");
-            let vout: i32 = parts.get(1).and_then(|v| v.parse().ok()).unwrap_or(0);
-            
+            let (txid, vout) = parse_outpoint(&outpoint, "spent outpoint")?;
+
             sqlx::query(
                 r#"UPDATE "TraceBalanceUtxo"
-                   SET spent = true
-                   WHERE outpoint_txid = $1 AND outpoint_vout = $2"#
+                   SET spent = true, spent_at_height = $3
+                   WHERE outpoint_txid = $1 AND outpoint_vout = $2"#,
             )
             .bind(txid)
             .bind(vout)
+            .bind(block_height)
             .execute(&mut *tx)
             .await?;
         }
-        
+
         tx.commit().await?;
-        
+
         Ok(())
     }
 }
@@ -236,14 +275,14 @@ impl OptimizedBalanceProcessor {
             tracker: OptimizedBalanceTracker::new(pool),
         }
     }
-    
+
     pub fn with_context(pool: PgPool, context: crate::types::TransactionContext) -> Self {
         Self {
             extractor: ValueTransferExtractor::with_context(context),
             tracker: OptimizedBalanceTracker::new(pool),
         }
     }
-    
+
     /// Process a trace event and update balances
     pub async fn process_trace(&mut self, trace: &TraceEvent) -> Result<()> {
         if let Some(changes) = self.extractor.extract(trace)? {
@@ -256,22 +295,29 @@ impl OptimizedBalanceProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{TransactionContext, VoutInfo};
-    use serde_json::json;
-    
+
+    #[test]
+    fn outpoint_parser_rejects_ambiguous_or_negative_values() {
+        assert!(parse_outpoint("txid", "outpoint").is_err());
+        assert!(parse_outpoint(":0", "outpoint").is_err());
+        assert!(parse_outpoint("txid:-1", "outpoint").is_err());
+        assert!(parse_outpoint("txid:0:1", "outpoint").is_err());
+        assert_eq!(parse_outpoint("txid:7", "outpoint").unwrap(), ("txid", 7));
+    }
+
     #[tokio::test]
     #[ignore] // Requires database
     async fn test_optimized_balance_tracker() {
         let database_url = std::env::var("DATABASE_URL")
             .unwrap_or_else(|_| "postgres://localhost/alkanes_test".to_string());
-        
+
         let pool = PgPool::connect(&database_url).await.unwrap();
-        
+
         // Apply schema
         crate::schema::apply_schema(&pool).await.unwrap();
-        
+
         let tracker = OptimizedBalanceTracker::new(pool.clone());
-        
+
         let changes = vec![
             BalanceChange {
                 outpoint: "abc123:0".to_string(),
@@ -279,6 +325,7 @@ mod tests {
                 alkane_id: AlkaneId::new(4, 10),
                 amount: 1000,
                 block_height: 100,
+                tx_hash: "abc123".to_string(),
             },
             BalanceChange {
                 outpoint: "abc123:1".to_string(),
@@ -286,15 +333,16 @@ mod tests {
                 alkane_id: AlkaneId::new(4, 10),
                 amount: 500,
                 block_height: 100,
+                tx_hash: "abc123".to_string(),
             },
         ];
-        
+
         tracker.process_balance_changes(changes).await.unwrap();
-        
+
         // Verify aggregate balance
         let balance: String = sqlx::query_scalar(
             r#"SELECT total_amount::TEXT FROM "TraceBalanceAggregate"
-               WHERE address = $1 AND alkane_block = $2 AND alkane_tx = $3"#
+               WHERE address = $1 AND alkane_block = $2 AND alkane_tx = $3"#,
         )
         .bind("bc1qtest")
         .bind(4)
@@ -302,22 +350,22 @@ mod tests {
         .fetch_one(&pool)
         .await
         .unwrap();
-        
+
         assert_eq!(balance.parse::<u128>().unwrap(), 1500);
-        
+
         // Verify holder count
         let count: i64 = sqlx::query_scalar(
             r#"SELECT count FROM "TraceHolderCount"
-               WHERE alkane_block = $1 AND alkane_tx = $2"#
+               WHERE alkane_block = $1 AND alkane_tx = $2"#,
         )
         .bind(4)
         .bind(10i64)
         .fetch_one(&pool)
         .await
         .unwrap();
-        
+
         assert_eq!(count, 1);
-        
+
         // Clean up
         crate::schema::drop_schema(&pool).await.unwrap();
     }

--- a/docs/MARKETPLACE_CANONICAL_COMMIT.md
+++ b/docs/MARKETPLACE_CANONICAL_COMMIT.md
@@ -1,0 +1,173 @@
+# Marketplace canonical producer commitment v1
+
+`alkanes-contract-indexer` publishes Marketplace-readable state through
+`"MarketplaceCanonicalCommit"`. The legacy pipeline still performs some transforms in separate
+database transactions, so the commit row is the atomic visibility boundary: a consumer must never
+treat a `TraceAlkane` or `TraceBalanceUtxo` row above the latest committed height as canonical.
+
+Startup refuses an `indexer_position` that does not exactly equal the latest canonical commitment.
+That makes adoption intentionally fail closed: a database created by an older producer requires a
+full replay instead of silently blessing legacy partial state. It also rejects authority or spend
+staging rows outside the one immediately retryable height, and rejects every spent mutation newer
+than the committed tip.
+
+## Publication fields
+
+Each immutable row contains:
+
+- `height`, `block_hash`, and `previous_block_hash` (lowercase 64-character Core hashes)
+- `reorg_epoch`, incremented once for each atomically removed fork suffix
+- `producer_revision`, injected at build time from the exact Git revision (or the explicit
+  `ALKANES_PRODUCER_REVISION` build variable)
+- `schema_revision = marketplace-canonical-commit-v1`
+- count and SHA-256 digest for `TraceAlkane` rows created at the height
+- count and SHA-256 digest for `TraceBalanceUtxo` rows created or spent at the height
+- count and SHA-256 root for the complete active (`spent = false`) UTXO inventory
+- `manifest_hash`, binding every field above
+
+The same serializable transaction inserts the commitment and the matching `ProcessedBlocks` row,
+then advances the single `indexer_position` row. There is no update-on-conflict path for a committed
+height. An exact retry is idempotent; a different hash or manifest is an error.
+
+The SQL consumer contract is:
+
+```sql
+"MarketplaceCanonicalCommit" (
+  height BIGINT PRIMARY KEY,
+  block_hash TEXT UNIQUE NOT NULL,
+  previous_block_hash TEXT NOT NULL,
+  reorg_epoch BIGINT NOT NULL,
+  producer_revision TEXT NOT NULL,
+  schema_revision TEXT NOT NULL,
+  trace_alkane_row_count BIGINT NOT NULL,
+  trace_alkane_row_hash TEXT NOT NULL,
+  trace_balance_utxo_row_count BIGINT NOT NULL,
+  trace_balance_utxo_row_hash TEXT NOT NULL,
+  active_inventory_count BIGINT NOT NULL,
+  active_inventory_root TEXT NOT NULL,
+  manifest_hash TEXT UNIQUE NOT NULL,
+  committed_at TIMESTAMPTZ NOT NULL
+)
+
+"MarketplaceCanonicalState" (
+  id SMALLINT PRIMARY KEY CHECK (id = 1),
+  reorg_epoch BIGINT NOT NULL
+)
+```
+
+Hashes are lowercase 64-character hexadecimal strings. `producer_revision` is a lowercase 40- or
+64-character Git object ID, and the v1 database constraint pins `schema_revision` to
+`marketplace-canonical-commit-v1`.
+
+The marker's `reorg_epoch` is the epoch in which that height was published. Consumers must also
+read the singleton state's current epoch in the same database snapshot. Immediately after rollback
+and before the replacement child is published, the state epoch is intentionally newer than the
+immutable ancestor marker's epoch.
+
+## Digest encoding
+
+The algorithm is `alkanes-marketplace-canonical-manifest-v1`. Every domain and field is encoded as
+an unsigned 64-bit big-endian byte length followed by exact UTF-8 bytes. A row begins with byte
+`0x01` and an unsigned 64-bit big-endian field count. Rows use PostgreSQL's canonical decimal text
+for integers/numerics and are ordered by their stable primary-key components before SHA-256.
+
+Per-height `TraceAlkane` fields are:
+
+1. `alkane_block`
+2. `alkane_tx`
+3. `created_at_block`
+4. `created_at_tx`
+5. `created_at_height`
+
+Per-height `TraceBalanceUtxo` commitment entries are immutable logical events. A row created and
+spent in the same block contributes both a `create` and a `spend` entry. This keeps every historical
+height recomputable even though the live row's spent status changes. Active-inventory entries use
+`event_kind = active`; therefore `trace_balance_utxo_row_count` counts logical event entries, while
+`active_inventory_count` counts physical active rows. Fields are:
+
+1. `event_kind` (`create`, `spend`, or `active`)
+2. `outpoint_txid`
+3. `outpoint_vout`
+4. `address`
+5. `alkane_block`
+6. `alkane_tx`
+7. `amount`
+8. `block_height`
+9. `spent`
+10. `spent_at_height` (empty string when SQL `NULL`)
+
+For a `create` entry, `spent` is the literal `false` and `spent_at_height` is empty. For a `spend`
+entry, `spent` is `true`. Active entries at height `H` satisfy `block_height <= H AND
+(spent_at_height IS NULL OR spent_at_height > H)` and encode `spent = false` with an empty
+`spent_at_height`. This makes historical inventory roots recomputable from the current table.
+
+The domains are respectively
+`alkanes-marketplace-trace-alkane-height-v1`,
+`alkanes-marketplace-trace-balance-utxo-height-v1`, and
+`alkanes-marketplace-active-inventory-v1`.
+
+`manifest_hash` uses domain `alkanes-marketplace-canonical-manifest-v1` and exactly one row with
+these fields in order: `height`, `block_hash`, `previous_block_hash`, `reorg_epoch`,
+`producer_revision`, `schema_revision`, `trace_alkane_row_count`, `trace_alkane_row_hash`,
+`trace_balance_utxo_row_count`, `trace_balance_utxo_row_hash`, `active_inventory_count`, and
+`active_inventory_root`. The published row count is not appended to a row digest; it is separately
+bound by the manifest. An empty row set hashes only its length-prefixed domain.
+
+Encoding test vector: domain `domain` with rows `["b", "2"]` and `["a", "1"]` (supplied in
+either order) hashes to
+`abc7d197a4f756fbd71d96257424da42d666904f82088e8629847910966fcc3b`.
+
+## Failure, retry, and reorg rules
+
+The full block interval is serialized with a PostgreSQL advisory lock. Registry loading, create-row
+persistence, trace balance processing, and UTXO extraction errors are propagated; they cannot
+advance progress. Before retrying an uncommitted height, its authoritative rows are deleted and
+aggregate balance/holder tables are rebuilt from the remaining active `TraceBalanceUtxo` inventory.
+The transaction list comes directly from Bitcoin Core and must contain only unique canonical txids.
+Every fetched transaction body must exactly cover that list, report the same confirmed Core block
+height/hash/timestamp, and provide structurally valid inputs, outputs, values, and scripts. The Core
+height/hash link is checked again immediately before publication so a mid-transform reorg aborts the
+attempt.
+
+Protostone decoding and trace conversion are also fail closed. A missing trace payload, missing
+event variant, unknown call/status enum, undecodable protostone message, or transfer missing its
+Alkane ID/value aborts the block. Such data is never normalized to an empty trace or zero balance.
+
+Every non-coinbase Bitcoin input is first written to the private
+`MarketplaceBalanceSpendStage`. Staging never changes consumer-visible inventory. Publication
+marks matching `TraceBalanceUtxo` rows spent, records `spent_at_height`, rebuilds aggregates, hashes
+the resulting active inventory, inserts the marker and progress rows, and clears staging in one
+transaction. A deferred trigger refuses any spent mutation without the matching marker. This also
+makes same-block create-and-spend rows deterministic.
+
+Every monitoring pass compares the committed tip hash with Bitcoin Core, including when no higher
+block exists. On a same-height or deep fork, the producer scans committed hashes backwards until it
+finds a Core-matching ancestor. One serializable transaction then:
+
+1. re-verifies the selected ancestor's stored hash;
+2. increments `reorg_epoch`;
+3. deletes `TraceAlkane` and `TraceBalanceUtxo` rows created above it and reverses spends above it;
+4. rebuilds aggregate balance/holder tables;
+5. deletes the `ProcessedBlocks` and commitment suffix; and
+6. rewinds or clears `indexer_position`.
+
+Database triggers reject updates/deletes of commitment and `ProcessedBlocks` rows, reject invalid
+`indexer_position` advances, and reject late mutations of `TraceAlkane`/`TraceBalanceUtxo` at or
+below a committed height. A deferred marker trigger requires the matching `ProcessedBlocks` and
+`indexer_position` rows and current state epoch before commit. The singleton epoch can only advance
+by exactly one inside hash-verified rollback. Only canonical spend publication and hash-verified
+rollback use narrowly scoped local bypass settings.
+
+## Consumer rule
+
+Marketplace authorities should read the latest commitment, require the expected producer and schema
+revisions, independently verify its Core hash/checkpoint, and include the complete commitment fields
+in readiness evidence. Read registry rows with `created_at_height <= height` and UTXO rows with
+`block_height <= height`; active inventory at `H` uses `(spent_at_height IS NULL OR
+spent_at_height > H)`. Recompute the latest per-height digests and active root before reporting
+readiness. Startup performs this same
+latest-state verification and also requires `ProcessedBlocks` to mirror the full marker chain.
+
+The commit row publishes only the registry and canonical UTXO inventory. Legacy raw trace,
+AMM/candle/storage, and auxiliary protocol tables are not covered by this v1 Marketplace
+commitment; consumers must not infer their completeness from this marker.


### PR DESCRIPTION
## Summary
- publish immutable per-height marketplace commitments with producer/schema revision pins, deterministic row commitments, inventory roots, and manifests
- serialize processing, atomically publish canonical state/progress, and atomically roll back reorg suffixes
- fail closed on malformed Core transaction lists, source transaction provenance, protostone decoding, trace events, registries, and numeric fields
- add DDL guards, startup full-history validation, documentation, and an exact-head hosted producer gate

## Verification
- cargo test -p alkanes-contract-indexer (Rust 1.86.0, protoc 29.3)
- cargo test -p alkanes-trace-transform --lib (Rust 1.86.0, protoc 29.3)
- cargo check -p alkanes-contract-indexer --bins (Rust 1.86.0, protoc 29.3)
- git diff --check
- credential filename/content scan: clean

## Boundary
No production deployment or server mutation was performed. The PostgreSQL DDL/trigger/reorg rehearsal still requires a disposable PostgreSQL instance; this workstation has no local PostgreSQL, psql, or Docker runtime.