### PR TITLE
fix(ci): cover alkanes-cli-common, and stop publishing twice per merge

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,17 +14,14 @@ on:
       - 'crates/alkanes-cli-common/**'
       - 'prod_wasms/**'
       - '.github/workflows/publish-npm.yml'
-  pull_request:
-    branches:
-      - develop
-    types:
-      - closed
-    paths:
-      - 'ts-sdk/**'
-      - 'crates/alkanes-web-sys/**'
-      - 'crates/alkanes-cli-common/**'
-      - 'prod_wasms/**'
-      - '.github/workflows/publish-npm.yml'
+  # NOTE: the `pull_request: [closed]` trigger that used to sit here was
+  # removed 2026-08-06. Every merge into develop fires BOTH `push: develop`
+  # and the closed-PR event, so each merge published TWICE. The build is not
+  # reproducible, so the two tarballs differ; `latest` then points at whichever
+  # job happened to finish last, and the dist-tag step is continue-on-error so
+  # the drift is silent. `push: develop` alone covers merges — a closed PR that
+  # merged IS a push to develop, and a closed PR that did NOT merge should
+  # never have published at all.
 
 env:
   NODE_VERSION: '20'
@@ -33,8 +30,10 @@ env:
 
 jobs:
   publish-npm:
-    # Only run on push events or when a PR is merged (not just closed)
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    # `push: develop` is now the only trigger, so the old
+    # `github.event_name == 'push' || (pull_request && merged)` guard is dead
+    # weight — its pull_request half can no longer be reached. Dropped rather
+    # than left to imply a trigger that isn't there.
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,13 @@ name: Rust
 
 on:
   push:
-    branches: ["main"]
+    # `develop` is the branch that SHIPS — publish-npm.yml publishes the
+    # @alkanes/ts-sdk from it — and until now it was also the branch nothing
+    # tested. main, which this workflow did cover, publishes nothing. Testing
+    # only the branch that doesn't ship is the wrong way round.
+    branches: ["main", "develop"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "develop"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -21,6 +25,15 @@ jobs:
             command: "cargo test -p protorune --features test-utils"
           - name: "Protorune Unit Tests"
             command: "cargo test -p protorune --target x86_64-unknown-linux-gnu"
+          # alkanes-cli-common was in NO matrix leg, despite being compiled
+          # INTO the published WASM (provider, coin selection, execute) — the
+          # crate every wallet consumer's transactions are built by. Nothing
+          # here ran a line of it: not its 284 tests, not even a type-check of
+          # its test cfg. That is why a `TweakedKeypair::to_keypair` compile
+          # error sat on main (bitcoin 0.32 renamed it `to_inner`) with three
+          # green checks above it.
+          - name: "Alkanes CLI Common Tests"
+            command: "cargo test -p alkanes-cli-common --lib --target x86_64-unknown-linux-gnu"
       fail-fast: false # Allows all tests to run even if one fails
 
     name: ${{ matrix.test-config.name }}


### PR DESCRIPTION
Follow-up to #292. That one made CI *run*; this one points it at the right things.

> ### ⚠️ Correction (2026-08-06) — scope reduced, read before merging
>
> An earlier version of this description claimed this PR fixes `develop`'s missing CI. **It does not, and cannot.** A workflow only takes effect from the branch it lives on, so a `main`-targeted edit to `rust.yml`'s triggers does nothing for pushes or PRs to `develop` until it reaches `develop`. flex caught this; the `branches: [main, develop]` change here is necessary but not sufficient, and a **fresh develop-cut branch** is the right mechanism. That work is separate and in flight.
>
> What this PR actually delivers is items 2 and 3 below. Item 1 is groundwork only.

## 1. `develop` added to the trigger list (groundwork — see correction above)

`rust.yml` was gated to `branches: [main]` while `publish-npm.yml` publishes `@alkanes/ts-sdk` from **`develop`** — the branch that ships was the branch nothing tested. This adds `develop` to both trigger lists so the workflow is correct *once it lives on that branch*.

## 2. `alkanes-cli-common` was in no matrix leg

It is compiled **into** the published WASM — provider, coin selection, `execute` — the crate every consumer's transactions are built by. No leg ran a line of it: not its 284 tests, not even a type-check of its test cfg.

That is the direct reason a `TweakedKeypair::to_keypair` compile error sat on `main` (bitcoin 0.32 renamed it `to_inner`) with three green checks above it, and the reason #291's green checks execute none of the code #291 changes.

New leg: `cargo test -p alkanes-cli-common --lib`.

## 3. Every merge published twice

`publish-npm.yml` fired on both `push: develop` and `pull_request: [closed]`. The build is not reproducible, so the two tarballs differ. `latest` resolves to whichever job finished last, and the dist-tag step is `continue-on-error`, so the drift is silent.

Removed the `pull_request` trigger: a closed PR that merged **is** a push to develop, and one that did not merge should never have published. The job's `github.event_name == 'push' || (pull_request && merged)` guard became unreachable and went with it.

## Expect `develop` to go red once CI reaches it

~739 commits ahead of `main`, never tested. Anything that surfaces is a standing finding this workflow could not previously report — not a regression from this PR.

## Not in scope

`publish-npm.yml` still has **no test gate** — it publishes without running the suite. Worth fixing; bundling it here would make the trigger change harder to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)