### PR TITLE
ci(publish): gate the npm publish on tests, and stop swallowing dist-tag failures

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,17 +14,13 @@ on:
       - 'crates/alkanes-cli-common/**'
       - 'prod_wasms/**'
       - '.github/workflows/publish-npm.yml'
-  pull_request:
-    branches:
-      - develop
-    types:
-      - closed
-    paths:
-      - 'ts-sdk/**'
-      - 'crates/alkanes-web-sys/**'
-      - 'crates/alkanes-cli-common/**'
-      - 'prod_wasms/**'
-      - '.github/workflows/publish-npm.yml'
+  # NOTE: there used to be a second `pull_request: [closed]` trigger here. It was
+  # NOT a fallback — merging a PR into develop IS a push to develop, so both
+  # triggers fired for the same commit and the job ran TWICE. Observed on commit
+  # 085e303: run 175 (push) and run 176 (pull_request) started 28s apart and both
+  # published. The wasm-pack/tsc build is not byte-reproducible, so the two runs
+  # produced DIFFERENT bytes under different version tags, and `latest` resolved
+  # to whichever `npm publish` happened to land second. Do not re-add it.
 
 env:
   NODE_VERSION: '20'
@@ -32,9 +28,42 @@ env:
   WASM_PACK_VERSION: '0.13.1'
 
 jobs:
+  # Publishing gate. alkanes-cli-common is compiled into the web-sys WASM that
+  # ships in this package, so a broken crate must not reach the registry: every
+  # published tag is immutable (#286) and cannot be taken back, only superseded.
+  test:
+    name: Test (publish gate)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: wasm32-unknown-unknown
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-gate-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-gate-
+      # --lib only: the integration targets under crates/alkanes-cli-common/tests/
+      # are bit-rotted and do not compile (see rust.yml for the same note).
+      - name: Test alkanes-cli-common
+        run: cargo test -p alkanes-cli-common --lib --target x86_64-unknown-linux-gnu
+
   publish-npm:
-    # Only run on push events or when a PR is merged (not just closed)
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    needs: test
+    # Belt-and-braces: `on.push.branches` already restricts this to develop.
+    if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -216,9 +245,12 @@ jobs:
           name: pkg-manifest-${{ steps.version.outputs.version }}
           path: pkg-manifests/*.json
 
+      # NOT continue-on-error. The dist-tag IS the thing consumers resolve; a
+      # silent failure here leaves `latest-dev` pointing at an older build while
+      # the run still reports success, which is exactly how the tag drifted away
+      # from the newest publish unnoticed. If tagging fails, the run must go red.
       - name: Tag as latest-dev
         working-directory: ts-sdk
-        continue-on-error: true
         run: |
           echo "Tagging as latest-dev..."
           npm dist-tag add @alkanes/ts-sdk@${{ steps.version.outputs.version }} latest-dev \

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,13 +14,17 @@ on:
       - 'crates/alkanes-cli-common/**'
       - 'prod_wasms/**'
       - '.github/workflows/publish-npm.yml'
-  # NOTE: there used to be a second `pull_request: [closed]` trigger here. It was
-  # NOT a fallback — merging a PR into develop IS a push to develop, so both
-  # triggers fired for the same commit and the job ran TWICE. Observed on commit
-  # 085e303: run 175 (push) and run 176 (pull_request) started 28s apart and both
-  # published. The wasm-pack/tsc build is not byte-reproducible, so the two runs
-  # produced DIFFERENT bytes under different version tags, and `latest` resolved
-  # to whichever `npm publish` happened to land second. Do not re-add it.
+  pull_request:
+    branches:
+      - develop
+    types:
+      - closed
+    paths:
+      - 'ts-sdk/**'
+      - 'crates/alkanes-web-sys/**'
+      - 'crates/alkanes-cli-common/**'
+      - 'prod_wasms/**'
+      - '.github/workflows/publish-npm.yml'
 
 env:
   NODE_VERSION: '20'
@@ -55,15 +59,19 @@ jobs:
           key: ${{ runner.os }}-cargo-gate-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-gate-
-      # --lib only: the integration targets under crates/alkanes-cli-common/tests/
-      # are bit-rotted and do not compile (see rust.yml for the same note).
+      # --lib only, deliberately: the integration targets under
+      # crates/alkanes-cli-common/tests/ have bit-rotted (struct fields added
+      # without updating callers, `alkanes::protorunes` items moved) and do not
+      # compile; half that directory is already parked as *.rs.bak. Un-rotting
+      # them is separate work. --lib still compiles src/mock_provider.rs and
+      # runs the crate's unit tests, which is what this gate needs.
       - name: Test alkanes-cli-common
         run: cargo test -p alkanes-cli-common --lib --target x86_64-unknown-linux-gnu
 
   publish-npm:
     needs: test
-    # Belt-and-braces: `on.push.branches` already restricts this to develop.
-    if: github.ref == 'refs/heads/develop'
+    # Only run on push events or when a PR is merged (not just closed)
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,14 +1,10 @@
 name: Rust
 
-# NOTE: `develop` is the branch that actually ships. `publish-npm.yml` builds and
-# publishes @alkanes/ts-sdk from `develop`, while `main` is hundreds of commits
-# behind. Until 2026-08-06 this workflow triggered on `main` only, so the branch
-# users install from was tested by nothing. Keep BOTH branches in these lists.
 on:
   push:
-    branches: ["main", "develop"]
+    branches: ["main"]
   pull_request:
-    branches: ["main", "develop"]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -25,20 +21,6 @@ jobs:
             command: "cargo test -p protorune --features test-utils"
           - name: "Protorune Unit Tests"
             command: "cargo test -p protorune --target x86_64-unknown-linux-gnu"
-          # alkanes-cli-common is compiled INTO the published @alkanes/ts-sdk
-          # web-sys WASM: it is the wallet, coin-selection and PSBT code the app
-          # depends on. Until 2026-08-06 no matrix leg built it at all, so a
-          # plain compile error could sit on a branch with three green checks.
-          #
-          # --lib ONLY, deliberately: the integration targets under
-          # crates/alkanes-cli-common/tests/ have bit-rotted (struct fields added
-          # without updating callers, `alkanes::protorunes` items moved) and do
-          # not compile. Half of that directory is already parked as *.rs.bak.
-          # Un-rotting them is tracked separately; gating on --lib now is what
-          # makes this leg green-on-arrival instead of permanently red, and it
-          # still covers src/mock_provider.rs and the 271 unit tests.
-          - name: "Alkanes CLI Common Unit Tests"
-            command: "cargo test -p alkanes-cli-common --lib --target x86_64-unknown-linux-gnu"
       fail-fast: false # Allows all tests to run even if one fails
 
     name: ${{ matrix.test-config.name }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,14 @@
 name: Rust
 
+# NOTE: `develop` is the branch that actually ships. `publish-npm.yml` builds and
+# publishes @alkanes/ts-sdk from `develop`, while `main` is hundreds of commits
+# behind. Until 2026-08-06 this workflow triggered on `main` only, so the branch
+# users install from was tested by nothing. Keep BOTH branches in these lists.
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "develop"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "develop"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -21,6 +25,20 @@ jobs:
             command: "cargo test -p protorune --features test-utils"
           - name: "Protorune Unit Tests"
             command: "cargo test -p protorune --target x86_64-unknown-linux-gnu"
+          # alkanes-cli-common is compiled INTO the published @alkanes/ts-sdk
+          # web-sys WASM: it is the wallet, coin-selection and PSBT code the app
+          # depends on. Until 2026-08-06 no matrix leg built it at all, so a
+          # plain compile error could sit on a branch with three green checks.
+          #
+          # --lib ONLY, deliberately: the integration targets under
+          # crates/alkanes-cli-common/tests/ have bit-rotted (struct fields added
+          # without updating callers, `alkanes::protorunes` items moved) and do
+          # not compile. Half of that directory is already parked as *.rs.bak.
+          # Un-rotting them is tracked separately; gating on --lib now is what
+          # makes this leg green-on-arrival instead of permanently red, and it
+          # still covers src/mock_provider.rs and the 271 unit tests.
+          - name: "Alkanes CLI Common Unit Tests"
+            command: "cargo test -p alkanes-cli-common --lib --target x86_64-unknown-linux-gnu"
       fail-fast: false # Allows all tests to run even if one fails
 
     name: ${{ matrix.test-config.name }}


### PR DESCRIPTION
**Scoped to complement #293, not compete with it.** This PR originally also carried the rust.yml matrix leg and the develop triggers; @0xcasuwu's #293 covers those, so I removed them here. What is left is the two items #293 deliberately leaves out.

The diff touches only `publish-npm.yml`, and only in hunks #293 does not: the trigger block and the `if:` line are untouched, so the two should merge cleanly in either order.

## 1. `needs: test` — gate the publish

`alkanes-cli-common` is compiled **into** the web-sys WASM this workflow publishes, so a crate that does not build must not reach the registry.

That matters more here than in ordinary CI because publishes are **immutable** (#286): a bad tag cannot be withdrawn, only superseded. A check that reports after `npm publish` is not a gate. So the test job sits upstream of it.

The gate runs `cargo test -p alkanes-cli-common --lib --target x86_64-unknown-linux-gnu` — the same command #293 adds to the matrix.

### Why `--lib`

The integration targets under `crates/alkanes-cli-common/tests/` have bit-rotted and do not compile: struct fields added without updating callers (`EnhancedExecuteParams`, `SendParams`, `ProtoruneOutpointResponse`), `alkanes::protorunes` items moved (`BalanceSheet`, `AlkaneId`, `Balances`), `MockProvider::set_protorunes_response` gone. About half that directory is already parked as `*.rs.bak`.

`--lib` still compiles `src/mock_provider.rs` and runs the crate's unit tests, which is what a publish gate needs. Restoring the integration tests and widening to `-p` is worth its own PR.

## 2. Drop `continue-on-error` from the dist-tag step

`latest-dev` is what consumers actually resolve. Swallowing a failure there leaves the tag pointing at an older build while the run still reports success — precisely how the tag drifts with nobody noticing.

The **Cloudflare purge keeps** its `continue-on-error`: it is genuinely best-effort and already handles its own errors internally.

## Not touched

GCP Workload-Identity auth and the Cloudflare purge step are unchanged.

## Verified locally

| tree | `cargo test -p alkanes-cli-common --lib --target x86_64-unknown-linux-gnu` |
|---|---|
| `develop` (this PR's base) | green — 271 passed |
| `main` | **red — does not compile** (`no method named to_keypair found for struct TweakedKeypair`) |
| #291 head | green — 284 passed |

That last row is the ordering constraint worth flagging on #293 — see my comment there.
