### PR TITLE
fix(rpc-core): two unauthenticated remote panics in the lua_* handler, plus unbounded multicall recursion

### DIFF
--- a/crates/alkanes-rpc-core/src/dispatch.rs
+++ b/crates/alkanes-rpc-core/src/dispatch.rs
@@ -1,6 +1,8 @@
+use std::cell::Cell;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
+use std::rc::Rc;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -9,6 +11,96 @@ use serde_json::{Value, json};
 use crate::backend::{BitcoinBackend, MetashrewBackend, EsploraBackend, OrdBackend};
 use crate::codec;
 use crate::types::*;
+
+// ---------------------------------------------------------------------------
+// Multicall recursion guard
+//
+// `handle_multicall` re-enters `dispatch` once per entry, and an entry may
+// itself be a `sandshrew_multicall`. Without a bound that is EXPONENTIAL
+// amplification on an UNAUTHENTICATED endpoint: nesting is limited only by
+// serde_json's 128-deep recursion ceiling, so one ~100KB request expands into
+// thousands of internal calls against rockshrew and electrs.
+//
+// Two independent bounds, because either alone is insufficient: a depth cap
+// alone still permits N^depth, and a total cap alone still lets a deep chain
+// burn the whole allowance on stack frames.
+// ---------------------------------------------------------------------------
+
+/// Maximum number of `sandshrew_multicall` frames that may be on the stack.
+///
+/// The SDK's multicall.lua (lua/multicall.lua) is a FLAT `ipairs` loop over
+/// `[method, params]` tuples — it never nests, so a legitimate multicall is
+/// depth 1. Depth 2 is allowed purely so a `lua_evalsaved(<multicall hash>)`
+/// envelope whose entries are themselves `sandshrew_multicall` keeps working.
+/// Exponential blow-up requires depth >= 3, which is refused.
+const MAX_MULTICALL_DEPTH: u32 = 2;
+
+/// Maximum sub-calls one top-level request may fan out through multicall,
+/// summed across every nesting level.
+///
+/// Real callers batch tens to low hundreds of entries (per-outpoint and
+/// per-alkane probes). 1024 leaves roughly an order of magnitude of headroom
+/// over the largest batch observed in production while making the worst case a
+/// FIXED, LINEAR 1024 backend calls per HTTP request rather than an unbounded
+/// exponential. Entries past the budget are not dropped silently — each gets
+/// an error entry, so the results array stays 1:1 with the request.
+const MAX_MULTICALL_SUBCALLS: u32 = 1024;
+
+/// Per-top-level-request recursion/fan-out allowance for multicall.
+///
+/// Minted fresh by every public `dispatch()` call, so concurrently dispatched
+/// requests (e.g. the entries of a JSON-RPC batch, which the edge polls
+/// together) can never share or steal each other's allowance — the failure
+/// mode a dispatcher-owned counter would have.
+#[derive(Clone)]
+struct CallBudget {
+    /// `sandshrew_multicall` frames already entered on this path.
+    depth: u32,
+    /// Sub-calls still available to the whole request tree.
+    remaining: Rc<Cell<u32>>,
+}
+
+impl CallBudget {
+    fn root() -> Self {
+        Self { depth: 0, remaining: Rc::new(Cell::new(MAX_MULTICALL_SUBCALLS)) }
+    }
+
+    /// Budget for the sub-requests of a multicall frame: one level deeper,
+    /// sharing the same remaining allowance.
+    fn child(&self) -> Self {
+        Self { depth: self.depth + 1, remaining: Rc::clone(&self.remaining) }
+    }
+
+    /// Reserve up to `n` sub-calls, returning how many were actually granted.
+    fn take(&self, n: usize) -> usize {
+        let available = self.remaining.get() as usize;
+        let granted = n.min(available);
+        self.remaining.set((available - granted) as u32);
+        granted
+    }
+}
+
+/// Percent-encode one path segment.
+///
+/// The esplora path is assembled from a caller-controlled method name and raw
+/// params, so an unencoded param such as `"../../whatever"` yields an
+/// arbitrary GET path against the in-cluster electrs. Everything outside the
+/// RFC 3986 unreserved set is escaped, which in particular escapes `/` — so a
+/// traversal payload collapses into a single inert segment. Every legitimate
+/// value here (addresses, txids, block hashes, heights) is unreserved already,
+/// so encoding is a no-op for real traffic.
+fn encode_path_segment(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    out
+}
 
 /// Core RPC dispatcher that routes JSON-RPC requests to the appropriate backend.
 ///
@@ -40,6 +132,19 @@ where
         &'a self,
         request: &'a JsonRpcRequest,
     ) -> Pin<Box<dyn Future<Output = Result<JsonRpcResponse>> + 'a>> {
+        // Every top-level entry mints its own multicall allowance.
+        self.dispatch_with_budget(request, CallBudget::root())
+    }
+
+    /// `dispatch` carrying the multicall recursion/fan-out budget. Internal
+    /// recursion that can reach `handle_multicall` goes through here so the
+    /// budget is threaded rather than reset; the public `dispatch` signature is
+    /// unchanged for consumers.
+    fn dispatch_with_budget<'a>(
+        &'a self,
+        request: &'a JsonRpcRequest,
+        budget: CallBudget,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonRpcResponse>> + 'a>> {
         Box::pin(async move {
             let method_parts: Vec<&str> = request.method.split('_').collect();
 
@@ -68,8 +173,8 @@ where
                 "esplora" => self.handle_esplora_method(&method_name, &request.params, &request.id).await,
                 "alkanes" => self.handle_alkanes_method(&method_name, &request.params, &request.id).await,
                 "metashrew" => self.metashrew.forward(request).await,
-                "sandshrew" => self.handle_sandshrew_method(&method_name, &request.params, &request.id).await,
-                "lua" => self.handle_lua_method(&method_name, &request.params, &request.id).await,
+                "sandshrew" => self.handle_sandshrew_method(&method_name, &request.params, &request.id, &budget).await,
+                "lua" => self.handle_lua_method(&method_name, &request.params, &request.id, &budget).await,
                 "btc" => self.handle_bitcoind_method(&method_name, &request.params, &request.id).await,
                 // Espo (OYL data API) — polyfill using alkanes indexer data
                 // essentials.get_address_outpoints → split by _ → ["essentials.get", "address", "outpoints"]
@@ -119,13 +224,18 @@ where
         let mut path = String::from("/");
         let mut param_index = 0;
 
+        // Params are interpolated as PATH SEGMENTS, so each one is
+        // percent-encoded (see `encode_path_segment`) — otherwise a param like
+        // "../../whatever" turns a caller-chosen esplora method into an
+        // arbitrary GET against the in-cluster electrs. The literal method
+        // parts are not encoded: they are the crate's own route template.
         for (i, part) in path_parts.iter().enumerate() {
             if part.is_empty() {
                 if param_index < params.len() {
                     if let Some(param_str) = params[param_index].as_str() {
-                        path.push_str(param_str);
+                        path.push_str(&encode_path_segment(param_str));
                     } else {
-                        path.push_str(&params[param_index].to_string());
+                        path.push_str(&encode_path_segment(&params[param_index].to_string()));
                     }
                     param_index += 1;
                 }
@@ -141,9 +251,9 @@ where
         while param_index < params.len() {
             path.push('/');
             if let Some(param_str) = params[param_index].as_str() {
-                path.push_str(param_str);
+                path.push_str(&encode_path_segment(param_str));
             } else {
-                path.push_str(&params[param_index].to_string());
+                path.push_str(&encode_path_segment(&params[param_index].to_string()));
             }
             param_index += 1;
         }
@@ -631,11 +741,12 @@ where
         method: &str,
         params: &[Value],
         request_id: &Value,
+        budget: &CallBudget,
     ) -> Result<JsonRpcResponse> {
         match method {
-            "multicall" => self.handle_multicall(params, request_id).await,
+            "multicall" => self.handle_multicall(params, request_id, budget).await,
             "balances" => self.handle_balances(params, request_id).await,
-            "evalscript" | "evalsaved" => self.handle_lua_method(method, params, request_id).await,
+            "evalscript" | "evalsaved" => self.handle_lua_method(method, params, request_id, budget).await,
             _ => Ok(JsonRpcResponse::error(
                 METHOD_NOT_FOUND,
                 format!("sandshrew method not supported in core: {}", method),
@@ -804,11 +915,19 @@ where
         method: &str,
         params: &[Value],
         request_id: &Value,
+        budget: &CallBudget,
     ) -> Result<JsonRpcResponse> {
         // params[0] = script hash (evalsaved) or script content (evalscript)
         // params[1..] = script arguments
+        //
+        // `JsonRpcRequest.params` is `#[serde(default)]` and its custom
+        // deserializer maps `null` to an empty Vec, so `"params":[]`,
+        // `"params":null` and a MISSING `params` member all arrive here as a
+        // zero-length slice. `&params[1..]` panics on that ("range start index
+        // 1 out of range for slice of length 0") — an unauthenticated remote
+        // panic. `get(1..)` yields None instead of trapping.
         let identifier = params.get(0).and_then(|v| v.as_str()).unwrap_or("");
-        let args = &params[1..];
+        let args = params.get(1..).unwrap_or(&[]);
 
         // Determine which script is being called
         let script_type = match method {
@@ -820,13 +939,22 @@ where
         match script_type.as_deref() {
             Some("balances") => self.lua_shim_balances(args, request_id).await,
             Some("spendable_utxos") => self.lua_shim_spendable_utxos(args, request_id).await,
-            Some("multicall") => self.lua_shim_multicall(args, request_id).await,
+            Some("multicall") => self.lua_shim_multicall(args, request_id, budget).await,
             Some("batch_utxo_balances") => self.lua_shim_batch_utxo_balances(args, request_id).await,
             _ => {
-                // Unknown script — return error so the SDK can fall back
+                // Unknown script — return error so the SDK can fall back.
+                //
+                // The identifier is caller-controlled and arbitrary UTF-8.
+                // `&identifier[..16]` slices by BYTE, so a multi-byte
+                // character straddling byte 16 panics ("byte index 16 is not a
+                // char boundary"). This is the ERROR path — it runs for every
+                // unrecognised script, i.e. the common case — so byte-slicing
+                // here was a remotely reachable panic on unauthenticated
+                // input. Truncate by CHARACTER instead.
+                let short: String = identifier.chars().take(16).collect();
                 Ok(JsonRpcResponse::error(
                     INTERNAL_ERROR,
-                    format!("Lua script not available (hash: {})", &identifier[..identifier.len().min(16)]),
+                    format!("Lua script not available (hash: {})", short),
                     request_id.clone(),
                 ))
             }
@@ -1117,10 +1245,14 @@ where
         &self,
         args: &[Value],
         request_id: &Value,
+        budget: &CallBudget,
     ) -> Result<JsonRpcResponse> {
-        // The multicall script expects args as a single array param
+        // The multicall script expects args as a single array param.
+        // The Lua envelope is the SAME logical multicall level as the
+        // sandshrew_multicall it shims, so the budget passes through
+        // unchanged — handle_multicall is what charges the frame.
         let calls = args.get(0).cloned().unwrap_or(Value::Array(vec![]));
-        let inner = self.handle_multicall(&[calls], request_id).await?;
+        let inner = self.handle_multicall(&[calls], request_id, budget).await?;
 
         match inner {
             JsonRpcResponse::Success { result, id, .. } => {
@@ -1138,7 +1270,22 @@ where
         &self,
         params: &[Value],
         request_id: &Value,
+        budget: &CallBudget,
     ) -> Result<JsonRpcResponse> {
+        // Recursion guard. A multicall entry may itself be a
+        // sandshrew_multicall; refuse once too many frames are stacked rather
+        // than let the fan-out compound. See MAX_MULTICALL_DEPTH.
+        if budget.depth >= MAX_MULTICALL_DEPTH {
+            return Ok(JsonRpcResponse::error(
+                INVALID_PARAMS,
+                format!(
+                    "multicall nesting too deep (limit {})",
+                    MAX_MULTICALL_DEPTH
+                ),
+                request_id.clone(),
+            ));
+        }
+
         if params.is_empty() {
             return Ok(JsonRpcResponse::error(
                 INVALID_PARAMS,
@@ -1191,14 +1338,22 @@ where
             });
         }
 
-        // Execute all requests in parallel
-        let futures: Vec<_> = requests.iter()
-            .map(|req| self.dispatch(req))
+        // Charge the shared per-request allowance BEFORE fanning out. Entries
+        // past the budget are answered with an error instead of being dropped,
+        // so the results array stays 1:1 with the request.
+        // See MAX_MULTICALL_SUBCALLS.
+        let granted = budget.take(requests.len());
+        let refused = requests.len() - granted;
+
+        // Execute all requests in parallel, one level deeper.
+        let child = budget.child();
+        let futures: Vec<_> = requests[..granted].iter()
+            .map(|req| self.dispatch_with_budget(req, child.clone()))
             .collect();
 
         let results = futures::future::join_all(futures).await;
 
-        let formatted: Vec<Value> = results.into_iter().map(|r| {
+        let mut formatted: Vec<Value> = results.into_iter().map(|r| {
             match r {
                 Ok(JsonRpcResponse::Success { result, .. }) => {
                     json!({ "result": result })
@@ -1216,6 +1371,18 @@ where
                 }
             }
         }).collect();
+
+        for _ in 0..refused {
+            formatted.push(json!({
+                "error": {
+                    "code": INVALID_PARAMS,
+                    "message": format!(
+                        "multicall sub-call budget exhausted (limit {} per request)",
+                        MAX_MULTICALL_SUBCALLS
+                    )
+                }
+            }));
+        }
 
         Ok(JsonRpcResponse::success(
             serde_json::to_value(formatted)?,

--- a/crates/alkanes-rpc-core/tests/dispatch_hardening.rs
+++ b/crates/alkanes-rpc-core/tests/dispatch_hardening.rs
@@ -1,0 +1,308 @@
+//! Regression tests for remotely-triggerable faults in `RpcDispatcher`.
+//!
+//! Every request built here is something an UNAUTHENTICATED client can post to
+//! the public JSON-RPC endpoint, so each of these panicking would be a remote
+//! DoS (in the wasip2 edge a panic is a wasm trap -> 5xx).
+
+use std::cell::RefCell;
+
+use alkanes_rpc_core::backend::{
+    BitcoinBackend, EsploraBackend, MetashrewBackend, NoOrd,
+};
+use alkanes_rpc_core::types::{JsonRpcRequest, JsonRpcResponse};
+use alkanes_rpc_core::RpcDispatcher;
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::executor::block_on;
+use serde_json::{json, Value};
+
+// ---------------------------------------------------------------------------
+// Mock backends — count invocations so fan-out can be asserted, and never
+// touch the network.
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct MockBitcoin {
+    calls: RefCell<usize>,
+}
+
+#[async_trait(?Send)]
+impl BitcoinBackend for MockBitcoin {
+    async fn call(&self, _method: &str, _params: Vec<Value>, id: Value) -> Result<JsonRpcResponse> {
+        *self.calls.borrow_mut() += 1;
+        Ok(JsonRpcResponse::success(json!(1), id))
+    }
+}
+
+#[derive(Default)]
+struct MockMetashrew;
+
+#[async_trait(?Send)]
+impl MetashrewBackend for MockMetashrew {
+    async fn forward(&self, request: &JsonRpcRequest) -> Result<JsonRpcResponse> {
+        Ok(JsonRpcResponse::success(json!(null), request.id.clone()))
+    }
+}
+
+#[derive(Default)]
+struct MockEsplora {
+    paths: RefCell<Vec<String>>,
+}
+
+#[async_trait(?Send)]
+impl EsploraBackend for MockEsplora {
+    async fn fetch(&self, path: &str) -> Result<Value> {
+        self.paths.borrow_mut().push(path.to_string());
+        Ok(json!([]))
+    }
+}
+
+type Dispatcher = RpcDispatcher<MockBitcoin, MockMetashrew, MockEsplora, NoOrd>;
+
+fn dispatcher() -> Dispatcher {
+    RpcDispatcher::new(
+        MockBitcoin::default(),
+        MockMetashrew,
+        MockEsplora::default(),
+        NoOrd,
+    )
+}
+
+fn req(method: &str, params: Vec<Value>) -> JsonRpcRequest {
+    JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        method: method.to_string(),
+        params,
+        id: json!(1),
+    }
+}
+
+fn error_message(resp: &JsonRpcResponse) -> Option<String> {
+    match resp {
+        JsonRpcResponse::Error { error, .. } => Some(error.message.clone()),
+        _ => None,
+    }
+}
+
+fn results(resp: &JsonRpcResponse) -> Vec<Value> {
+    match resp {
+        JsonRpcResponse::Success { result, .. } => {
+            result.as_array().cloned().expect("multicall returns an array")
+        }
+        JsonRpcResponse::Error { error, .. } => panic!("expected success, got {:?}", error),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bug 1 — empty `params` panicked on `&params[1..]`
+//
+//   {"jsonrpc":"2.0","id":1,"method":"lua_evalscript","params":[]}
+//     -> "range start index 1 out of range for slice of length 0"
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lua_methods_survive_empty_params() {
+    let d = dispatcher();
+    for method in [
+        "lua_evalscript",
+        "lua_evalsaved",
+        "sandshrew_evalscript",
+        "sandshrew_evalsaved",
+    ] {
+        // "params": []
+        let resp = block_on(d.dispatch(&req(method, vec![]))).expect("dispatch must not fail");
+        let msg = error_message(&resp)
+            .unwrap_or_else(|| panic!("{method} with empty params should be a JSON-RPC error"));
+        assert!(
+            msg.contains("Lua script not available"),
+            "{method}: unexpected message {msg}"
+        );
+    }
+}
+
+#[test]
+fn lua_methods_survive_missing_and_null_params() {
+    let d = dispatcher();
+    // `params` omitted entirely, and `"params": null` — both hit
+    // JsonRpcRequest's `#[serde(default)]` / null-to-empty deserializer and
+    // land in handle_lua_method with a zero-length slice.
+    for raw in [
+        r#"{"jsonrpc":"2.0","id":1,"method":"lua_evalsaved"}"#,
+        r#"{"jsonrpc":"2.0","id":1,"method":"lua_evalsaved","params":null}"#,
+        r#"{"jsonrpc":"2.0","id":1,"method":"sandshrew_evalscript","params":null}"#,
+    ] {
+        let request: JsonRpcRequest = serde_json::from_str(raw).expect("parses");
+        assert!(request.params.is_empty(), "precondition: {raw}");
+        let resp = block_on(d.dispatch(&request)).expect("dispatch must not fail");
+        assert!(
+            error_message(&resp).is_some(),
+            "{raw} should be a JSON-RPC error, not a panic"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bug 2 — byte-slicing the caller-controlled identifier on the ERROR path
+//
+//   &identifier[..identifier.len().min(16)]
+//     -> "byte index 16 is not a char boundary"
+//
+// Fires for ANY unrecognised script, i.e. the normal outcome.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_script_identifier_with_multibyte_char_across_byte_16() {
+    // 15 ASCII bytes, then a 4-byte U+1F600 occupying bytes 15..19 — so byte
+    // index 16 lands strictly INSIDE the character.
+    let identifier = "aaaaaaaaaaaaaaa\u{1F600}zzz";
+    assert_eq!(identifier.as_bytes().len(), 15 + 4 + 3);
+    assert!(
+        !identifier.is_char_boundary(16),
+        "precondition: byte 16 must not be a char boundary"
+    );
+
+    let d = dispatcher();
+    for method in ["lua_evalsaved", "lua_evalscript", "sandshrew_evalsaved"] {
+        let resp = block_on(d.dispatch(&req(method, vec![json!(identifier)])))
+            .expect("dispatch must not fail");
+        let msg = error_message(&resp).unwrap_or_else(|| panic!("{method} should error"));
+        assert!(
+            msg.contains("Lua script not available"),
+            "{method}: unexpected message {msg}"
+        );
+        // Truncated by CHARACTER: 16 chars, the emoji intact.
+        assert!(
+            msg.contains("aaaaaaaaaaaaaaa\u{1F600}"),
+            "{method}: identifier should be char-truncated, got {msg}"
+        );
+        assert!(!msg.contains('z'), "{method}: should stop at 16 chars, got {msg}");
+    }
+}
+
+#[test]
+fn unknown_script_identifier_multibyte_at_every_offset() {
+    // Sweep the emoji across the truncation point so no off-by-one survives.
+    let d = dispatcher();
+    for pad in 10..24 {
+        let identifier = format!("{}\u{1F600}tail", "a".repeat(pad));
+        let resp = block_on(d.dispatch(&req("lua_evalsaved", vec![json!(identifier)])))
+            .expect("dispatch must not fail");
+        assert!(
+            error_message(&resp).is_some(),
+            "pad={pad} should error, not panic"
+        );
+    }
+}
+
+#[test]
+fn non_string_and_empty_identifiers_are_tolerated() {
+    let d = dispatcher();
+    for params in [
+        vec![json!(null)],
+        vec![json!(42)],
+        vec![json!("")],
+        vec![json!({"not": "a string"})],
+    ] {
+        let resp =
+            block_on(d.dispatch(&req("lua_evalsaved", params.clone()))).expect("dispatch must not fail");
+        assert!(error_message(&resp).is_some(), "{params:?} should error");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bug 3 — unbounded multicall recursion / fan-out
+// ---------------------------------------------------------------------------
+
+#[test]
+fn flat_multicall_still_works() {
+    // A legitimate multicall is the SDK's flat list of [method, params]
+    // tuples (lua/multicall.lua). It must be entirely unaffected.
+    let d = dispatcher();
+    let calls: Vec<Value> = (0..50).map(|_| json!(["btc_getblockcount", []])).collect();
+    let resp = block_on(d.dispatch(&req("sandshrew_multicall", calls))).expect("dispatch");
+    let out = results(&resp);
+    assert_eq!(out.len(), 50);
+    assert!(out.iter().all(|r| r.get("result").is_some()), "{out:?}");
+    assert_eq!(*d.bitcoin.calls.borrow(), 50);
+}
+
+#[test]
+fn nested_multicall_is_depth_limited() {
+    let d = dispatcher();
+    // multicall( multicall( multicall( btc_getblockcount ) ) )
+    let inner = json!(["sandshrew_multicall", [["btc_getblockcount", []]]]);
+    let mid = json!(["sandshrew_multicall", [inner]]);
+    let resp = block_on(d.dispatch(&req("sandshrew_multicall", vec![mid]))).expect("dispatch");
+
+    let rendered = serde_json::to_string(&resp).unwrap();
+    assert!(
+        rendered.contains("multicall nesting too deep"),
+        "expected a depth refusal, got {rendered}"
+    );
+    // The third level never ran, so the leaf backend was never reached.
+    assert_eq!(
+        *d.bitcoin.calls.borrow(),
+        0,
+        "leaf call should have been cut off by the depth guard"
+    );
+}
+
+#[test]
+fn multicall_fanout_is_budget_capped() {
+    let d = dispatcher();
+    let calls: Vec<Value> = (0..1200).map(|_| json!(["btc_getblockcount", []])).collect();
+    let resp = block_on(d.dispatch(&req("sandshrew_multicall", calls))).expect("dispatch");
+    let out = results(&resp);
+
+    // Response stays 1:1 with the request…
+    assert_eq!(out.len(), 1200);
+    // …but only the budgeted prefix actually reached a backend.
+    assert_eq!(*d.bitcoin.calls.borrow(), 1024);
+    let refused = out
+        .iter()
+        .filter(|r| {
+            r.get("error")
+                .and_then(|e| e.get("message"))
+                .and_then(|m| m.as_str())
+                .map(|m| m.contains("sub-call budget exhausted"))
+                .unwrap_or(false)
+        })
+        .count();
+    assert_eq!(refused, 1200 - 1024);
+}
+
+#[test]
+fn each_top_level_request_gets_a_fresh_budget() {
+    // The budget is per-dispatch, so back-to-back (or concurrently polled)
+    // requests must not starve each other.
+    let d = dispatcher();
+    let calls: Vec<Value> = (0..600).map(|_| json!(["btc_getblockcount", []])).collect();
+    for _ in 0..3 {
+        let resp = block_on(d.dispatch(&req("sandshrew_multicall", calls.clone()))).expect("dispatch");
+        let out = results(&resp);
+        assert!(out.iter().all(|r| r.get("result").is_some()), "budget leaked across requests");
+    }
+    assert_eq!(*d.bitcoin.calls.borrow(), 1800);
+}
+
+// ---------------------------------------------------------------------------
+// Esplora path assembly — params are path segments and must be encoded.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn esplora_params_are_percent_encoded() {
+    let d = dispatcher();
+    let _ = block_on(d.dispatch(&req("esplora_foo", vec![json!("../../whatever")]))).expect("dispatch");
+    let paths = d.esplora.paths.borrow();
+    assert_eq!(paths.len(), 1);
+    assert_eq!(paths[0], "/foo/..%2F..%2Fwhatever");
+    assert!(!paths[0].contains("../"), "traversal survived: {}", paths[0]);
+}
+
+#[test]
+fn esplora_normal_params_are_unchanged() {
+    let d = dispatcher();
+    let addr = "bc1pk6nvyxrxmryqsuahhhpal5hkjy4kx6cjmzchqu9xrfhhqfr8dv2skgpwvj";
+    let _ = block_on(d.dispatch(&req("esplora_address::utxo", vec![json!(addr)]))).expect("dispatch");
+    assert_eq!(d.esplora.paths.borrow()[0], format!("/address/{addr}/utxo"));
+}


### PR DESCRIPTION
Three faults in `alkanes-rpc-core`'s dispatcher that an **anonymous** POST to the public JSON-RPC endpoint can trigger. In the wasip2 tlsd edge a Rust panic is a wasm trap, so the first two are a remote 5xx on demand. All three are live on mainnet today via the edge's git-rev pin (`d33c58fe`).

Public API is unchanged — `dispatch` keeps its signature; budget threading is a private `dispatch_with_budget`.

## 1. HIGH — empty `params` panics on `&params[1..]`

`JsonRpcRequest.params` is `#[serde(default)]`, so `"params":[]`, `"params":null`, **and a missing `params` member** all arrive at `handle_lua_method` as a zero-length slice. The `params.get(0)` on the line above is defensive; the next line is not.

**Trigger** (nothing else required — no auth, no valid script):
```json
{"jsonrpc":"2.0","id":1,"method":"lua_evalscript","params":[]}
```
```
range start index 1 out of range for slice of length 0
```

Reachable via `lua_evalscript`, `lua_evalsaved`, `sandshrew_evalscript`, `sandshrew_evalsaved`.

**Fix:** `params.get(1..).unwrap_or(&[])`.

## 2. HIGH — byte-slicing a caller-controlled `&str` on the error path

```rust
format!("Lua script not available (hash: {})", &identifier[..identifier.len().min(16)])
```

`identifier` is arbitrary caller-supplied UTF-8 and the slice is by **byte**, so any multi-byte character straddling byte 16 panics.

**Trigger:**
```json
{"jsonrpc":"2.0","id":1,"method":"lua_evalsaved","params":["aaaaaaaaaaaaaaa😀zzz"]}
```
```
byte index 16 is not a char boundary; it is inside '😀' (bytes 15..19)
```

This is **more dangerous than #1**: it is the *unknown script* branch, i.e. the path taken for every identifier the shim does not recognise — the normal outcome, not an edge case.

**Fix:** truncate by character — `identifier.chars().take(16).collect::<String>()`.

## 3. MEDIUM — unbounded multicall recursion / fan-out

`handle_multicall` re-entered `dispatch` once per entry with **no depth or fan-out limit**, and an entry may itself be a `sandshrew_multicall`. Nesting was bounded only by serde_json's 128-deep recursion ceiling, so one ~100KB unauthenticated request expands into thousands of internal calls against rockshrew and electrs.

Fixed with a per-top-level-request `CallBudget` carrying **two** bounds — either alone is insufficient, since a depth cap still permits `N^depth` and a total cap alone still lets a deep chain burn the whole allowance on stack frames:

- **`MAX_MULTICALL_DEPTH = 2`.** The SDK's `multicall.lua` is a flat `ipairs` loop over `[method, params]` tuples and never nests, so a legitimate multicall is depth 1. Depth 2 exists only so a `lua_evalsaved(<multicall hash>)` envelope whose entries are themselves multicalls keeps working. Exponential blow-up requires depth ≥ 3, which is refused.
- **`MAX_MULTICALL_SUBCALLS = 1024`**, shared across every nesting level. Real callers batch tens to low hundreds of entries (per-outpoint and per-alkane probes), so this leaves roughly an order of magnitude of headroom while making the worst case a **fixed, linear** 1024 backend calls per HTTP request instead of an unbounded exponential.

Over-budget entries are answered with an error entry rather than dropped, so the results array stays 1:1 with the request. The budget is minted fresh by each public `dispatch()` call, so concurrently polled JSON-RPC batch entries cannot steal each other's allowance.

## Also — esplora path params are now percent-encoded

The esplora path was assembled from the caller-chosen method name and raw params with no encoding, so `{"method":"esplora_foo","params":["../../whatever"]}` produced an arbitrary GET path against the in-cluster electrs. Read-only and low value to an attacker, but the encoding is a few lines and collapses a traversal payload into a single inert segment. Every legitimate value (addresses, txids, block hashes, heights) is already RFC 3986 unreserved, so this is a no-op for real traffic.

## Tests

New `crates/alkanes-rpc-core/tests/dispatch_hardening.rs` — 11 tests over mock backends that count invocations and never touch the network. Bug 2's test sweeps the emoji across the truncation point (pad 10..24) so no off-by-one survives, and `flat_multicall_still_works` pins that an ordinary 50-entry flat multicall is untouched.

**Before the fix** — the two panics reproduce with the exact messages, and the guards are absent:
```
---- lua_methods_survive_empty_params stdout ----
thread 'lua_methods_survive_empty_params' panicked at crates/alkanes-rpc-core/src/dispatch.rs:811:27:
range start index 1 out of range for slice of length 0

---- unknown_script_identifier_with_multibyte_char_across_byte_16 stdout ----
thread '...' panicked at crates/alkanes-rpc-core/src/dispatch.rs:829:79:
byte index 16 is not a char boundary; it is inside '😀' (bytes 15..19) of `aaaaaaaaaaaaaaa😀zzz`

---- nested_multicall_is_depth_limited stdout ----
expected a depth refusal, got {"jsonrpc":"2.0","result":[{"result":[{"result":[{"result":1}]}]}],"id":1}

---- multicall_fanout_is_budget_capped stdout ----
assertion `left == right` failed
  left: 1200
 right: 1024

test result: FAILED. 4 passed; 7 failed
```

**After:**
```
running 11 tests
test esplora_normal_params_are_unchanged ... ok
test esplora_params_are_percent_encoded ... ok
test lua_methods_survive_empty_params ... ok
test lua_methods_survive_missing_and_null_params ... ok
test non_string_and_empty_identifiers_are_tolerated ... ok
test nested_multicall_is_depth_limited ... ok
test unknown_script_identifier_multibyte_at_every_offset ... ok
test flat_multicall_still_works ... ok
test unknown_script_identifier_with_multibyte_char_across_byte_16 ... ok
test multicall_fanout_is_budget_capped ... ok
test each_top_level_request_gets_a_fresh_budget ... ok

test result: ok. 11 passed; 0 failed
```
`cargo build -p alkanes-rpc-core` is green; the 9 pre-existing `types::tests` still pass. The two remaining lib warnings (`unused variable: params`, `dead_code: reverse_txid`) are pre-existing and untouched.

## Follow-up (not in this PR)

After merge, the tlsd edge pin at `subvh/tlsd-apps/alkanes-jsonrpc/Cargo.toml:23` needs bumping to the merge commit to actually ship this.
