### PR TITLE
fix(ci): run CI on develop — the branch that ships the SDK (port of #293)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,17 +14,14 @@ on:
       - 'crates/alkanes-cli-common/**'
       - 'prod_wasms/**'
       - '.github/workflows/publish-npm.yml'
-  pull_request:
-    branches:
-      - develop
-    types:
-      - closed
-    paths:
-      - 'ts-sdk/**'
-      - 'crates/alkanes-web-sys/**'
-      - 'crates/alkanes-cli-common/**'
-      - 'prod_wasms/**'
-      - '.github/workflows/publish-npm.yml'
+  # NOTE: the `pull_request: [closed]` trigger that used to sit here was
+  # removed 2026-08-06. Every merge into develop fires BOTH `push: develop`
+  # and the closed-PR event, so each merge published TWICE. The build is not
+  # reproducible, so the two tarballs differ; `latest` then points at whichever
+  # job happened to finish last, and the dist-tag step is continue-on-error so
+  # the drift is silent. `push: develop` alone covers merges — a closed PR that
+  # merged IS a push to develop, and a closed PR that did NOT merge should
+  # never have published at all.
 
 env:
   NODE_VERSION: '20'
@@ -33,8 +30,10 @@ env:
 
 jobs:
   publish-npm:
-    # Only run on push events or when a PR is merged (not just closed)
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    # `push: develop` is now the only trigger, so the old
+    # `github.event_name == 'push' || (pull_request && merged)` guard is dead
+    # weight — its pull_request half can no longer be reached. Dropped rather
+    # than left to imply a trigger that isn't there.
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,13 @@ name: Rust
 
 on:
   push:
-    branches: ["main"]
+    # `develop` is the branch that SHIPS — publish-npm.yml publishes the
+    # @alkanes/ts-sdk from it — and until now it was also the branch nothing
+    # tested. main, which this workflow did cover, publishes nothing. Testing
+    # only the branch that doesn't ship is the wrong way round.
+    branches: ["main", "develop"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "develop"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -21,6 +25,25 @@ jobs:
             command: "cargo test -p protorune --features test-utils"
           - name: "Protorune Unit Tests"
             command: "cargo test -p protorune --target x86_64-unknown-linux-gnu"
+          # alkanes-cli-common was in NO matrix leg, despite being compiled
+          # INTO the published WASM (provider, coin selection, execute) — the
+          # crate every wallet consumer's transactions are built by. Nothing
+          # here ran a line of it: not its unit tests, not even a type-check of
+          # its test cfg. That is why a `TweakedKeypair::to_keypair` compile
+          # error sat on main (bitcoin 0.32 renamed it `to_inner`) with three
+          # green checks above it.
+          #
+          # `--lib` is deliberate, not laziness: the integration targets under
+          # crates/alkanes-cli-common/tests/ have bit-rotted on develop and do
+          # not compile (25 errors — `EnhancedExecuteParams` gained
+          # `alkanes_change_address` / `excluded_utxos` /
+          # `known_pending_tx_hexes` and `SendParams` gained `mempool_indexer` /
+          # `ordinals_strategy` without their callers being updated). Un-rotting
+          # them is separate work; `--lib` still compiles src/mock_provider.rs
+          # and runs the crate's unit tests, which is the coverage that matters
+          # for what ships.
+          - name: "Alkanes CLI Common Tests"
+            command: "cargo test -p alkanes-cli-common --lib --target x86_64-unknown-linux-gnu"
       fail-fast: false # Allows all tests to run even if one fails
 
     name: ${{ matrix.test-config.name }}
@@ -32,7 +55,30 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+      # `--locked` is load-bearing, do not drop it.
+      #
+      # Without it `cargo install` re-resolves wasm-bindgen-cli's dependency
+      # tree from scratch against the registry as it exists TODAY, ignoring the
+      # Cargo.lock the crate publishes. Any transitive dep that raises its MSRV
+      # after release then breaks the build retroactively — this workflow was
+      # green on 2026-07-18 and failed on EVERY run from 2026-07-19 onward:
+      #
+      #   error: failed to compile `wasm-bindgen-cli v0.2.100`
+      #   Caused by:
+      #     rustc 1.86.0 is not supported by the following packages:
+      #       time@0.3.55 requires rustc 1.88.0
+      #       time-core@0.1.9 requires rustc 1.88.0
+      #
+      # rustc 1.86.0 comes from rust-toolchain.toml, which overrides the
+      # @stable action for every cargo invocation in this repo. wasm-bindgen-cli
+      # 0.2.100's own lockfile pins time 0.3.37 / time-core 0.1.2 (MSRV 1.67.1),
+      # so `--locked` both fixes this and makes the install reproducible.
+      #
+      # The 0.2.100 version pin is separately load-bearing: the wasm-bindgen
+      # runtime in this workspace must match the CLI that post-processes the
+      # module, so bumping the toolchain instead of locking the install is NOT
+      # an equivalent fix.
       - name: Install test runner
-        run: cargo install wasm-bindgen-cli --version 0.2.100
+        run: cargo install wasm-bindgen-cli --version 0.2.100 --locked
       - name: ${{ matrix.test-config.name }}
         run: ${{ matrix.test-config.command }}


### PR DESCRIPTION
Port of **@0xcasuwu**'s #293 to the branch where it actually takes effect. The change is his; this PR only moves it onto `develop`. Credit to him for finding it.

## Why this exists separately from #293

A workflow only governs the branch it lives on. #293 targets `main`, so merging it gives `main` the new coverage and gives `develop` nothing — and `develop` is the branch that matters here:

- `develop` is what `publish-npm.yml` publishes `@alkanes/ts-sdk` from.
- `develop` had **no CI at all** — `rust.yml` triggered only on `branches: ["main"]`. 739 commits have shipped from it untested.
- `main`, the branch `rust.yml` did cover, publishes nothing.

The branch that ships was the branch nothing tested. #293 should still merge to `main` on its own merits; this is the develop-side half.

## What this does

1. **`rust.yml` runs on `develop`** — `push` and `pull_request` both become `["main", "develop"]`.
2. **New `Alkanes CLI Common Tests` matrix leg.** `alkanes-cli-common` was in no leg at all, despite being compiled *into* the published WASM — it is the crate every consumer's transactions are actually built by. Nothing ran a line of it.
3. **`publish-npm.yml`'s `pull_request: [closed]` trigger removed.** Every merge into `develop` fired *both* `push: develop` and the closed-PR event, so **each merge published twice** under two different `0.1.6-<sha>.<run>` tags. The build is not reproducible, so the two tarballs differ; `latest-dev` then pointed at whichever job finished last, and the dist-tag step is `continue-on-error`, so the drift was silent. `push: develop` alone covers merges — a closed PR that merged *is* a push to develop, and one that did **not** merge should never have published at all.
4. **The now-unreachable `if:` guard dropped** with it, rather than left behind implying a trigger that no longer exists.

## `--lib` is deliberate

The leg runs `cargo test -p alkanes-cli-common --lib --target x86_64-unknown-linux-gnu`.

Without `--lib`, the integration targets under `crates/alkanes-cli-common/tests/` fail to compile on `develop` — 25 errors, all callers that were never updated when struct fields were added:

- `EnhancedExecuteParams` gained `alkanes_change_address`, `excluded_utxos`, `known_pending_tx_hexes`
- `SendParams` gained `mempool_indexer`, `ordinals_strategy`

That bit-rot is pre-existing and is separate work. `--lib` still compiles `src/mock_provider.rs` and runs the crate's unit tests, which is the coverage that matters for what ships.

**Verified locally on `develop` (`733393c`), same command CI will run:**

```
test result: ok. 271 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.67s
```

## One addition beyond #293: `--locked`

This also carries #292's `cargo install wasm-bindgen-cli --version 0.2.100 --locked` across from `main`. `develop`'s copy of `rust.yml` predates that fix.

This is not scope creep — without it the *install step itself* fails on every run, because `cargo install` re-resolves against the registry as it exists today and pulls `time@0.3.55` (MSRV 1.88) against this repo's `rust-toolchain.toml` pin of 1.86:

```
error: failed to compile `wasm-bindgen-cli v0.2.100`
Caused by:
  rustc 1.86.0 is not supported by the following packages:
    time@0.3.55 requires rustc 1.88.0
```

All four legs would die before running a single test, and "develop has CI" would be true only nominally. #296 ports the same fix; I verified by trial merge that the two resolve to a single copy with no conflict, and #296 stays `MERGEABLE`/`CLEAN`.

## Expect develop to go red

As @0xcasuwu warned on #293: turning CI on over 739 previously-untested commits will surface standing failures. Those are findings, not regressions from this PR, and the fix is to triage them — not to switch the CI back off.

## Note for reviewers: do **not** port #291's `to_keypair` → `to_inner` here

`main` and `develop` genuinely need different source at `mock_provider.rs:466`. They resolve different `bitcoin` patch versions:

| branch | `bitcoin` in `Cargo.lock` | correct call |
|---|---|---|
| `main` | 0.32.5 | `to_inner()` |
| `develop` | 0.32.7 | `to_keypair()` |

`develop` compiles clean as-is (271 passing, above). Applying #291's rename here would *break* it.

---

Co-authored-by: casuwu &lt;0xcasuwu&gt; — original change #293.
