### PR TITLE
fix(cpfp): child must out-bid its parent, and the parent must relay standalone

### DIFF
--- a/crates/alkanes-cli-common/src/alkanes/execute.rs
+++ b/crates/alkanes-cli-common/src/alkanes/execute.rs
@@ -51,6 +51,42 @@ const DUST_LIMIT: u64 = 546;
 /// must never be built below this floor.
 const MIN_RELAY_FEE_RATE: f32 = 1.0;
 
+/// Fee-rate floor, in sat/vB, for the **parent** of a split-tx CPFP package
+/// (Tx A, the wrap).
+///
+/// Tx A is a *structural* CPFP parent — Tx B has to spend its carrier output,
+/// so the pair exists by construction and is not a stuck-tx rescue. CPFP fixes
+/// a transaction's mining PRIORITY, never its RELAY: every node drops anything
+/// below its own `-minrelaytxfee` (1 sat/vB by default), so a sub-1-sat/vB
+/// parent simply never reaches most miners' mempools and a high-fee child
+/// cannot rescue a transaction they never received (1p1c package relay is not
+/// universally deployed). The parent must therefore clear min-relay
+/// STANDALONE.
+///
+/// 1.25 = the 1 sat/vB Core default plus ~25% margin, so the parent also
+/// clears stricter-than-default node policies and absorbs vsize-estimate
+/// drift. Ported from `CPFP_PARENT_MIN_FEE_RATE` in subfrost-app
+/// (`hooks/useEphemeralWrapPackage.ts`), where a 0.151 sat/vB parent
+/// (mainnet 81396b59…e7960cae, 2026-06-26) sat unconfirmed indefinitely
+/// while its child was fine.
+///
+/// NOTE: static floor — it does not track a rising `mempoolminfee` under
+/// congestion. A `max(1.25, live mempoolminfee)` floor would.
+const CPFP_PARENT_MIN_FEE_RATE: f32 = 1.25;
+
+/// The rate the split-tx CPFP **parent** (Tx A) must actually be built at.
+///
+/// The user's requested rate drives the *package*; the parent additionally has
+/// to relay on its own, hence the floor. Anything at or above the floor is
+/// passed through unchanged.
+fn parent_fee_rate_for_package(target_rate: f32) -> f32 {
+    if target_rate.is_finite() {
+        target_rate.max(CPFP_PARENT_MIN_FEE_RATE)
+    } else {
+        CPFP_PARENT_MIN_FEE_RATE
+    }
+}
+
 /// Compute the fee rate the CPFP **child** (Tx B) must pay so that the whole
 /// parent+child *package* clears the user's target fee rate, then floor the
 /// result at the network min-relay rate.
@@ -68,6 +104,33 @@ const MIN_RELAY_FEE_RATE: f32 = 1.0;
 /// makes up the difference. The result is floored at `MIN_RELAY_FEE_RATE` so
 /// the child is always individually relayable even if its parent confirms
 /// first and the child is briefly evaluated on its own.
+///
+/// # The child-inversion guard
+///
+/// The package can never be targeted BELOW what the parent already pays. Since
+/// the parent is floored at [`CPFP_PARENT_MIN_FEE_RATE`] independently of the
+/// user's `target_rate`, a user rate at or under that floor makes the naive
+/// shortfall `target_rate * package_vsize - parent_fee` go negative; the child
+/// then collapses to `target_rate` — a rate BELOW its own parent's. Observed
+/// on mainnet (subfrost-app, tx cd6ec685…154d981f, 2026-06-30):
+///
+/// ```text
+///   parent 5841c419…4282b6 : fee 975,  vsize 776  -> 1.256 sat/vB
+///   child  cd6ec685…d981f  : fee 117,  vsize ~316 -> 0.370 sat/vB  <- INVERTED
+///   package                : fee 1092, vsize 1092 -> 1.000 sat/vB
+/// ```
+///
+/// A CPFP child that under-bids its parent drags the package's effective rate
+/// DOWN — the package is then worth less to a miner than the parent alone, so
+/// the whole construction is pointless. Targeting
+/// `effective_rate = max(target_rate, parent_rate)` makes the shortfall always
+/// at least `effective_rate * child_vsize`, which pins the invariant
+///
+/// ```text
+///   child_rate >= package_rate >= parent_rate
+/// ```
+///
+/// at every requested rate.
 fn child_fee_rate_for_package(
     target_rate: f32,
     parent_fee: u64,
@@ -75,14 +138,24 @@ fn child_fee_rate_for_package(
     child_vsize: u64,
 ) -> f32 {
     let child_vsize = child_vsize.max(1) as f32;
+    // The parent's REALIZED rate. It is a published, already-paid cost the
+    // package inherits — the package target can never sit below it.
+    let parent_rate = if parent_vsize == 0 {
+        target_rate
+    } else {
+        parent_fee as f32 / parent_vsize as f32
+    };
+    let effective_rate = target_rate.max(parent_rate);
     let package_vsize = parent_vsize as f32 + child_vsize;
-    let required_package_fee = target_rate * package_vsize;
+    let required_package_fee = effective_rate * package_vsize;
     // What the child must contribute on top of the parent's actual fee.
+    // Because `effective_rate >= parent_rate`, this is always at least
+    // `effective_rate * child_vsize` — never negative, never inverted.
     let required_child_fee = (required_package_fee - parent_fee as f32).max(0.0);
     let child_rate = required_child_fee / child_vsize;
-    // Never below min-relay, and never below the user's own target either —
-    // a CPFP child should at minimum pay the target rate for itself.
-    child_rate.max(target_rate).max(MIN_RELAY_FEE_RATE)
+    // Never below min-relay, and never below the effective package rate
+    // either, so estimator drift cannot let the child slip under the target.
+    child_rate.max(effective_rate).max(MIN_RELAY_FEE_RATE)
 }
 
 /// frBTC, frZEC, frETH and any other cross-chain wrap target lives at block 32
@@ -777,8 +850,21 @@ impl<'a> EnhancedAlkanesExecutor<'a> {
         }
 
         // ---- Tx A: wrap-only ----------------------------------------------
+        // Resolve the user's package target BEFORE building Tx A: the parent
+        // has to relay standalone, so it is built at the floored parent rate
+        // (see parent_fee_rate_for_package), not at the raw package target.
+        let target_rate = self.resolve_fee_rate(params.fee_rate).await?;
+        let parent_rate = parent_fee_rate_for_package(target_rate);
+        if parent_rate > target_rate {
+            log::info!(
+                "[split-tx] parent fee rate floored at {:.3} sat/vB (requested {:.3}) — a sub-min-relay parent never reaches miners",
+                parent_rate, target_rate
+            );
+        }
+
         let mut tx_a_params = params.clone();
         tx_a_params.split_transactions = false;
+        tx_a_params.fee_rate = Some(parent_rate);
 
         // The wrap protostone's pointer typically targets p1 (forward to the
         // next protostone in the original atomic flow). In split mode we
@@ -821,7 +907,6 @@ impl<'a> EnhancedAlkanesExecutor<'a> {
         // clears the target rate, floored at min-relay — see
         // child_fee_rate_for_package. Decode Tx A from its broadcast hex to get
         // the parent's true vsize; fall back to an estimate if hex is missing.
-        let target_rate = self.resolve_fee_rate(params.fee_rate).await?;
         let parent_vsize = tx_a_result
             .reveal_tx_hex
             .as_ref()
@@ -928,8 +1013,20 @@ impl<'a> EnhancedAlkanesExecutor<'a> {
             ));
         }
 
+        // Same parent floor as execute_split: Tx A must clear min-relay on its
+        // own or the child can never rescue it. See parent_fee_rate_for_package.
+        let target_rate = self.resolve_fee_rate(params.fee_rate).await?;
+        let parent_rate = parent_fee_rate_for_package(target_rate);
+        if parent_rate > target_rate {
+            log::info!(
+                "[split-tx:psbt] parent fee rate floored at {:.3} sat/vB (requested {:.3}) — a sub-min-relay parent never reaches miners",
+                parent_rate, target_rate
+            );
+        }
+
         let mut tx_a_params = params.clone();
         tx_a_params.split_transactions = false;
+        tx_a_params.fee_rate = Some(parent_rate);
 
         let mut wrap_proto = params.protostones[0].clone();
         wrap_proto.pointer = Some(OutputTarget::Output(1));
@@ -961,7 +1058,6 @@ impl<'a> EnhancedAlkanesExecutor<'a> {
         // rate so it pays for both itself and any parent shortfall.
         let parent_vsize = tx_a_state.psbt.unsigned_tx.vsize() as u64;
         let parent_fee = tx_a_state.fee;
-        let target_rate = self.resolve_fee_rate(params.fee_rate).await?;
         // Estimate Tx B's vsize: it spends Tx A's alkane carrier + BTC change
         // (~2 inputs) and produces the execute output(s) + change + runestone.
         let child_vsize_estimate = Self::estimate_transaction_vsize(
@@ -4788,6 +4884,114 @@ mod tests {
         // Very low target still clamps to min-relay.
         let low = child_fee_rate_for_package(0.1, 0, 200, 150);
         assert!(low >= MIN_RELAY_FEE_RATE);
+    }
+
+    /// REGRESSION — mainnet tx cd6ec685…154d981f (2026-06-30).
+    ///
+    /// The parent is floored at CPFP_PARENT_MIN_FEE_RATE independently of the
+    /// user's target, so a target at/below that floor used to make the child
+    /// collapse to a rate BELOW its parent's. Reproduce the exact on-chain
+    /// numbers and assert the child now out-bids the parent.
+    #[test]
+    fn cpfp_child_never_underbids_its_parent_mainnet_cd6ec685() {
+        // parent: fee 975 sats over 776 vB = 1.256 sat/vB (the floored parent)
+        // child : ~316 vB. User asked for 1.0 sat/vB during a quiet mempool.
+        let parent_fee = 975u64;
+        let parent_vsize = 776u64;
+        let child_vsize = 316u64;
+        let target_rate = 1.0f32;
+
+        let parent_rate = parent_fee as f32 / parent_vsize as f32;
+        let child_rate =
+            child_fee_rate_for_package(target_rate, parent_fee, parent_vsize, child_vsize);
+
+        // The incident value was 0.370 sat/vB — below the parent's 1.256.
+        assert!(
+            child_rate >= parent_rate,
+            "child {child_rate} must not under-bid parent {parent_rate} (incident: 0.370 vs 1.256)"
+        );
+
+        // ...and the package must not be worth LESS to a miner than the parent
+        // alone. The incident package rate was 1.000 vs a 1.256 parent.
+        let package_rate = (parent_fee as f32 + child_rate * child_vsize as f32)
+            / (parent_vsize + child_vsize) as f32;
+        assert!(
+            package_rate >= parent_rate - 0.001,
+            "package {package_rate} must not drag the parent {parent_rate} down"
+        );
+        assert!(package_rate >= target_rate);
+    }
+
+    /// The invariant `child_rate >= package_rate >= parent_rate` must hold at
+    /// every requested rate — below, at, and far above the parent floor.
+    #[test]
+    fn cpfp_package_invariant_holds_across_the_rate_range() {
+        let parent_vsize = 776u64;
+        let child_vsize = 316u64;
+
+        for &requested in &[0.1f32, 0.5, 1.0, 1.24, 1.25, 1.26, 2.0, 5.0, 25.0, 100.0] {
+            // Build the parent the way the split path now does: at the floor.
+            let parent_build_rate = parent_fee_rate_for_package(requested);
+            let parent_fee = (parent_build_rate * parent_vsize as f32).ceil() as u64;
+            let parent_rate = parent_fee as f32 / parent_vsize as f32;
+
+            let child_rate =
+                child_fee_rate_for_package(requested, parent_fee, parent_vsize, child_vsize);
+            let package_rate = (parent_fee as f32 + child_rate * child_vsize as f32)
+                / (parent_vsize + child_vsize) as f32;
+
+            assert!(
+                child_rate >= package_rate - 0.001,
+                "requested {requested}: child {child_rate} < package {package_rate}"
+            );
+            assert!(
+                package_rate >= parent_rate - 0.001,
+                "requested {requested}: package {package_rate} < parent {parent_rate}"
+            );
+            assert!(
+                child_rate >= MIN_RELAY_FEE_RATE,
+                "requested {requested}: child {child_rate} below min-relay"
+            );
+            assert!(
+                package_rate >= requested - 0.001,
+                "requested {requested}: package {package_rate} below the user's target"
+            );
+        }
+    }
+
+    /// REGRESSION — mainnet tx 81396b59…e7960cae (2026-06-26).
+    ///
+    /// A parent built at the raw target sat unconfirmed at ~0.151 sat/vB: CPFP
+    /// fixes mining priority, never relay, so a sub-min-relay parent never
+    /// reaches the miners its child is trying to bribe. The parent must be
+    /// RAISED to the floor, never refused, and never left below it.
+    #[test]
+    fn cpfp_parent_is_floored_to_relay_standalone() {
+        // The incident rate, and everything else under the floor.
+        for &requested in &[0.0f32, 0.15, 0.151, 0.5, 1.0, 1.2499] {
+            let built = parent_fee_rate_for_package(requested);
+            assert!(
+                built >= CPFP_PARENT_MIN_FEE_RATE,
+                "requested {requested} produced a {built} sat/vB parent — below the floor"
+            );
+            assert!(built >= MIN_RELAY_FEE_RATE, "parent must clear Core min-relay");
+        }
+
+        // At or above the floor the user's rate is passed through untouched.
+        for &requested in &[1.25f32, 1.26, 3.0, 50.0] {
+            assert_eq!(parent_fee_rate_for_package(requested), requested);
+        }
+
+        // A non-finite rate must not leak NaN into a fee computation.
+        assert_eq!(parent_fee_rate_for_package(f32::NAN), CPFP_PARENT_MIN_FEE_RATE);
+
+        // And the floored parent really does clear min-relay in absolute sats.
+        let parent_vsize = 776u64;
+        let fee = (parent_fee_rate_for_package(0.15) * parent_vsize as f32).ceil() as u64;
+        assert!(
+            fee as f32 / parent_vsize as f32 >= MIN_RELAY_FEE_RATE,
+            "floored parent pays {fee} sats over {parent_vsize} vB"
+        );
     }
 
     /// `is_wrap_protostone` must reliably distinguish frBTC/frZEC/frETH wraps


### PR DESCRIPTION
Ports two CPFP safety guards that existed only in the TypeScript implementation (`hooks/useEphemeralWrapPackage.ts`) into the Rust copies, so all surfaces agree.

**Fix A — child-fee inversion.** A CPFP child must never bid below its parent; if it does, the package rate is *worse* than the parent alone and the child is pointless. From mainnet tx `cd6ec685…154d981f`: parent 1.256, child 0.370, package 1.000 sat/vB (TS fix `3a267152`).

**Fix B — parent floor 1.25 sat/vB.** A parent that cannot relay standalone strands the whole package. From mainnet tx `81396b59…e7960cae` stuck at 0.151 sat/vB (TS fix `87cff5c0`, raised to 1.25 in `3982a551` = Core's 1.0 default + ~25% for stricter node policies and ceil()-of-estimated-vsize drift).

No parent-min-fee constant existed anywhere in Rust before this.

Ported to each codebase's idiom rather than transliterated. Where this is integer-only (fee bytes feed the FROST sighash) the ancestor rate uses `div_ceil` deliberately — truncating could reopen the inversion by one sat/vB.

Three pre-existing tests encoded the *pre-fix* behaviour and were rewritten to the new invariant; each still asserts its original intent (a non-existent shortfall is not charged), just not the inverted number.

**Known gap, not addressed here:** both floors are static. Neither tracks a rising `mempoolminfee` under congestion — a `max(1.25, live mempoolminfee)` floor would. The TS side flags the same gap.

**Not addressed, needs a decision:** Rust replaces the CPFP parent and rewires the child's inputs atomically; the TS app *hard-refuses* parent RBF, because its child is signed by a one-time ephemeral browser key and a replaced parent orphans it, stranding proceeds at the MAST address. Both are coherent given their constraints, but the same user action behaves differently by surface, and Rust has no equivalent of TS's "this parent is structural, don't touch it" tag.

Verified: alkanes-cli-common 4 CPFP tests, subzero-btc-fee 29, subfrost-wallet-common 441 — all passing.