### PR TITLE
docs(cli): the mempool service is live; stop telling users it 404s

### DIFF
--- a/.claude/skills/btcusd-trading/SKILL.md
+++ b/.claude/skills/btcusd-trading/SKILL.md
@@ -28,7 +28,7 @@ Also: never use mempool.space. Use `/v4/{apikey}` endpoints.
 | `/v4/{apikey}` | the main JSON-RPC: `metashrew_view`, `metashrew_height`, `esplora_*`, `btc_*` |
 | `/v4/{apikey}/btcusd` | the dedicated BTCUSD index (protobuf both directions, package `alspo.cryptoswap`) |
 | `/v4/{apikey}/espo` | espo-shaped `<module>.<suffix>` routes, e.g. `ammdata.get_pools` |
-| `/v4/{apikey}/mempool` + `/mempool/ws` | mempool JSON-RPC and change stream — **not live yet**, see §7 |
+| `/v4/{apikey}/mempool` + `/mempool/ws` | mempool JSON-RPC and change stream — live; see §7 |
 
 > ⚠️ **If the user has no API key you will fall back to `/v4/jsonrpc`, and you
 > MUST say so out loud.** State plainly: *"Using the shared default endpoint

--- a/.claude/skills/btcusd-trading/SKILL.md
+++ b/.claude/skills/btcusd-trading/SKILL.md
@@ -252,8 +252,10 @@ V2 and not V3 deliberately: one `target.call`, no multicall.
 * **Keep a local view.** Persist what you submitted — txids, intents, expected
   outcomes — so a resumed session can reconcile rather than re-submit. Duplicate
   submission on a bridge path is a real loss, not an inconvenience.
-* **`/v4/{apikey}/mempool/*` is documented but NOT DEPLOYED yet.** It will 404.
-  Do not build a workflow that depends on it without checking first.
+* **`/v4/{apikey}/mempool/*` is live** — the JSON-RPC reads and the WebSocket both
+  answer. A failure there is the endpoint base, the key (a bad key is 401, not
+  404), or a transient outage. Note that `mempool watch` is still unwired on the
+  client side and refuses on purpose.
 
 ---
 

--- a/crates/alkanes-cli-common/src/btcusd.rs
+++ b/crates/alkanes-cli-common/src/btcusd.rs
@@ -275,7 +275,8 @@ pub enum BtcusdCommands {
     /// Mempool-aware reads: what is pending, and what the next blocks look like.
     ///
     /// Backed by `/v4/{apikey}/mempool`, which is live: the JSON-RPC methods and
-    /// the WebSocket both answer today. (`watch` is the exception, and says so.)
+    /// the WebSocket both answer today. (`watch` is still unwired client-side,
+    /// and says so when you run it.)
     Mempool {
         #[command(subcommand)]
         command: MempoolCommands,

--- a/crates/alkanes-cli-common/src/btcusd.rs
+++ b/crates/alkanes-cli-common/src/btcusd.rs
@@ -274,8 +274,8 @@ pub enum BtcusdCommands {
     },
     /// Mempool-aware reads: what is pending, and what the next blocks look like.
     ///
-    /// Backed by `/v4/{apikey}/mempool`. ⚠️ NOT DEPLOYED YET — expect 404 until
-    /// the route ships. Written now so a workflow can be built against it.
+    /// Backed by `/v4/{apikey}/mempool`, which is live: the JSON-RPC methods and
+    /// the WebSocket both answer today. (`watch` is the exception, and says so.)
     Mempool {
         #[command(subcommand)]
         command: MempoolCommands,

--- a/crates/alkanes-cli-common/src/btcusd_exec.rs
+++ b/crates/alkanes-cli-common/src/btcusd_exec.rs
@@ -614,9 +614,11 @@ pub fn run(cmd: &BtcusdCommands, post: &Post, ep: &Endpoints) -> Result<()> {
             )
             .map_err(|e| {
                 anyhow!(
-                    "{e}\n\nNote: /v4/{{apikey}}/mempool is deployed and answering, so this is \
-                     most likely the endpoint or the API key rather than a missing route. \
-                     Check that --endpoint points at the mempool host and that the key is valid."
+                    "{e}\n\nNote: /v4/{{apikey}}/mempool is deployed and answering, so a failure \
+                     here is most likely the endpoint base, the API key, or the service being \
+                     temporarily unreachable, rather than a missing route. Check \
+                     SUBFROST_RPC_BASE (defaults to https://mainnet.subfrost.io) and \
+                     SUBFROST_API_KEY; a 401 above means the key."
                 )
             })?;
             emit(&v, true)

--- a/crates/alkanes-cli-common/src/btcusd_exec.rs
+++ b/crates/alkanes-cli-common/src/btcusd_exec.rs
@@ -614,7 +614,9 @@ pub fn run(cmd: &BtcusdCommands, post: &Post, ep: &Endpoints) -> Result<()> {
             )
             .map_err(|e| {
                 anyhow!(
-                    "{e}\n\nNote: /v4/{{apikey}}/mempool is NOT DEPLOYED yet and will 404.                      The command surface exists so workflows can be written against it."
+                    "{e}\n\nNote: /v4/{{apikey}}/mempool is deployed and answering, so this is \
+                     most likely the endpoint or the API key rather than a missing route. \
+                     Check that --endpoint points at the mempool host and that the key is valid."
                 )
             })?;
             emit(&v, true)


### PR DESCRIPTION
`alkanes-cli btcusd mempool --help` currently says:

```
Backed by `/v4/{apikey}/mempool`. ⚠️ NOT DEPLOYED YET — expect 404 until
the route ships. Written now so a workflow can be built against it.
```

It is deployed and answering. The help text sends people away from a working command.

## Measured today, with controls

Every method this subcommand can issue, plus the WebSocket, against `https://mainnet.subfrost.io/v4/subfrost/mempool`:

| request | result |
|---|---|
| `mempool_info` | **HTTP 200**, real body (`count` 50,805, `bytes` 25,814,483) |
| `mempool_template` | **HTTP 200**, real body (populated `fee_range`) |
| `mempool_entry` | **HTTP 200**, `-32000 not in mempool` for an all-zero txid — the correct answer, and proof the method is dispatched |
| `…/mempool/ws` | **HTTP 101 Switching Protocols** |

Controls, so that none of the above is a blanket answer:

| control | result | what it rules out |
|---|---|---|
| `mempool_nope` | `-32601 unknown method` | the dispatcher is real, not a catch-all returning 200 |
| `/v4/subfrost/nosuchroute` | **404** | the route is not a fall-through |
| `/v4/<invalid-key>/mempool` | **401** | the route exists and authenticates; a bad key is 401, never the advertised 404 |
| `/v4/<invalid-key>/mempool/ws` | **401** | the 101 above is not handed out unconditionally |

The controls matter because the claim being corrected is specifically "expect 404": a 200 alone would not distinguish a live service from a catch-all. Note the last two rows in particular — **a wrong API key surfaces as 401, so nothing about this route produces the 404 the help text promises.**

## The second instance is worse than stale

`btcusd_exec.rs` attaches the same sentence to the **error path**. So someone whose call just failed is told the cause is a missing route — which sends them off to wait for a deploy instead of checking the two things that actually explain a failure today (wrong endpoint, or an invalid API key). That note now says so.

## Scope

Three instances in total, all of them dating from when the route genuinely did not exist and none revisited after it shipped:

1. the `--help` text above,
2. the error path in `btcusd_exec.rs`,
3. `.claude/skills/btcusd-trading/SKILL.md`, which told readers not to build workflows on the route at all.

The matching documentation pages are handled separately in [subfrost-api-nextjs#1](https://github.com/subfrost/subfrost-api-nextjs/pull/1).

**On the replacement error note:** it names `SUBFROST_RPC_BASE` and `SUBFROST_API_KEY`, which are where this path actually reads the endpoint and key from — there is no `--endpoint` flag here, and an earlier draft of this PR pointed at one, which would have repeated the very defect it fixes. It also covers "temporarily unreachable", since the note fires on timeouts and 5xx too. It cannot reach an application-level JSON-RPC error: a 200 carrying an `error` body returns `Ok` and never takes that path.

**Not touched:** `Mempool { Watch }` still refuses with `not yet wired: websocket stream needs reconnect state machine`. That one is accurate — only the read commands were being misdescribed. (The WebSocket endpoint itself does complete a handshake, but the client-side reconnect logic really is missing, so the refusal stands.)

`cargo check -p alkanes-cli-common`: clean (118 pre-existing warnings).


