### PR TITLE
docs(skill): the pool numbers were a week stale and pointed the wrong way

### DIFF
--- a/.claude/skills/btcusd-trading/SKILL.md
+++ b/.claude/skills/btcusd-trading/SKILL.md
@@ -85,18 +85,52 @@ delegatecall.
 
 ### Live constraints — check these before quoting anything
 
+**The invariants (these do not move):**
+
 * **Depth cap.** A single conversion may take at most **10% of the pool's frUSD
   reserve** (`MAX_POOL_SHARE_BPS = 1000`). Over that, the coordinator **refuses
   the swap and pays out plain frUSD instead** — the deposit still succeeds, no
-  error on either chain. At a ~$5,854/side pool that ceiling is about **$585**.
-* **The price is stale by construction.** The pool still prices BTC at the
-  **$64,164** fixed at init. A $585 buy executes near **$70,157** — roughly 8%
-  over market — and $1,000 around 15% over. The arb that would close it maxes out
-  at ~$75 of profit, so nobody can.
+  error on either chain. So the cap is a fraction, and its dollar value moves
+  with the pool.
+* **The pool's price is set by its own reserves, not by the market**, and this is
+  a shallow pool. The gap between the two can be any size and in either
+  direction, and arbitrage will not reliably close it — the profit available is
+  too small against fees at this depth.
 
-**Therefore: warn on any trade above the depth cap, and quote the effective
-execution price, not the pool's marginal price.** A user who sees "swap $1,000 to
-BTC" and gets frUSD at a 15% implied loss was not told enough.
+**Therefore: never quote either number from memory. Measure both, then warn on
+any trade above the depth cap and quote the effective execution price, not the
+pool's marginal price.**
+
+> ⚠️ **The measured values below are a SNAPSHOT and they go stale fast.** An
+> earlier version of this file carried numbers from 2026-08-10 and, one week
+> later, understated the pool by 4.2× and claimed the pool was "8% over market"
+> when it was 0.8% *under*. That error runs in the dangerous direction: it talks
+> a user out of a fair trade, and it would just as easily talk one into a bad one
+> after the next move. **Re-measure before quoting.**
+
+**Snapshot, measured 2026-08-17 at index height 962,598:**
+
+| | |
+|---|---|
+| frUSD reserve | 24,304.66 |
+| frBTC reserve | 0.38092710 |
+| implied pool price | ~$63,804 / BTC |
+| depth cap (10%) | ~$2,430 |
+| market (same day) | ~$64,327 / BTC — pool ~0.8% **under** |
+
+Re-measure with one call, and read `token0`/`token1` from the response rather
+than assuming the order:
+
+```bash
+curl -s https://mainnet.subfrost.io/v4/$KEY/btcusd \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"metashrew_view",
+       "params":["getpoolstate","0x0a05080410f20d","latest"]}'
+```
+
+The reserves come back as **decimal strings at 8 decimals** (see §3 — keep them
+strings). Divide frUSD by frBTC for the pool's implied USD/BTC, and compare it
+against a real market price before saying anything about premium or discount.
 
 ---
 
@@ -261,8 +295,9 @@ V2 and not V3 deliberately: one `target.call`, no multicall.
 
 1. Is the trade within the **depth cap**? If not, say what will actually happen
    (frUSD, not BTC).
-2. Have you quoted the **effective execution price**, including the ~8%+ the
-   stale price scale costs today?
+2. Have you **measured** the pool against the market today, and quoted the
+   **effective execution price** including whatever that gap costs — in whichever
+   direction it currently runs?
 3. For a bridge: is `btc_destination` a **standard, payable mainnet** script?
 4. For a bridge: is the approve **exactly** the amount?
 5. Are amounts still **strings**, not floats?

--- a/.claude/skills/btcusd-trading/SKILL.md
+++ b/.claude/skills/btcusd-trading/SKILL.md
@@ -104,22 +104,28 @@ pool's marginal price.**
 > ⚠️ **The measured values below are a SNAPSHOT and they go stale fast.** An
 > earlier version of this file carried numbers from 2026-08-10 and, one week
 > later, understated the pool by 4.2× and claimed the pool was "8% over market"
-> when it was 0.8% *under*. That error runs in the dangerous direction: it talks
-> a user out of a fair trade, and it would just as easily talk one into a bad one
+> when it was *under*. That error runs in the dangerous direction: it talks a
+> user out of a fair trade, and it would just as easily talk one into a bad one
 > after the next move. **Re-measure before quoting.**
+>
+> Note what actually changed: the pool's own `price_scale` barely moved (64,164 →
+> 64,069). The market rose to meet it. So the "stale by construction" framing was
+> right about the mechanism and wrong to assume the gap stays on one side.
 
-**Snapshot, measured 2026-08-17 at index height 962,598:**
+**Snapshot read 2026-08-17** (chain tip 962,947 via `metashrew_height`; the pool
+state itself is unchanged since block **962,598**, its last event, on 2026-08-15):
 
 | | |
 |---|---|
 | frUSD reserve | 24,304.66 |
 | frBTC reserve | 0.38092710 |
-| implied pool price | ~$63,804 / BTC |
-| depth cap (10%) | ~$2,430 |
-| market (same day) | ~$64,327 / BTC — pool ~0.8% **under** |
+| **pool price** (`marginal_price_q`) | **~$64,075 / BTC** |
+| `price_scale` | ~$64,069 / BTC |
+| reserve ratio (sanity check only) | ~$63,804 / BTC |
+| depth cap (10% of frUSD) | ~$2,430 |
+| market, same reading | ~$64,342 → pool ~0.4% **under** |
 
-Re-measure with one call, and read `token0`/`token1` from the response rather
-than assuming the order:
+Re-measure with one call:
 
 ```bash
 curl -s https://mainnet.subfrost.io/v4/$KEY/btcusd \
@@ -128,9 +134,19 @@ curl -s https://mainnet.subfrost.io/v4/$KEY/btcusd \
        "params":["getpoolstate","0x0a05080410f20d","latest"]}'
 ```
 
-The reserves come back as **decimal strings at 8 decimals** (see §3 — keep them
-strings). Divide frUSD by frBTC for the pool's implied USD/BTC, and compare it
-against a real market price before saying anything about premium or discount.
+> ⚠️ **The response is prost hex, not JSON.** `GetPoolStateResponse`: `token0`=f3,
+> `token1`=f4, `state`=f5, and inside that `reserve0`/`reserve1` are decimal
+> strings at 8 decimals (keep them strings — see §3). Read `token0`/`token1` from
+> the response rather than assuming the order. The reference decoder is
+> `decode_pool_state` in `alkanes-cli-common/src/btcusd_exec.rs`.
+
+> 🔴 **Take the pool's price from `marginal_price_q` (state f10), as
+> `price_q_scale / marginal_price_q` — the reciprocal rule in §3. Do NOT divide
+> the reserves.** In CryptoSwap the balances sit near `price_scale`, not at
+> parity, so the reserve ratio is not the tradable price: at this reading the two
+> differ by 0.42%, which is more than the pool's own mid fee. It is a sanity
+> check, nothing more. And for an actual trade, quote with `get_dy` (§4) rather
+> than any of these — none of them include your size.
 
 ---
 
@@ -149,7 +165,7 @@ Views: `getprice`, `getpoolstate`, `getreserves`, `getcandles`, `getpools`,
 `indexheight`. Buckets for candles: **3600 and 86400 only**.
 
 > ⚠️ **Amounts are decimal STRINGS and must stay strings.** `total_supply` is
-> `23113653069174808444` — past `u64`. Parsing as a double or u64 silently
+> `96211459799069359794` at the 2026-08-17 reading — past `u64`. Parsing as a double or u64 silently
 > corrupts it. This is not hypothetical: a u64 parse is what froze 23.0137 LP as
 > unspendable.
 >


### PR DESCRIPTION
`.claude/skills/btcusd-trading/SKILL.md` is read by an assistant *before it quotes a trade on real money*. A stale number in it is not a documentation nit — it is advice.

The measured values in §2 dated from 2026-08-10. Re-measured today via `/v4/{key}/btcusd` `getpoolstate`, at index height 962,598:

| | claimed | measured 2026-08-17 |
|---|---|---|
| frUSD reserve | ~$5,854/side | **24,304.66** (4.2× understated) |
| depth cap (10%) | ~$585 | **~$2,430** |
| pool price (`marginal_price_q`) | $64,164 (`price_scale`) | **~$64,075** |
| vs market | *"roughly 8% over"*, $1,000 *"around 15% over"* | market ~$64,342 → pool is **~0.4% UNDER** |

On the *same* instrument the pool barely moved: `price_scale` went 64,164 → 64,069. **The market rose to meet the pool** — so the file's "stale by construction" mechanism was right, and only its assumption that the gap stays on one side was wrong.

## The direction is what makes this worth a PR

Telling an assistant the pool sits 8% over market makes it **talk a user out of a trade that is currently fair**. And a fixed number would just as happily talk someone *into* a bad one after the next move. Either way the failure is silent — nothing errors, the advice is simply wrong.

The gap did not close through arbitrage. The market came to the pool, which is what the file's own "shallow pool" reasoning already predicted; the arb was never large enough to do it.

## Restructured so it cannot rot the same way

- **Invariants stated as invariants**: the cap is a *fraction* (`MAX_POOL_SHARE_BPS = 1000`), and a shallow pool's price is set by its reserves and can sit on *either* side of market.
- **The price now comes from `marginal_price_q`, not from dividing the reserves.** In CryptoSwap the balances sit near `price_scale` rather than at parity, so the ratio is not the tradable price — at this reading they differ by 0.42%, more than the pool's own mid fee. The ratio stays as a sanity check, and `get_dy` remains the answer for anything involving size.
- **Volatile numbers as a snapshot**, labelled with the height they were *read* at (`metashrew_height`) plus the block of the pool's last event — these are different numbers, and the earlier draft of this PR conflated them — with the earlier failure named, so the next reader knows the risk is real rather than theoretical.
- **The one-line command that re-measures**, right next to the snapshot, including the reminder to read `token0`/`token1` from the response instead of assuming the order.
- The pre-execution checklist now asks whether the pool was **measured against the market today**, rather than assuming a fixed premium.

Fees, opcodes, decimals and the depth-cap mechanism are untouched — those are properties of the contract, not of the day.

Related: [#301](https://github.com/kungfuflex/alkanes-rs/pull/301) corrects the stale mempool claim in the same file, including the endpoint table at line 31. The two touch different sections.

