### PR TITLE
fix(view): bounded balance-sheet walk on view read paths — kills the protorunesbyoutpoint infinite-hang class

### DIFF
--- a/crates/protorune/src/balance_sheet.rs
+++ b/crates/protorune/src/balance_sheet.rs
@@ -268,6 +268,57 @@ mod view_bound_tests {
     }
 
     #[test]
+    fn load_sheet_bounded_boundary_at_view_cap() {
+        metashrew_core::clear();
+        // Exactly VIEW_SHEET_MAX_ENTRIES real entries: loads fine.
+        let ptr = IndexPointer::from_keyword("/test/bounded-boundary");
+        let mut sheet: BalanceSheet<IndexPointer> = BalanceSheet::default();
+        for i in 0..VIEW_SHEET_MAX_ENTRIES {
+            sheet.set(&ProtoruneRuneId::new(2, i as u128), 1);
+        }
+        sheet.save(&ptr, false);
+        let loaded = load_sheet_bounded(&ptr, VIEW_SHEET_MAX_ENTRIES).unwrap();
+        assert_eq!(loaded.balances().len(), VIEW_SHEET_MAX_ENTRIES as usize);
+
+        // One past the cap (forged counter on the same record): refused
+        // before any entry read.
+        ptr.keyword("/runes")
+            .length_key()
+            .set_value::<u32>(VIEW_SHEET_MAX_ENTRIES + 1);
+        let err = load_sheet_bounded(&ptr, VIEW_SHEET_MAX_ENTRIES).unwrap_err();
+        assert!(err.to_string().contains("exceeds view cap"));
+    }
+
+    #[test]
+    fn view_outpoint_response_refuses_corrupt_record_instead_of_walking() {
+        // End-to-end through the ACTUAL converted view path (the function
+        // that hung on mainnet outpoint 2a1538bf…2e28:0): a protocol-1
+        // OUTPOINT_TO_RUNES record with a forged length must surface as a
+        // fast view Err — the same error class as the known per-outpoint
+        // panics — never an unbounded walk.
+        use bitcoin::hashes::Hash;
+        metashrew_core::clear();
+        let outpoint = bitcoin::OutPoint {
+            txid: bitcoin::Txid::all_zeros(),
+            vout: 0,
+        };
+        let outpoint_bytes = crate::view::outpoint_to_bytes(&outpoint).unwrap();
+        crate::tables::RuneTable::for_protocol(1)
+            .OUTPOINT_TO_RUNES
+            .select(&outpoint_bytes)
+            .keyword("/runes")
+            .length_key()
+            .set_value::<u32>(u32::MAX);
+
+        let err = crate::view::protorune_outpoint_to_outpoint_response(&outpoint, 1)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("exceeds view cap"),
+            "expected the bounded-loader refusal, got: {err}"
+        );
+    }
+
+    #[test]
     fn load_sheet_bounded_refuses_corrupt_length_fast() {
         metashrew_core::clear();
         // Forge the 2026-08-22 hang-incident shape: a stored /runes/length

--- a/crates/protorune/src/balance_sheet.rs
+++ b/crates/protorune/src/balance_sheet.rs
@@ -183,6 +183,54 @@ pub fn load_sheet<T: KeyValuePointer + Clone>(ptr: &T) -> BalanceSheet<T> {
     result
 }
 
+/// Maximum entry count a VIEW read will walk in a stored balance sheet.
+///
+/// A healthy outpoint carries a handful of protorune balances; a stored
+/// `/runes` length counter in the thousands-and-up is a corruption signature,
+/// not a real wallet. Incident (mainnet, 2026-08-22): the protocol-1
+/// OUTPOINT_TO_RUNES record for outpoint 2a1538bf…2e28:0 (h961009, written
+/// during the 2026-08-07 reconcile-rollback window) carries a pathological
+/// entry list; `load_sheet`'s unbounded walk — two host KV reads per entry —
+/// made `protorunesbyoutpoint` HANG until the JSON-RPC layer's 60s timeout,
+/// on every request, pinning a view-runtime permit each time. Sibling vouts
+/// of the same tx (healthy records) answered in <1s.
+pub const VIEW_SHEET_MAX_ENTRIES: u32 = 4096;
+
+/// Bounded, fallible variant of [`load_sheet`] for VIEW paths only.
+///
+/// Refuses (fast, with a diagnostic error the JSON-RPC layer surfaces as a
+/// normal view error) instead of walking a corrupt stored length. This turns
+/// the hang class above into the same fast-error class as the known
+/// `option::unwrap_failed` per-outpoint panics, which downstream consumers
+/// already tolerate per-outpoint.
+///
+/// CONSENSUS SAFETY: the indexer keeps calling the unbounded [`load_sheet`] —
+/// this function must only ever be reached from view functions. Never swap it
+/// into block-application paths: refusing a sheet during indexing would
+/// change indexed state.
+pub fn load_sheet_bounded<T: KeyValuePointer + Clone>(
+    ptr: &T,
+    max_entries: u32,
+) -> Result<BalanceSheet<T>> {
+    let runes_ptr = ptr.keyword("/runes");
+    let balances_ptr = ptr.keyword("/balances");
+    let length = runes_ptr.length();
+    if length > max_entries {
+        return Err(anyhow!(
+            "balance sheet entry count {} exceeds view cap {} — corrupt stored record, refusing unbounded walk",
+            length,
+            max_entries
+        ));
+    }
+    let mut result = BalanceSheet::default();
+    for i in 0..length {
+        let rune = ProtoruneRuneId::from(runes_ptr.select_index(i).get());
+        let balance = balances_ptr.select_index(i).get_value::<u128>();
+        result.set(&rune, balance);
+    }
+    Ok(result)
+}
+
 pub fn clear_balances<T: KeyValuePointer>(ptr: &T) {
     let runes_ptr = ptr.keyword("/runes");
     let balances_ptr = ptr.keyword("/balances");
@@ -197,3 +245,41 @@ pub fn clear_balances<T: KeyValuePointer>(ptr: &T) {
 }
 
 impl<P: KeyValuePointer + Clone + std::fmt::Debug> PersistentRecord for BalanceSheet<P> {}
+
+#[cfg(test)]
+mod view_bound_tests {
+    use super::*;
+    use protorune_support::balance_sheet::BalanceSheetOperations;
+
+    #[test]
+    fn load_sheet_bounded_matches_load_sheet_on_healthy_records() {
+        metashrew_core::clear();
+        let ptr = IndexPointer::from_keyword("/test/bounded-ok");
+        let mut sheet: BalanceSheet<IndexPointer> = BalanceSheet::default();
+        sheet.set(&ProtoruneRuneId::new(2, 0), 1_000);
+        sheet.set(&ProtoruneRuneId::new(32, 7), 5);
+        sheet.save(&ptr, false);
+
+        let bounded = load_sheet_bounded(&ptr, VIEW_SHEET_MAX_ENTRIES).unwrap();
+        let unbounded = load_sheet(&ptr);
+        assert_eq!(bounded.balances(), unbounded.balances());
+        assert_eq!(bounded.get_cached(&ProtoruneRuneId::new(2, 0)), 1_000);
+        assert_eq!(bounded.get_cached(&ProtoruneRuneId::new(32, 7)), 5);
+    }
+
+    #[test]
+    fn load_sheet_bounded_refuses_corrupt_length_fast() {
+        metashrew_core::clear();
+        // Forge the 2026-08-22 hang-incident shape: a stored /runes/length
+        // far beyond any real wallet, with no matching entries. The
+        // unbounded walker would spin for length iterations (two host reads
+        // each); the bounded loader must refuse before the first read.
+        let ptr = IndexPointer::from_keyword("/test/bounded-corrupt");
+        ptr.keyword("/runes")
+            .length_key()
+            .set_value::<u32>(u32::MAX);
+
+        let err = load_sheet_bounded(&ptr, VIEW_SHEET_MAX_ENTRIES).unwrap_err();
+        assert!(err.to_string().contains("exceeds view cap"));
+    }
+}

--- a/crates/protorune/src/view.rs
+++ b/crates/protorune/src/view.rs
@@ -1,5 +1,8 @@
 use crate::tables::RuneTable;
-use crate::{balance_sheet::load_sheet, tables};
+use crate::{
+    balance_sheet::{load_sheet_bounded, VIEW_SHEET_MAX_ENTRIES},
+    tables,
+};
 use anyhow::{anyhow, Result};
 use bitcoin;
 use protorune_support::balance_sheet::{BalanceSheetOperations, ProtoruneRuneId};
@@ -43,11 +46,14 @@ pub fn protorune_outpoint_to_outpoint_response(
 ) -> Result<OutpointResponse> {
     //    println!("protocol_id: {}", protocol_id);
     let outpoint_bytes = outpoint_to_bytes(outpoint)?;
-    let balance_sheet = load_sheet(
+    // Bounded: a corrupt stored length (2026-08-22 hang incident, outpoint
+    // 2a1538bf…2e28:0) must fail fast as a view error, never walk unbounded.
+    let balance_sheet = load_sheet_bounded(
         &tables::RuneTable::for_protocol(protocol_id)
             .OUTPOINT_TO_RUNES
             .select(&outpoint_bytes),
-    );
+        VIEW_SHEET_MAX_ENTRIES,
+    )?;
 
     let mut height: u128 = tables::RUNES
         .OUTPOINT_TO_HEIGHT
@@ -85,7 +91,10 @@ pub fn protorune_outpoint_to_outpoint_response(
 
 pub fn rune_outpoint_to_outpoint_response(outpoint: &OutPoint) -> Result<OutpointResponse> {
     let outpoint_bytes = outpoint_to_bytes(outpoint)?;
-    let balance_sheet = load_sheet(&tables::RUNES.OUTPOINT_TO_RUNES.select(&outpoint_bytes));
+    let balance_sheet = load_sheet_bounded(
+        &tables::RUNES.OUTPOINT_TO_RUNES.select(&outpoint_bytes),
+        VIEW_SHEET_MAX_ENTRIES,
+    )?;
 
     let mut height: u128 = tables::RUNES
         .OUTPOINT_TO_HEIGHT
@@ -123,7 +132,10 @@ pub fn rune_outpoint_to_outpoint_response(outpoint: &OutPoint) -> Result<Outpoin
 
 pub fn outpoint_to_outpoint_response(outpoint: &OutPoint) -> Result<OutpointResponse> {
     let outpoint_bytes = outpoint_to_bytes(outpoint)?;
-    let balance_sheet = load_sheet(&tables::RUNES.OUTPOINT_TO_RUNES.select(&outpoint_bytes));
+    let balance_sheet = load_sheet_bounded(
+        &tables::RUNES.OUTPOINT_TO_RUNES.select(&outpoint_bytes),
+        VIEW_SHEET_MAX_ENTRIES,
+    )?;
     let mut height: u128 = tables::RUNES
         .OUTPOINT_TO_HEIGHT
         .select(&outpoint_bytes)

--- a/src/view.rs
+++ b/src/view.rs
@@ -1233,12 +1233,18 @@ pub fn simulate_transaction_with_overrides(
     let probe_atomic = AtomicPointer::default();
     let mut combined: Vec<alkanes_support::parcel::AlkaneTransfer> = Vec::new();
     for input in &tx.input {
-        use protorune::balance_sheet::load_sheet;
-        let sheet = load_sheet(&mut probe_atomic.derive(
-            &table
-                .OUTPOINT_TO_RUNES
-                .select(&consensus_encode(&input.previous_output)?),
-        ));
+        use protorune::balance_sheet::{load_sheet_bounded, VIEW_SHEET_MAX_ENTRIES};
+        // Bounded: this is a VIEW probe over live OUTPOINT_TO_RUNES — a
+        // corrupt stored length (2026-08-22 hang incident) must error fast,
+        // not walk unbounded inside a simulate call.
+        let sheet = load_sheet_bounded(
+            &mut probe_atomic.derive(
+                &table
+                    .OUTPOINT_TO_RUNES
+                    .select(&consensus_encode(&input.previous_output)?),
+            ),
+            VIEW_SHEET_MAX_ENTRIES,
+        )?;
         for (rune_id, balance) in sheet.balances().iter() {
             if *balance == 0 {
                 continue;


### PR DESCRIPTION
## The bug (live on mainnet right now)

`metashrew_view protorunesbyoutpoint` **hangs forever** — no response, no error — for outpoint `2a1538bfdd82e998d59015c641129d0516e8ba3f29c44be39155662f272c2e28:0` (h961009). Reproduce:

```bash
curl -s -m 30 -X POST 'https://mainnet.subfrost.io/v4/subfrost' -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","method":"metashrew_view","params":["protorunesbyoutpoint","0a20282e2c272f665591e34bc4293fbae816059d1241c61590d598e982ddbf38152a1a020801","latest"],"id":1}'
```

Discriminators that localize it precisely:
- vouts **1–3 of the same tx** answer in <1 s (fast, empty)
- the **same outpoint under protocol tag 2** (`1a020802`) — fast, empty
- the same outpoint via **`runesbyoutpoint`** (RUNES table) — fast, empty

So the poison is confined to the **protocol-1 `OUTPOINT_TO_RUNES` record for vout 0** — written during the 2026-08-07 reconcile-rollback window (h~960996–961104, the same window subfrost-app quarantines in `OUTPOINT_QUARANTINE_RANGES`). `load_sheet` (`crates/protorune/src/balance_sheet.rs:172`) walks the stored `/runes/length` with **no upper bound**, two host KV reads per entry; the view store runs at `u64::MAX` fuel with yield-only semantics, so nothing traps — the call spins until rockshrew-mono's 60 s JSON-RPC timeout, **pinning a view-runtime permit the whole time, on every request**. One poisoned record = a trivial per-request DoS. Unlike the known `option::unwrap_failed` panic class (malformed entries → fast `-32000`), this record's entries are individually well-formed, so it walks instead of panicking.

Downstream this is what blanked the 69-UTXO bond-bot wallet in subfrost-app ("assets don't display, app times out") — 68 of its 69 outpoints resolve at p50 ≈ 250 ms; this one outpoint hung every wallet-state build.

## The fix

`load_sheet_bounded` — a fallible, **view-only** variant that refuses any stored sheet whose `/runes/length` exceeds `VIEW_SHEET_MAX_ENTRIES` (4096; a healthy outpoint carries a handful) *before the first entry read*, converting the hang into the same fast `-32000` view-error class consumers already tolerate per-outpoint. Converted call sites — all of them view functions:

- `protorune::view::protorune_outpoint_to_outpoint_response` (the hanging path)
- `protorune::view::rune_outpoint_to_outpoint_response`
- `protorune::view::outpoint_to_outpoint_response`
- alkanes `src/view.rs` simulate-probe over spent outpoints

**Consensus safety:** the indexer keeps calling the unbounded `load_sheet` — block application untouched, no state change, no reindex. The bounded variant is reachable only from views, and the doc comment forbids swapping it into block-application paths.

## Verification

- `view_bound_tests` in `balance_sheet.rs`: healthy records load identically to `load_sheet`; a forged `u32::MAX` `/runes/length` (the incident shape) is refused fast with `"exceeds view cap"`.
- Full protorune suite 16/16 green; workspace `cargo check` clean.
- After deploy, the curl above should return a fast JSON-RPC error; the vout-1/protocol-2 controls must stay fast + empty.

## Companions

- **metashrew**: view-store epoch deadline (hard wall-clock bound on all view WASM) — covers this class generically; PR incoming.
- **subfrost-app #655** (merged path): hang-sentinel + soft-partial so wallets holding such an outpoint render correctly regardless of when this lands.

Root-cause anchors: `crates/protorune/src/balance_sheet.rs:172` (unbounded walk), `src/view.rs:258` (protocol-1-only augmentation branch — why protocol 2 is unaffected), `metashrew crates/metashrew-runtime/src/runtime.rs:872` (`set_fuel(u64::MAX)` + yield-only for views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)